### PR TITLE
[pipelines] adiciona dados de inflação

### DIFF
--- a/pipelines/bases/__init__.py
+++ b/pipelines/bases/__init__.py
@@ -6,4 +6,7 @@ Prefect flows for basedosdados project
 ###############################################################################
 from pipelines.bases.br_cvm_administradores_carteira.flows import *
 from pipelines.bases.br_cvm_oferta_publica_distribuicao.flows import *
+from pipelines.bases.br_ibge_inpc.flows import *
+from pipelines.bases.br_ibge_ipca.flows import *
+from pipelines.bases.br_ibge_ipca15.flows import *
 from pipelines.bases.test_pipeline.flows import *

--- a/pipelines/bases/br_ibge_inpc/__init__.py
+++ b/pipelines/bases/br_ibge_inpc/__init__.py
@@ -1,0 +1,7 @@
+"""
+Prefect flows for br_ibge_inpc project
+"""
+###############################################################################
+# Automatically managed, please do not touch
+###############################################################################
+from .flows import *

--- a/pipelines/bases/br_ibge_inpc/flows.py
+++ b/pipelines/bases/br_ibge_inpc/flows.py
@@ -1,0 +1,60 @@
+"""
+Flows for br_ibge_inpc
+"""
+
+from prefect import Flow
+from prefect.run_configs import KubernetesRun
+from prefect.storage import GCS
+from pipelines.constants import constants
+from pipelines.utils import upload_to_gcs
+from pipelines.bases.br_ibge_inpc.tasks import (
+    crawl,
+    clean_mes_brasil,
+    clean_mes_rm,
+    clean_mes_municipio,
+    clean_mes_geral,
+)
+from pipelines.bases.br_ibge_inpc.schedules import every_month
+
+INDICE = "inpc"
+
+with Flow("br_ibge_inpc.brasil") as br_ibge_inpc_br:
+    FOLDER="br/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_brasil(INDICE)
+    upload_to_gcs("br_ibge_inpc", "brasil", filepath)
+
+br_ibge_inpc_br.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_inpc_br.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_inpc_br.schedule = every_month
+
+with Flow("br_ibge_inpc.rm") as br_ibge_inpc_rm:
+    FOLDER="rm/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_rm(INDICE)
+    upload_to_gcs("br_ibge_inpc", "rm", filepath)
+
+br_ibge_inpc_rm.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_inpc_rm.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_inpc_rm.schedule = every_month
+
+
+with Flow("br_ibge_inpc.municipio") as br_ibge_inpc_municipio:
+    FOLDER="mun/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_municipio(INDICE)
+    upload_to_gcs("br_ibge_inpc", "municipio", filepath)
+
+br_ibge_inpc_municipio.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_inpc_municipio.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_inpc_municipio.schedule = every_month
+
+with Flow("br_ibge_inpc.geral") as br_ibge_inpc_geral:
+    FOLDER="mes/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_geral(INDICE)
+    upload_to_gcs("br_ibge_inpc", "geral", filepath)
+
+br_ibge_inpc_geral.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_inpc_geral.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_inpc_geral.schedule = every_month

--- a/pipelines/bases/br_ibge_inpc/flows.py
+++ b/pipelines/bases/br_ibge_inpc/flows.py
@@ -6,9 +6,9 @@ from prefect import Flow
 from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 from pipelines.constants import constants
-from pipelines.utils import upload_to_gcs
+from pipelines.utils import upload_to_gcs, create_bd_table, create_header
 from pipelines.bases.br_ibge_inpc.tasks import (
-    crawl,
+    crawler,
     clean_mes_brasil,
     clean_mes_rm,
     clean_mes_municipio,
@@ -20,9 +20,29 @@ INDICE = "inpc"
 
 with Flow("br_ibge_inpc.brasil") as br_ibge_inpc_br:
     FOLDER="br/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_brasil(INDICE)
-    upload_to_gcs("br_ibge_inpc", "brasil", filepath)
+    dataset_id = "br_ibge_inpc"
+    table_id = "brasil"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_inpc_br.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_inpc_br.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
@@ -30,9 +50,29 @@ br_ibge_inpc_br.schedule = every_month
 
 with Flow("br_ibge_inpc.rm") as br_ibge_inpc_rm:
     FOLDER="rm/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_rm(INDICE)
-    upload_to_gcs("br_ibge_inpc", "rm", filepath)
+    dataset_id = "br_ibge_inpc"
+    table_id = "rm"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_inpc_rm.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_inpc_rm.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
@@ -41,9 +81,29 @@ br_ibge_inpc_rm.schedule = every_month
 
 with Flow("br_ibge_inpc.municipio") as br_ibge_inpc_municipio:
     FOLDER="mun/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_municipio(INDICE)
-    upload_to_gcs("br_ibge_inpc", "municipio", filepath)
+    dataset_id = "br_ibge_inpc"
+    table_id = "municipio"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_inpc_municipio.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_inpc_municipio.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
@@ -51,9 +111,29 @@ br_ibge_inpc_municipio.schedule = every_month
 
 with Flow("br_ibge_inpc.geral") as br_ibge_inpc_geral:
     FOLDER="mes/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_geral(INDICE)
-    upload_to_gcs("br_ibge_inpc", "geral", filepath)
+    dataset_id = "br_ibge_inpc"
+    table_id = "geral"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_inpc_geral.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_inpc_geral.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)

--- a/pipelines/bases/br_ibge_inpc/schedules.py
+++ b/pipelines/bases/br_ibge_inpc/schedules.py
@@ -1,0 +1,20 @@
+"""
+Schedules for br_ibge_inpc
+"""
+
+from datetime import timedelta, datetime
+from prefect.schedules import Schedule
+from prefect.schedules.clocks import IntervalClock
+from pipelines.constants import constants
+
+every_month = Schedule(
+    clocks=[
+        IntervalClock(
+            interval=timedelta(days=30),
+            start_date=datetime(2021, 1, 1),
+            labels=[
+                constants.BASEDOSDADOS_AGENT_LABEL.value,
+            ]
+        )
+    ]
+)

--- a/pipelines/bases/br_ibge_inpc/tasks.py
+++ b/pipelines/bases/br_ibge_inpc/tasks.py
@@ -1,0 +1,521 @@
+"""
+Tasks for br_ibge_inpc
+"""
+
+from prefect import task
+import pandas as pd
+import os
+import glob
+import wget
+from tqdm import tqdm
+from time import sleep
+
+
+@task
+def crawl(indice: str, folder:str) -> None:
+    os.system('mkdir -p "/tmp/data"')
+    os.system('mkdir -p "/tmp/data/input"')
+    os.system('mkdir -p "/tmp/data/input/br"')
+    os.system('mkdir -p "/tmp/data/input/rm"')
+    os.system('mkdir -p "/tmp/data/input/mun"')
+    os.system('mkdir -p "/tmp/data/input/mes"')
+    os.system('mkdir -p "/tmp/data/output"')
+    os.system('mkdir -p "/tmp/data/output/ip15"')
+    os.system('mkdir -p "/tmp/data/output/ipca"')
+    os.system('mkdir -p "/tmp/data/output/inpc"')
+
+    links = {
+        "br/ipca_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "br/ipca_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "br/ipca_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "br/ipca_subitem": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/947075621",
+        "br/inpc_subitem": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/1084704443",
+        "br/ip15_subitem": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-783617233",
+        "br/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7169/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7169/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7169/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/947075621",
+        "rm/ipca_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/847634158",
+        "rm/inpc_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-884745035",
+        "rm/inpc_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1265010694",
+        "rm/ip15_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1750716307",
+        "rm/ip15_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1258570016",
+        "rm/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7169/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7169/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7169/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/866963382",
+        "mun/ipca_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-113176757",
+        "mun/inpc_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/1139761886",
+        "mun/inpc_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1289673003",
+        "mun/ip15_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-260564956",
+        "mun/ip15_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-317614754",
+        "mun/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7169/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7169/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7169/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mes/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela1737.csv&terr=N&rank=-&query=t/1737/n1/all/v/all/p/all/d/v63%202,v69%202,v2263%202,v2264%202,v2265%202,v2266%2013/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
+        "mes/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela3065.csv&terr=N&rank=-&query=t/3065/n1/all/v/all/p/all/d/v355%202,v356%202,v1117%2013,v1118%202,v1119%202,v1120%202/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
+        "mes/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela1736.csv&terr=N&rank=-&query=t/1736/n1/all/v/all/p/all/d/v44%202,v68%202,v2289%2013,v2290%202,v2291%202,v2292%202/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
+    }
+    links = {k: v for k, v in links.items() if k.__contains__(indice) & k.__contains__(folder)}
+    # precisei adicionar try catchs no loop para conseguir baixar todas
+    # as tabelas sem ter pproblema com o limite de requisição do sidra
+    links_keys = list(links.keys())
+    success_dwnl = []
+    for key in tqdm(links_keys):
+        try:
+            wget.download(links[key], out="/tmp/data/input/" + key + ".csv")
+            success_dwnl.append(key)
+        except:
+            try:
+                sleep(10)
+                wget.download(links[key], out="/tmp/data/input/" + key + ".csv")
+                success_dwnl.append(key)
+            except:
+                pass
+
+    if len(links_keys) == len(success_dwnl):
+        print("All files were successfully downloaded")
+    else:
+        print("The folowing files failed to download:")
+        rems = set(links_keys) - set(success_dwnl)
+        for rem in rems:
+            print(rem)
+
+
+@task
+def clean_mes_brasil(indice: str) -> None:
+    rename = {
+        "Mês": "ano",
+        "Geral, grupo, subgrupo, item e subitem": "categoria",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA - Peso mensal (%)": "peso_mensal",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Peso mensal (%)": "peso_mensal",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Peso mensal (%)": "peso_mensal",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "id_categoria",
+        "id_categoria_bd",
+        "categoria",
+        "peso_mensal",
+        "variacao_mensal",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/br/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        df = pd.read_csv(arq, skipfooter=14, skiprows=2, sep=";", dtype="str")
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        # substituir "..." por vazio
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Split coluna data e substituir mes
+        df[["mes", "ano"]] = df["ano"].str.split(" ", 1, expand=True)
+        df["mes"] = df["mes"].map(n_mes)
+
+        # Split coluna categoria e add id_categoria_bd
+        if arq.split("_")[-1].split(".")[0] != "geral":
+            df[["id_categoria", "categoria"]] = df["categoria"].str.split(
+                ".", 1, expand=True
+            )
+
+        if arq.split("_")[-1].split(".")[0] == "grupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(lambda x: x + ".0.00.000")
+            df = df[ordem]
+            grupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subgrupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + ".00.000"
+            )
+            df = df[ordem]
+            subgrupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "item":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + ".000"
+            )
+            df = df[ordem]
+            item = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subitem":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "geral":
+            df["id_categoria"] = ""
+            df["id_categoria_bd"] = "0.0.00.000"
+            df = df[ordem]
+            geral = pd.DataFrame(df)
+
+    df = pd.concat([grupo, subgrupo, item, subitem, geral])
+    filepath = "/tmp/data/output/{}/categoria_brasil.csv".format(indice)
+    df.to_csv(filepath, index=False)
+    
+    return filepath
+
+
+@task
+def clean_mes_rm(indice: str):
+    rename = {
+        "Cód.": "id_regiao_metropolitana",
+        "Unnamed: 1": "rm",
+        "Mês": "ano",
+        "Geral, grupo, subgrupo, item e subitem": "categoria",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA - Peso mensal (%)": "peso_mensal",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Peso mensal (%)": "peso_mensal",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Peso mensal (%)": "peso_mensal",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "id_regiao_metropolitana",
+        "id_categoria",
+        "id_categoria_bd",
+        "categoria",
+        "peso_mensal",
+        "variacao_mensal",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/rm/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        df = pd.read_csv(arq, skipfooter=14, skiprows=2, sep=";", dtype="str")
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        # substituir "..." por vazio
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Split coluna data e substituir mes
+        df[["mes", "ano"]] = df["ano"].str.split(" ", 1, expand=True)
+        df["mes"] = df["mes"].map(n_mes)
+
+        # Split coluna categoria e add id_categoria_bd
+        if arq.split("_")[-1].split(".")[0] != "geral":
+            df[["id_categoria", "categoria"]] = df["categoria"].str.split(
+                ".", 1, expand=True
+            )
+
+        if arq.split("_")[-1].split(".")[0] == "grupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(lambda x: x + ".0.00.000")
+            df = df[ordem]
+            grupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subgrupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + ".00.000"
+            )
+            df = df[ordem]
+            subgrupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "item":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + ".000"
+            )
+            df = df[ordem]
+            item = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_1":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_1 = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_2":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_2 = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "geral":
+            df["id_categoria"] = ""
+            df["id_categoria_bd"] = "0.0.00.000"
+            df = df[ordem]
+            geral = pd.DataFrame(df)
+
+    df = pd.concat([grupo, subgrupo, item, subitem_1, subitem_2, geral])
+    filepath = "/tmp/data/output/{}/categoria_rm.csv".format(indice)
+    df.to_csv(filepath, index=False)
+    
+    return filepath
+
+
+@task
+def clean_mes_municipio(indice: str):
+    rename = {
+        "Cód.": "id_municipio",
+        "Unnamed: 1": "municipio",
+        "Mês": "ano",
+        "Geral, grupo, subgrupo, item e subitem": "categoria",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA - Peso mensal (%)": "peso_mensal",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Peso mensal (%)": "peso_mensal",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Peso mensal (%)": "peso_mensal",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "id_municipio",
+        "id_categoria",
+        "id_categoria_bd",
+        "categoria",
+        "peso_mensal",
+        "variacao_mensal",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/mun/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        df = pd.read_csv(arq, skipfooter=14, skiprows=2, sep=";", dtype="str")
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        # substituir "..." por vazio
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Split coluna data e substituir mes
+        df[["mes", "ano"]] = df["ano"].str.split(" ", 1, expand=True)
+        df["mes"] = df["mes"].map(n_mes)
+
+        # Split coluna categoria e add id_categoria_bd
+        if arq.split("_")[-1].split(".")[0] != "geral":
+            df[["id_categoria", "categoria"]] = df["categoria"].str.split(
+                ".", 1, expand=True
+            )
+
+        if arq.split("_")[-1].split(".")[0] == "grupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(lambda x: x + ".0.00.000")
+            df = df[ordem]
+            grupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subgrupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + ".00.000"
+            )
+            df = df[ordem]
+            subgrupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "item":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + ".000"
+            )
+            df = df[ordem]
+            item = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_1":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_1 = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_2":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_2 = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "geral":
+            df["id_categoria"] = ""
+            df["id_categoria_bd"] = "0.0.00.000"
+            df = df[ordem]
+            geral = pd.DataFrame(df)
+
+    df = pd.concat([grupo, subgrupo, item, subitem_1, subitem_2, geral])
+    filepath = "/tmp/data/output/{}/categoria_municipio.csv".format(indice)
+    df.to_csv(filepath, index=False)
+    
+    return filepath
+
+
+@task
+def clean_mes_geral(indice: str):
+    rename = {
+        "IPCA - Número-índice (base: dezembro de 1993 = 100) (Número-índice)": "indice",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada em 3 meses (%)": "variacao_trimestral",
+        "IPCA - Variação acumulada em 6 meses (%)": "variacao_semestral",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Número-índice (base: dezembro de 1993 = 100) (Número-índice)": "indice",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada em 3 meses (%)": "variacao_trimestral",
+        "IPCA15 - Variação acumulada em 6 meses (%)": "variacao_semestral",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Número-índice (base: dezembro de 1993 = 100) (Número-índice)": "indice",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada em 3 meses (%)": "variacao_trimestral",
+        "INPC - Variação acumulada em 6 meses (%)": "variacao_semestral",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "indice",
+        "variacao_mensal",
+        "variacao_trimestral",
+        "variacao_semestral",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/mes/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        if indice == "ip15":
+            df = pd.read_csv(arq, skiprows=2, skipfooter=11, sep=";")
+        else:
+            df = pd.read_csv(arq, skiprows=2, skipfooter=13, sep=";")
+
+        df["mes"], df["ano"] = df["Mês"].str.split(" ", 1).str
+        df["mes"] = df["mes"].map(n_mes)
+
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Renomeando colunas e ordenando
+        df = df[ordem]
+
+    filepath = "/tmp/data/output/{}/mes_geral.csv".format(indice)
+    df.to_csv(filepath, index=False)
+
+    return filepath

--- a/pipelines/bases/br_ibge_inpc/tasks.py
+++ b/pipelines/bases/br_ibge_inpc/tasks.py
@@ -12,7 +12,7 @@ from time import sleep
 
 
 @task
-def crawl(indice: str, folder:str) -> None:
+def crawler(indice: str, folder:str) -> None:
     os.system('mkdir -p "/tmp/data"')
     os.system('mkdir -p "/tmp/data/input"')
     os.system('mkdir -p "/tmp/data/input/br"')

--- a/pipelines/bases/br_ibge_ipca/__init__.py
+++ b/pipelines/bases/br_ibge_ipca/__init__.py
@@ -1,0 +1,7 @@
+"""
+Prefect flows for br_ibge_ipca project
+"""
+###############################################################################
+# Automatically managed, please do not touch
+###############################################################################
+from .flows import *

--- a/pipelines/bases/br_ibge_ipca/flows.py
+++ b/pipelines/bases/br_ibge_ipca/flows.py
@@ -6,9 +6,9 @@ from prefect import Flow
 from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 from pipelines.constants import constants
-from pipelines.utils import upload_to_gcs
+from pipelines.utils import upload_to_gcs, create_bd_table, create_header
 from pipelines.bases.br_ibge_ipca.tasks import (
-    crawl,
+    crawler,
     clean_mes_brasil,
     clean_mes_rm,
     clean_mes_municipio,
@@ -20,19 +20,60 @@ INDICE = "ipca"
 
 with Flow("br_ibge_ipca.brasil") as br_ibge_ipca_br:
     FOLDER="br/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_brasil(INDICE)
-    upload_to_gcs("br_ibge_ipca", "brasil", filepath)
+    dataset_id = "br_ibge_ipca"
+    table_id = "brasil"
 
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
+    
 br_ibge_ipca_br.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca_br.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
 br_ibge_ipca_br.schedule = every_month
 
 with Flow("br_ibge_ipca.rm") as br_ibge_ipca_rm:
     FOLDER="rm/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_rm(INDICE)
-    upload_to_gcs("br_ibge_ipca", "rm", filepath)
+    dataset_id = "br_ibge_ipca"
+    table_id = "rm"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_ipca_rm.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca_rm.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
@@ -41,9 +82,29 @@ br_ibge_ipca_rm.schedule = every_month
 
 with Flow("br_ibge_ipca.municipio") as br_ibge_ipca_municipio:
     FOLDER="mun/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_municipio(INDICE)
-    upload_to_gcs("br_ibge_ipca", "municipio", filepath)
+    dataset_id = "br_ibge_ipca"
+    table_id = "municipio"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_ipca_municipio.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca_municipio.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
@@ -51,9 +112,29 @@ br_ibge_ipca_municipio.schedule = every_month
 
 with Flow("br_ibge_ipca.geral") as br_ibge_ipca_geral:
     FOLDER="mes/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_geral(INDICE)
-    upload_to_gcs("br_ibge_ipca", "geral", filepath)
+    dataset_id = "br_ibge_ipca"
+    table_id = "geral"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_ipca_geral.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca_geral.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)

--- a/pipelines/bases/br_ibge_ipca/flows.py
+++ b/pipelines/bases/br_ibge_ipca/flows.py
@@ -1,0 +1,60 @@
+"""
+Flows for br_ibge_ipca
+"""
+
+from prefect import Flow
+from prefect.run_configs import KubernetesRun
+from prefect.storage import GCS
+from pipelines.constants import constants
+from pipelines.utils import upload_to_gcs
+from pipelines.bases.br_ibge_ipca.tasks import (
+    crawl,
+    clean_mes_brasil,
+    clean_mes_rm,
+    clean_mes_municipio,
+    clean_mes_geral,
+)
+from pipelines.bases.br_ibge_ipca.schedules import every_month
+
+INDICE = "ipca"
+
+with Flow("br_ibge_ipca.brasil") as br_ibge_ipca_br:
+    FOLDER="br/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_brasil(INDICE)
+    upload_to_gcs("br_ibge_ipca", "brasil", filepath)
+
+br_ibge_ipca_br.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_ipca_br.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_ipca_br.schedule = every_month
+
+with Flow("br_ibge_ipca.rm") as br_ibge_ipca_rm:
+    FOLDER="rm/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_rm(INDICE)
+    upload_to_gcs("br_ibge_ipca", "rm", filepath)
+
+br_ibge_ipca_rm.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_ipca_rm.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_ipca_rm.schedule = every_month
+
+
+with Flow("br_ibge_ipca.municipio") as br_ibge_ipca_municipio:
+    FOLDER="mun/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_municipio(INDICE)
+    upload_to_gcs("br_ibge_ipca", "municipio", filepath)
+
+br_ibge_ipca_municipio.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_ipca_municipio.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_ipca_municipio.schedule = every_month
+
+with Flow("br_ibge_ipca.geral") as br_ibge_ipca_geral:
+    FOLDER="mes/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_geral(INDICE)
+    upload_to_gcs("br_ibge_ipca", "geral", filepath)
+
+br_ibge_ipca_geral.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_ipca_geral.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_ipca_geral.schedule = every_month

--- a/pipelines/bases/br_ibge_ipca/schedules.py
+++ b/pipelines/bases/br_ibge_ipca/schedules.py
@@ -1,0 +1,20 @@
+"""
+Schedules for br_ibge_ipca
+"""
+
+from datetime import timedelta, datetime
+from prefect.schedules import Schedule
+from prefect.schedules.clocks import IntervalClock
+from pipelines.constants import constants
+
+every_month = Schedule(
+    clocks=[
+        IntervalClock(
+            interval=timedelta(days=30),
+            start_date=datetime(2021, 1, 1),
+            labels=[
+                constants.BASEDOSDADOS_AGENT_LABEL.value,
+            ]
+        )
+    ]
+)

--- a/pipelines/bases/br_ibge_ipca/tasks.py
+++ b/pipelines/bases/br_ibge_ipca/tasks.py
@@ -12,7 +12,7 @@ from time import sleep
 
 
 @task
-def crawl(indice: str, folder:str) -> None:
+def crawler(indice: str, folder:str) -> None:
     os.system('mkdir -p "/tmp/data"')
     os.system('mkdir -p "/tmp/data/input"')
     os.system('mkdir -p "/tmp/data/input/br"')

--- a/pipelines/bases/br_ibge_ipca/tasks.py
+++ b/pipelines/bases/br_ibge_ipca/tasks.py
@@ -1,0 +1,521 @@
+"""
+Tasks for br_ibge_ipca
+"""
+
+from prefect import task
+import pandas as pd
+import os
+import glob
+import wget
+from tqdm import tqdm
+from time import sleep
+
+
+@task
+def crawl(indice: str, folder:str) -> None:
+    os.system('mkdir -p "/tmp/data"')
+    os.system('mkdir -p "/tmp/data/input"')
+    os.system('mkdir -p "/tmp/data/input/br"')
+    os.system('mkdir -p "/tmp/data/input/rm"')
+    os.system('mkdir -p "/tmp/data/input/mun"')
+    os.system('mkdir -p "/tmp/data/input/mes"')
+    os.system('mkdir -p "/tmp/data/output"')
+    os.system('mkdir -p "/tmp/data/output/ip15"')
+    os.system('mkdir -p "/tmp/data/output/ipca"')
+    os.system('mkdir -p "/tmp/data/output/inpc"')
+
+    links = {
+        "br/ipca_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "br/ipca_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "br/ipca_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "br/ipca_subitem": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/947075621",
+        "br/inpc_subitem": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/1084704443",
+        "br/ip15_subitem": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-783617233",
+        "br/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7169/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7169/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7169/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/947075621",
+        "rm/ipca_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/847634158",
+        "rm/inpc_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-884745035",
+        "rm/inpc_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1265010694",
+        "rm/ip15_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1750716307",
+        "rm/ip15_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1258570016",
+        "rm/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7169/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7169/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7169/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/866963382",
+        "mun/ipca_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-113176757",
+        "mun/inpc_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/1139761886",
+        "mun/inpc_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1289673003",
+        "mun/ip15_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-260564956",
+        "mun/ip15_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-317614754",
+        "mun/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7169/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7169/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7169/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mes/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela1737.csv&terr=N&rank=-&query=t/1737/n1/all/v/all/p/all/d/v63%202,v69%202,v2263%202,v2264%202,v2265%202,v2266%2013/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
+        "mes/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela3065.csv&terr=N&rank=-&query=t/3065/n1/all/v/all/p/all/d/v355%202,v356%202,v1117%2013,v1118%202,v1119%202,v1120%202/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
+        "mes/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela1736.csv&terr=N&rank=-&query=t/1736/n1/all/v/all/p/all/d/v44%202,v68%202,v2289%2013,v2290%202,v2291%202,v2292%202/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
+    }
+    links = {k: v for k, v in links.items() if k.__contains__(indice) & k.__contains__(folder)}
+    # precisei adicionar try catchs no loop para conseguir baixar todas
+    # as tabelas sem ter pproblema com o limite de requisição do sidra
+    links_keys = list(links.keys())
+    success_dwnl = []
+    for key in tqdm(links_keys):
+        try:
+            wget.download(links[key], out="/tmp/data/input/" + key + ".csv")
+            success_dwnl.append(key)
+        except:
+            try:
+                sleep(10)
+                wget.download(links[key], out="/tmp/data/input/" + key + ".csv")
+                success_dwnl.append(key)
+            except:
+                pass
+
+    if len(links_keys) == len(success_dwnl):
+        print("All files were successfully downloaded")
+    else:
+        print("The folowing files failed to download:")
+        rems = set(links_keys) - set(success_dwnl)
+        for rem in rems:
+            print(rem)
+
+
+@task
+def clean_mes_brasil(indice: str) -> None:
+    rename = {
+        "Mês": "ano",
+        "Geral, grupo, subgrupo, item e subitem": "categoria",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA - Peso mensal (%)": "peso_mensal",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Peso mensal (%)": "peso_mensal",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Peso mensal (%)": "peso_mensal",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "id_categoria",
+        "id_categoria_bd",
+        "categoria",
+        "peso_mensal",
+        "variacao_mensal",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/br/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        df = pd.read_csv(arq, skipfooter=14, skiprows=2, sep=";", dtype="str")
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        # substituir "..." por vazio
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Split coluna data e substituir mes
+        df[["mes", "ano"]] = df["ano"].str.split(" ", 1, expand=True)
+        df["mes"] = df["mes"].map(n_mes)
+
+        # Split coluna categoria e add id_categoria_bd
+        if arq.split("_")[-1].split(".")[0] != "geral":
+            df[["id_categoria", "categoria"]] = df["categoria"].str.split(
+                ".", 1, expand=True
+            )
+
+        if arq.split("_")[-1].split(".")[0] == "grupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(lambda x: x + ".0.00.000")
+            df = df[ordem]
+            grupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subgrupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + ".00.000"
+            )
+            df = df[ordem]
+            subgrupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "item":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + ".000"
+            )
+            df = df[ordem]
+            item = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subitem":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "geral":
+            df["id_categoria"] = ""
+            df["id_categoria_bd"] = "0.0.00.000"
+            df = df[ordem]
+            geral = pd.DataFrame(df)
+
+    df = pd.concat([grupo, subgrupo, item, subitem, geral])
+    filepath = "/tmp/data/output/{}/categoria_brasil.csv".format(indice)
+    df.to_csv(filepath, index=False)
+    
+    return filepath
+
+
+@task
+def clean_mes_rm(indice: str):
+    rename = {
+        "Cód.": "id_regiao_metropolitana",
+        "Unnamed: 1": "rm",
+        "Mês": "ano",
+        "Geral, grupo, subgrupo, item e subitem": "categoria",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA - Peso mensal (%)": "peso_mensal",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Peso mensal (%)": "peso_mensal",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Peso mensal (%)": "peso_mensal",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "id_regiao_metropolitana",
+        "id_categoria",
+        "id_categoria_bd",
+        "categoria",
+        "peso_mensal",
+        "variacao_mensal",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/rm/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        df = pd.read_csv(arq, skipfooter=14, skiprows=2, sep=";", dtype="str")
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        # substituir "..." por vazio
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Split coluna data e substituir mes
+        df[["mes", "ano"]] = df["ano"].str.split(" ", 1, expand=True)
+        df["mes"] = df["mes"].map(n_mes)
+
+        # Split coluna categoria e add id_categoria_bd
+        if arq.split("_")[-1].split(".")[0] != "geral":
+            df[["id_categoria", "categoria"]] = df["categoria"].str.split(
+                ".", 1, expand=True
+            )
+
+        if arq.split("_")[-1].split(".")[0] == "grupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(lambda x: x + ".0.00.000")
+            df = df[ordem]
+            grupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subgrupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + ".00.000"
+            )
+            df = df[ordem]
+            subgrupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "item":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + ".000"
+            )
+            df = df[ordem]
+            item = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_1":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_1 = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_2":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_2 = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "geral":
+            df["id_categoria"] = ""
+            df["id_categoria_bd"] = "0.0.00.000"
+            df = df[ordem]
+            geral = pd.DataFrame(df)
+
+    df = pd.concat([grupo, subgrupo, item, subitem_1, subitem_2, geral])
+    filepath = "/tmp/data/output/{}/categoria_rm.csv".format(indice)
+    df.to_csv(filepath, index=False)
+    
+    return filepath
+
+
+@task
+def clean_mes_municipio(indice: str):
+    rename = {
+        "Cód.": "id_municipio",
+        "Unnamed: 1": "municipio",
+        "Mês": "ano",
+        "Geral, grupo, subgrupo, item e subitem": "categoria",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA - Peso mensal (%)": "peso_mensal",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Peso mensal (%)": "peso_mensal",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Peso mensal (%)": "peso_mensal",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "id_municipio",
+        "id_categoria",
+        "id_categoria_bd",
+        "categoria",
+        "peso_mensal",
+        "variacao_mensal",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/mun/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        df = pd.read_csv(arq, skipfooter=14, skiprows=2, sep=";", dtype="str")
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        # substituir "..." por vazio
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Split coluna data e substituir mes
+        df[["mes", "ano"]] = df["ano"].str.split(" ", 1, expand=True)
+        df["mes"] = df["mes"].map(n_mes)
+
+        # Split coluna categoria e add id_categoria_bd
+        if arq.split("_")[-1].split(".")[0] != "geral":
+            df[["id_categoria", "categoria"]] = df["categoria"].str.split(
+                ".", 1, expand=True
+            )
+
+        if arq.split("_")[-1].split(".")[0] == "grupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(lambda x: x + ".0.00.000")
+            df = df[ordem]
+            grupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subgrupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + ".00.000"
+            )
+            df = df[ordem]
+            subgrupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "item":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + ".000"
+            )
+            df = df[ordem]
+            item = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_1":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_1 = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_2":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_2 = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "geral":
+            df["id_categoria"] = ""
+            df["id_categoria_bd"] = "0.0.00.000"
+            df = df[ordem]
+            geral = pd.DataFrame(df)
+
+    df = pd.concat([grupo, subgrupo, item, subitem_1, subitem_2, geral])
+    filepath = "/tmp/data/output/{}/categoria_municipio.csv".format(indice)
+    df.to_csv(filepath, index=False)
+    
+    return filepath
+
+
+@task
+def clean_mes_geral(indice: str):
+    rename = {
+        "IPCA - Número-índice (base: dezembro de 1993 = 100) (Número-índice)": "indice",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada em 3 meses (%)": "variacao_trimestral",
+        "IPCA - Variação acumulada em 6 meses (%)": "variacao_semestral",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Número-índice (base: dezembro de 1993 = 100) (Número-índice)": "indice",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada em 3 meses (%)": "variacao_trimestral",
+        "IPCA15 - Variação acumulada em 6 meses (%)": "variacao_semestral",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Número-índice (base: dezembro de 1993 = 100) (Número-índice)": "indice",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada em 3 meses (%)": "variacao_trimestral",
+        "INPC - Variação acumulada em 6 meses (%)": "variacao_semestral",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "indice",
+        "variacao_mensal",
+        "variacao_trimestral",
+        "variacao_semestral",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/mes/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        if indice == "ip15":
+            df = pd.read_csv(arq, skiprows=2, skipfooter=11, sep=";")
+        else:
+            df = pd.read_csv(arq, skiprows=2, skipfooter=13, sep=";")
+
+        df["mes"], df["ano"] = df["Mês"].str.split(" ", 1).str
+        df["mes"] = df["mes"].map(n_mes)
+
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Renomeando colunas e ordenando
+        df = df[ordem]
+
+    filepath = "/tmp/data/output/{}/mes_geral.csv".format(indice)
+    df.to_csv(filepath, index=False)
+
+    return filepath

--- a/pipelines/bases/br_ibge_ipca15/__init__.py
+++ b/pipelines/bases/br_ibge_ipca15/__init__.py
@@ -1,0 +1,7 @@
+"""
+Prefect flows for br_ibge_ipca15 project
+"""
+###############################################################################
+# Automatically managed, please do not touch
+###############################################################################
+from .flows import *

--- a/pipelines/bases/br_ibge_ipca15/flows.py
+++ b/pipelines/bases/br_ibge_ipca15/flows.py
@@ -1,0 +1,60 @@
+"""
+Flows for br_ibge_ipca15
+"""
+
+from prefect import Flow
+from prefect.run_configs import KubernetesRun
+from prefect.storage import GCS
+from pipelines.constants import constants
+from pipelines.utils import upload_to_gcs
+from pipelines.bases.br_ibge_ipca15.tasks import (
+    crawl,
+    clean_mes_brasil,
+    clean_mes_rm,
+    clean_mes_municipio,
+    clean_mes_geral,
+)
+from pipelines.bases.br_ibge_ipca15.schedules import every_month
+
+INDICE = "ip15"
+
+with Flow("br_ibge_ipca15.brasil") as br_ibge_ipca15_br:
+    FOLDER="br/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_brasil(INDICE)
+    upload_to_gcs("br_ibge_ipca15", "brasil", filepath)
+
+br_ibge_ipca15_br.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_ipca15_br.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_ipca15_br.schedule = every_month
+
+with Flow("br_ibge_ipca15.rm") as br_ibge_ipca15_rm:
+    FOLDER="rm/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_rm(INDICE)
+    upload_to_gcs("br_ibge_ipca15", "rm", filepath)
+
+br_ibge_ipca15_rm.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_ipca15_rm.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_ipca15_rm.schedule = every_month
+
+
+with Flow("br_ibge_ipca15.municipio") as br_ibge_ipca15_municipio:
+    FOLDER="mun/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_municipio(INDICE)
+    upload_to_gcs("br_ibge_ipca15", "municipio", filepath)
+
+br_ibge_ipca15_municipio.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_ipca15_municipio.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_ipca15_municipio.schedule = every_month
+
+with Flow("br_ibge_ipca15.geral") as br_ibge_ipca15_geral:
+    FOLDER="mes/"
+    crawl(INDICE, FOLDER)
+    filepath = clean_mes_geral(INDICE)
+    upload_to_gcs("br_ibge_ipca15", "geral", filepath)
+
+br_ibge_ipca15_geral.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+br_ibge_ipca15_geral.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+br_ibge_ipca15_geral.schedule = every_month

--- a/pipelines/bases/br_ibge_ipca15/flows.py
+++ b/pipelines/bases/br_ibge_ipca15/flows.py
@@ -9,7 +9,7 @@ from prefect.storage import GCS
 from pipelines.constants import constants
 from pipelines.utils import upload_to_gcs, create_bd_table, create_header
 from pipelines.bases.br_ibge_ipca15.tasks import (
-    crawl,
+    crawler,
     clean_mes_brasil,
     clean_mes_rm,
     clean_mes_municipio,
@@ -21,12 +21,13 @@ INDICE = "ip15"
 
 with Flow("br_ibge_ipca15.brasil") as br_ibge_ipca15_br:
     FOLDER = "br/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_brasil(INDICE)
     dataset_id = "br_ibge_ipca15"
     table_id = "brasil"
 
     wait_header_path = create_header(path=filepath)
+    # print(wait_header_path)
 
     # Create table in BigQuery
     wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
@@ -51,9 +52,29 @@ br_ibge_ipca15_br.schedule = every_month
 
 with Flow("br_ibge_ipca15.rm") as br_ibge_ipca15_rm:
     FOLDER = "rm/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_rm(INDICE)
-    upload_to_gcs("br_ibge_ipca15", "rm", filepath)
+    dataset_id = "br_ibge_ipca15"
+    table_id = "rm"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_ipca15_rm.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca15_rm.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
@@ -62,9 +83,29 @@ br_ibge_ipca15_rm.schedule = every_month
 
 with Flow("br_ibge_ipca15.municipio") as br_ibge_ipca15_municipio:
     FOLDER = "mun/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_municipio(INDICE)
-    upload_to_gcs("br_ibge_ipca15", "municipio", filepath)
+    dataset_id = "br_ibge_ipca15"
+    table_id = "municipio"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_ipca15_municipio.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca15_municipio.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
@@ -72,9 +113,29 @@ br_ibge_ipca15_municipio.schedule = every_month
 
 with Flow("br_ibge_ipca15.geral") as br_ibge_ipca15_geral:
     FOLDER = "mes/"
-    crawl(INDICE, FOLDER)
+    crawler(INDICE, FOLDER)
     filepath = clean_mes_geral(INDICE)
-    upload_to_gcs("br_ibge_ipca15", "geral", filepath)
+    dataset_id = "br_ibge_ipca15"
+    table_id = "geral"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_bd_table,
+    )
 
 br_ibge_ipca15_geral.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca15_geral.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)

--- a/pipelines/bases/br_ibge_ipca15/flows.py
+++ b/pipelines/bases/br_ibge_ipca15/flows.py
@@ -2,11 +2,12 @@
 Flows for br_ibge_ipca15
 """
 
+from multiprocessing.connection import wait
 from prefect import Flow
 from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 from pipelines.constants import constants
-from pipelines.utils import upload_to_gcs
+from pipelines.utils import upload_to_gcs, create_bd_table, create_header
 from pipelines.bases.br_ibge_ipca15.tasks import (
     crawl,
     clean_mes_brasil,
@@ -19,17 +20,37 @@ from pipelines.bases.br_ibge_ipca15.schedules import every_month
 INDICE = "ip15"
 
 with Flow("br_ibge_ipca15.brasil") as br_ibge_ipca15_br:
-    FOLDER="br/"
+    FOLDER = "br/"
     crawl(INDICE, FOLDER)
     filepath = clean_mes_brasil(INDICE)
-    upload_to_gcs("br_ibge_ipca15", "brasil", filepath)
+    dataset_id = "br_ibge_ipca15"
+    table_id = "brasil"
+
+    wait_header_path = create_header(path=filepath)
+
+    # Create table in BigQuery
+    wait_create_db = create_bd_table(  # pylint: disable=invalid-name
+        path=wait_header_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_type="overwrite",
+        wait=wait_header_path,
+    )
+
+    # Upload to GCS
+    upload_to_gcs(
+        path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        wait=wait_create_db,
+    )
 
 br_ibge_ipca15_br.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca15_br.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
 br_ibge_ipca15_br.schedule = every_month
 
 with Flow("br_ibge_ipca15.rm") as br_ibge_ipca15_rm:
-    FOLDER="rm/"
+    FOLDER = "rm/"
     crawl(INDICE, FOLDER)
     filepath = clean_mes_rm(INDICE)
     upload_to_gcs("br_ibge_ipca15", "rm", filepath)
@@ -40,7 +61,7 @@ br_ibge_ipca15_rm.schedule = every_month
 
 
 with Flow("br_ibge_ipca15.municipio") as br_ibge_ipca15_municipio:
-    FOLDER="mun/"
+    FOLDER = "mun/"
     crawl(INDICE, FOLDER)
     filepath = clean_mes_municipio(INDICE)
     upload_to_gcs("br_ibge_ipca15", "municipio", filepath)
@@ -50,7 +71,7 @@ br_ibge_ipca15_municipio.run_config = KubernetesRun(image=constants.DOCKER_IMAGE
 br_ibge_ipca15_municipio.schedule = every_month
 
 with Flow("br_ibge_ipca15.geral") as br_ibge_ipca15_geral:
-    FOLDER="mes/"
+    FOLDER = "mes/"
     crawl(INDICE, FOLDER)
     filepath = clean_mes_geral(INDICE)
     upload_to_gcs("br_ibge_ipca15", "geral", filepath)

--- a/pipelines/bases/br_ibge_ipca15/flows.py
+++ b/pipelines/bases/br_ibge_ipca15/flows.py
@@ -29,7 +29,7 @@ with Flow("br_ibge_ipca15.brasil") as br_ibge_ipca15_br:
     wait_header_path = create_header(path=filepath)
 
     # Create table in BigQuery
-    wait_create_db = create_bd_table(  # pylint: disable=invalid-name
+    wait_create_bd_table = create_bd_table(  # pylint: disable=invalid-name
         path=wait_header_path,
         dataset_id=dataset_id,
         table_id=table_id,
@@ -42,7 +42,7 @@ with Flow("br_ibge_ipca15.brasil") as br_ibge_ipca15_br:
         path=filepath,
         dataset_id=dataset_id,
         table_id=table_id,
-        wait=wait_create_db,
+        wait=wait_create_bd_table,
     )
 
 br_ibge_ipca15_br.storage = GCS(constants.GCS_FLOWS_BUCKET.value)

--- a/pipelines/bases/br_ibge_ipca15/schedules.py
+++ b/pipelines/bases/br_ibge_ipca15/schedules.py
@@ -1,0 +1,20 @@
+"""
+Schedules for br_ibge_ipca15
+"""
+
+from datetime import timedelta, datetime
+from prefect.schedules import Schedule
+from prefect.schedules.clocks import IntervalClock
+from pipelines.constants import constants
+
+every_month = Schedule(
+    clocks=[
+        IntervalClock(
+            interval=timedelta(days=30),
+            start_date=datetime(2021, 1, 1),
+            labels=[
+                constants.BASEDOSDADOS_AGENT_LABEL.value,
+            ]
+        )
+    ]
+)

--- a/pipelines/bases/br_ibge_ipca15/tasks.py
+++ b/pipelines/bases/br_ibge_ipca15/tasks.py
@@ -1,0 +1,521 @@
+"""
+Tasks for br_ibge_ipca15
+"""
+
+from prefect import task
+import pandas as pd
+import os
+import glob
+import wget
+from tqdm import tqdm
+from time import sleep
+
+
+@task
+def crawl(indice: str, folder:str) -> None:
+    os.system('mkdir -p "/tmp/data"')
+    os.system('mkdir -p "/tmp/data/input"')
+    os.system('mkdir -p "/tmp/data/input/br"')
+    os.system('mkdir -p "/tmp/data/input/rm"')
+    os.system('mkdir -p "/tmp/data/input/mun"')
+    os.system('mkdir -p "/tmp/data/input/mes"')
+    os.system('mkdir -p "/tmp/data/output"')
+    os.system('mkdir -p "/tmp/data/output/ip15"')
+    os.system('mkdir -p "/tmp/data/output/ipca"')
+    os.system('mkdir -p "/tmp/data/output/inpc"')
+
+    links = {
+        "br/ipca_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "br/ipca_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "br/ipca_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "br/ipca_subitem": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/947075621",
+        "br/inpc_subitem": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/1084704443",
+        "br/ip15_subitem": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-783617233",
+        "br/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n1/all/v/all/p/all/c315/7169/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "br/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n1/all/v/all/p/all/c315/7169/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "br/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n1/all/v/all/p/all/c315/7169/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "rm/ipca_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/947075621",
+        "rm/ipca_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/847634158",
+        "rm/inpc_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-884745035",
+        "rm/inpc_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1265010694",
+        "rm/ip15_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1750716307",
+        "rm/ip15_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1258570016",
+        "rm/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n7/all/v/all/p/all/c315/7169/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "rm/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n7/all/v/all/p/all/c315/7169/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "rm/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n7/all/v/all/p/all/c315/7169/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_grupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7170,7445,7486,7558,7625,7660,7712,7766,7786/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_subgrupo": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7171,7432,7446,7479,7487,7521,7548,7559,7604,7615,7620,7626,7661,7683,7697,7713,7767,7787,47656/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_item": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7172,7184,7200,7219,7241,7254,7283,7303,7335,7349,7356,7372,7384,7389,7401,7415,7433,7447,7454,7461,7480,7484,7488,7495,7517,7522,7541,7549,7560,7572,7587,7605,7616,7621,7627,7640,7656,7662,7684,7690,7695,7698,7714,7730,7758,7777,7782,7788,12427,107678,109464/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mun/ipca_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/866963382",
+        "mun/ipca_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-113176757",
+        "mun/inpc_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/1139761886",
+        "mun/inpc_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-1289673003",
+        "mun/ip15_subitem_1": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-260564956",
+        "mun/ip15_subitem_2": "https://sidra.ibge.gov.br/geratabela/DownloadSelecaoComplexa/-317614754",
+        "mun/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7060.csv&terr=NC&rank=-&query=t/7060/n6/all/v/all/p/all/c315/7169/d/v63%202,v66%204,v69%202,v2265%202/l/,v,t%2Bp%2Bc315",
+        "mun/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7063.csv&terr=NC&rank=-&query=t/7063/n6/all/v/all/p/all/c315/7169/d/v44%202,v45%204,v68%202,v2292%202/l/,v,t%2Bp%2Bc315",
+        "mun/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela7062.csv&terr=NC&rank=-&query=t/7062/n6/all/v/all/p/all/c315/7169/d/v355%202,v356%202,v357%204,v1120%202/l/,v,t%2Bp%2Bc315",
+        "mes/ipca_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela1737.csv&terr=N&rank=-&query=t/1737/n1/all/v/all/p/all/d/v63%202,v69%202,v2263%202,v2264%202,v2265%202,v2266%2013/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
+        "mes/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela3065.csv&terr=N&rank=-&query=t/3065/n1/all/v/all/p/all/d/v355%202,v356%202,v1117%2013,v1118%202,v1119%202,v1120%202/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
+        "mes/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela1736.csv&terr=N&rank=-&query=t/1736/n1/all/v/all/p/all/d/v44%202,v68%202,v2289%2013,v2290%202,v2291%202,v2292%202/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
+    }
+    links = {k: v for k, v in links.items() if k.__contains__(indice) & k.__contains__(folder)}
+    # precisei adicionar try catchs no loop para conseguir baixar todas
+    # as tabelas sem ter pproblema com o limite de requisição do sidra
+    links_keys = list(links.keys())
+    success_dwnl = []
+    for key in tqdm(links_keys):
+        try:
+            wget.download(links[key], out="/tmp/data/input/" + key + ".csv")
+            success_dwnl.append(key)
+        except:
+            try:
+                sleep(10)
+                wget.download(links[key], out="/tmp/data/input/" + key + ".csv")
+                success_dwnl.append(key)
+            except:
+                pass
+
+    if len(links_keys) == len(success_dwnl):
+        print("All files were successfully downloaded")
+    else:
+        print("The folowing files failed to download:")
+        rems = set(links_keys) - set(success_dwnl)
+        for rem in rems:
+            print(rem)
+
+
+@task
+def clean_mes_brasil(indice: str) -> None:
+    rename = {
+        "Mês": "ano",
+        "Geral, grupo, subgrupo, item e subitem": "categoria",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA - Peso mensal (%)": "peso_mensal",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Peso mensal (%)": "peso_mensal",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Peso mensal (%)": "peso_mensal",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "id_categoria",
+        "id_categoria_bd",
+        "categoria",
+        "peso_mensal",
+        "variacao_mensal",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/br/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        df = pd.read_csv(arq, skipfooter=14, skiprows=2, sep=";", dtype="str")
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        # substituir "..." por vazio
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Split coluna data e substituir mes
+        df[["mes", "ano"]] = df["ano"].str.split(" ", 1, expand=True)
+        df["mes"] = df["mes"].map(n_mes)
+
+        # Split coluna categoria e add id_categoria_bd
+        if arq.split("_")[-1].split(".")[0] != "geral":
+            df[["id_categoria", "categoria"]] = df["categoria"].str.split(
+                ".", 1, expand=True
+            )
+
+        if arq.split("_")[-1].split(".")[0] == "grupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(lambda x: x + ".0.00.000")
+            df = df[ordem]
+            grupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subgrupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + ".00.000"
+            )
+            df = df[ordem]
+            subgrupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "item":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + ".000"
+            )
+            df = df[ordem]
+            item = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subitem":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "geral":
+            df["id_categoria"] = ""
+            df["id_categoria_bd"] = "0.0.00.000"
+            df = df[ordem]
+            geral = pd.DataFrame(df)
+
+    df = pd.concat([grupo, subgrupo, item, subitem, geral])
+    filepath = "/tmp/data/output/{}/categoria_brasil.csv".format(indice)
+    df.to_csv(filepath, index=False)
+    
+    return filepath
+
+
+@task
+def clean_mes_rm(indice: str):
+    rename = {
+        "Cód.": "id_regiao_metropolitana",
+        "Unnamed: 1": "rm",
+        "Mês": "ano",
+        "Geral, grupo, subgrupo, item e subitem": "categoria",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA - Peso mensal (%)": "peso_mensal",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Peso mensal (%)": "peso_mensal",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Peso mensal (%)": "peso_mensal",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "id_regiao_metropolitana",
+        "id_categoria",
+        "id_categoria_bd",
+        "categoria",
+        "peso_mensal",
+        "variacao_mensal",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/rm/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        df = pd.read_csv(arq, skipfooter=14, skiprows=2, sep=";", dtype="str")
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        # substituir "..." por vazio
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Split coluna data e substituir mes
+        df[["mes", "ano"]] = df["ano"].str.split(" ", 1, expand=True)
+        df["mes"] = df["mes"].map(n_mes)
+
+        # Split coluna categoria e add id_categoria_bd
+        if arq.split("_")[-1].split(".")[0] != "geral":
+            df[["id_categoria", "categoria"]] = df["categoria"].str.split(
+                ".", 1, expand=True
+            )
+
+        if arq.split("_")[-1].split(".")[0] == "grupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(lambda x: x + ".0.00.000")
+            df = df[ordem]
+            grupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subgrupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + ".00.000"
+            )
+            df = df[ordem]
+            subgrupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "item":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + ".000"
+            )
+            df = df[ordem]
+            item = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_1":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_1 = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_2":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_2 = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "geral":
+            df["id_categoria"] = ""
+            df["id_categoria_bd"] = "0.0.00.000"
+            df = df[ordem]
+            geral = pd.DataFrame(df)
+
+    df = pd.concat([grupo, subgrupo, item, subitem_1, subitem_2, geral])
+    filepath = "/tmp/data/output/{}/categoria_rm.csv".format(indice)
+    df.to_csv(filepath, index=False)
+    
+    return filepath
+
+
+@task
+def clean_mes_municipio(indice: str):
+    rename = {
+        "Cód.": "id_municipio",
+        "Unnamed: 1": "municipio",
+        "Mês": "ano",
+        "Geral, grupo, subgrupo, item e subitem": "categoria",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA - Peso mensal (%)": "peso_mensal",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Peso mensal (%)": "peso_mensal",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Peso mensal (%)": "peso_mensal",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "id_municipio",
+        "id_categoria",
+        "id_categoria_bd",
+        "categoria",
+        "peso_mensal",
+        "variacao_mensal",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/mun/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        df = pd.read_csv(arq, skipfooter=14, skiprows=2, sep=";", dtype="str")
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        # substituir "..." por vazio
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Split coluna data e substituir mes
+        df[["mes", "ano"]] = df["ano"].str.split(" ", 1, expand=True)
+        df["mes"] = df["mes"].map(n_mes)
+
+        # Split coluna categoria e add id_categoria_bd
+        if arq.split("_")[-1].split(".")[0] != "geral":
+            df[["id_categoria", "categoria"]] = df["categoria"].str.split(
+                ".", 1, expand=True
+            )
+
+        if arq.split("_")[-1].split(".")[0] == "grupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(lambda x: x + ".0.00.000")
+            df = df[ordem]
+            grupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "subgrupo":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + ".00.000"
+            )
+            df = df[ordem]
+            subgrupo = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "item":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + ".000"
+            )
+            df = df[ordem]
+            item = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_1":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_1 = pd.DataFrame(df)
+        elif "_".join(arq.split("_")[1:]).split(".")[0] == "subitem_2":
+            df["id_categoria_bd"] = df["id_categoria"].apply(
+                lambda x: x[0] + "." + x[1] + "." + x[2:4] + "." + x[4:7]
+            )
+            df = df[ordem]
+            subitem_2 = pd.DataFrame(df)
+        elif arq.split("_")[-1].split(".")[0] == "geral":
+            df["id_categoria"] = ""
+            df["id_categoria_bd"] = "0.0.00.000"
+            df = df[ordem]
+            geral = pd.DataFrame(df)
+
+    df = pd.concat([grupo, subgrupo, item, subitem_1, subitem_2, geral])
+    filepath = "/tmp/data/output/{}/categoria_municipio.csv".format(indice)
+    df.to_csv(filepath, index=False)
+    
+    return filepath
+
+
+@task
+def clean_mes_geral(indice: str):
+    rename = {
+        "IPCA - Número-índice (base: dezembro de 1993 = 100) (Número-índice)": "indice",
+        "IPCA - Variação mensal (%)": "variacao_mensal",
+        "IPCA - Variação acumulada em 3 meses (%)": "variacao_trimestral",
+        "IPCA - Variação acumulada em 6 meses (%)": "variacao_semestral",
+        "IPCA - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "IPCA15 - Número-índice (base: dezembro de 1993 = 100) (Número-índice)": "indice",
+        "IPCA15 - Variação mensal (%)": "variacao_mensal",
+        "IPCA15 - Variação acumulada em 3 meses (%)": "variacao_trimestral",
+        "IPCA15 - Variação acumulada em 6 meses (%)": "variacao_semestral",
+        "IPCA15 - Variação acumulada no ano (%)": "variacao_anual",
+        "IPCA15 - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+        "INPC - Número-índice (base: dezembro de 1993 = 100) (Número-índice)": "indice",
+        "INPC - Variação mensal (%)": "variacao_mensal",
+        "INPC - Variação acumulada em 3 meses (%)": "variacao_trimestral",
+        "INPC - Variação acumulada em 6 meses (%)": "variacao_semestral",
+        "INPC - Variação acumulada no ano (%)": "variacao_anual",
+        "INPC - Variação acumulada em 12 meses (%)": "variacao_doze_meses",
+    }
+
+    ordem = [
+        "ano",
+        "mes",
+        "indice",
+        "variacao_mensal",
+        "variacao_trimestral",
+        "variacao_semestral",
+        "variacao_anual",
+        "variacao_doze_meses",
+    ]
+
+    n_mes = {
+        "janeiro": "1",
+        "fevereiro": "2",
+        "março": "3",
+        "abril": "4",
+        "maio": "5",
+        "junho": "6",
+        "julho": "7",
+        "agosto": "8",
+        "setembro": "9",
+        "outubro": "10",
+        "novembro": "11",
+        "dezembro": "12",
+    }
+    arquivos = [
+        arquivo
+        for arquivo in glob.iglob("/tmp/data/input/mes/*")
+        if arquivo.split("/")[-1].split("_")[0] == indice
+    ]
+    for arq in arquivos:
+        if indice == "ip15":
+            df = pd.read_csv(arq, skiprows=2, skipfooter=11, sep=";")
+        else:
+            df = pd.read_csv(arq, skiprows=2, skipfooter=13, sep=";")
+
+        df["mes"], df["ano"] = df["Mês"].str.split(" ", 1).str
+        df["mes"] = df["mes"].map(n_mes)
+
+        # renomear colunas
+        df.rename(columns=rename, inplace=True)
+        df = df.replace("...", "")
+        df = df.replace("-", "")
+
+        # Normalizando float
+        df = df.replace(",", ".", regex=True)
+
+        # Renomeando colunas e ordenando
+        df = df[ordem]
+
+    filepath = "/tmp/data/output/{}/mes_geral.csv".format(indice)
+    df.to_csv(filepath, index=False)
+
+    return filepath

--- a/pipelines/bases/br_ibge_ipca15/tasks.py
+++ b/pipelines/bases/br_ibge_ipca15/tasks.py
@@ -9,10 +9,11 @@ import glob
 import wget
 from tqdm import tqdm
 from time import sleep
+from pipelines.utils import upload_to_gcs_utils, create_bd_table_utils
 
 
 @task
-def crawl(indice: str, folder:str) -> None:
+def crawl(indice: str, folder: str) -> None:
     os.system('mkdir -p "/tmp/data"')
     os.system('mkdir -p "/tmp/data/input"')
     os.system('mkdir -p "/tmp/data/input/br"')
@@ -80,7 +81,11 @@ def crawl(indice: str, folder:str) -> None:
         "mes/ip15_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela3065.csv&terr=N&rank=-&query=t/3065/n1/all/v/all/p/all/d/v355%202,v356%202,v1117%2013,v1118%202,v1119%202,v1120%202/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
         "mes/inpc_geral": "https://sidra.ibge.gov.br/geratabela?format=br.csv&name=tabela1736.csv&terr=N&rank=-&query=t/1736/n1/all/v/all/p/all/d/v44%202,v68%202,v2289%2013,v2290%202,v2291%202,v2292%202/l/,v,t%2Bp&abreviarRotulos=True&exibirNotas=False",
     }
-    links = {k: v for k, v in links.items() if k.__contains__(indice) & k.__contains__(folder)}
+    links = {
+        k: v
+        for k, v in links.items()
+        if k.__contains__(indice) & k.__contains__(folder)
+    }
     # precisei adicionar try catchs no loop para conseguir baixar todas
     # as tabelas sem ter pproblema com o limite de requisição do sidra
     links_keys = list(links.keys())
@@ -208,7 +213,7 @@ def clean_mes_brasil(indice: str) -> None:
     df = pd.concat([grupo, subgrupo, item, subitem, geral])
     filepath = "/tmp/data/output/{}/categoria_brasil.csv".format(indice)
     df.to_csv(filepath, index=False)
-    
+
     return filepath
 
 
@@ -323,7 +328,7 @@ def clean_mes_rm(indice: str):
     df = pd.concat([grupo, subgrupo, item, subitem_1, subitem_2, geral])
     filepath = "/tmp/data/output/{}/categoria_rm.csv".format(indice)
     df.to_csv(filepath, index=False)
-    
+
     return filepath
 
 
@@ -438,7 +443,7 @@ def clean_mes_municipio(indice: str):
     df = pd.concat([grupo, subgrupo, item, subitem_1, subitem_2, geral])
     filepath = "/tmp/data/output/{}/categoria_municipio.csv".format(indice)
     df.to_csv(filepath, index=False)
-    
+
     return filepath
 
 

--- a/pipelines/bases/br_ibge_ipca15/tasks.py
+++ b/pipelines/bases/br_ibge_ipca15/tasks.py
@@ -9,11 +9,9 @@ import glob
 import wget
 from tqdm import tqdm
 from time import sleep
-from pipelines.utils import upload_to_gcs_utils, create_bd_table_utils
-
 
 @task
-def crawl(indice: str, folder: str) -> None:
+def crawler(indice: str, folder: str) -> None:
     os.system('mkdir -p "/tmp/data"')
     os.system('mkdir -p "/tmp/data/input"')
     os.system('mkdir -p "/tmp/data/input/br"')

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Union
 import logging
 
 import basedosdados as bd
-from mysqlx import Row
+# from mysqlx import Row
 import pandas as pd
 
 import prefect
@@ -125,7 +125,7 @@ def create_bd_table(
 
     # pylint: disable=C0103
     st = bd.Storage(dataset_id=dataset_id, table_id=table_id)
-
+    
     # full dump
     if dump_type == "append":
         if tb.table_exists(mode="staging"):
@@ -160,8 +160,8 @@ def create_bd_table(
             path=path,
             if_storage_data_exists="replace",
             if_table_config_exists="replace",
-            if_table_exists="replace",
-            location="southamerica-east1",
+            if_table_exists="replace"
+            # location="southamerica-east1",
         )
 
         log(

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -1,27 +1,33 @@
 """
 General utilities for all pipelines.
 """
-
-from typing import Any, Dict
-
+from pathlib import Path
+from typing import Any, Dict, Union
 import logging
+
+import basedosdados as bd
+from mysqlx import Row
+import pandas as pd
+
 import prefect
+from prefect import task
 
 
-def log(msg: Any, level: str = 'info') -> None:
+def log(msg: Any, level: str = "info") -> None:
     """
     Logs a message to prefect's logger.
     """
     levels = {
-        'debug': logging.DEBUG,
-        'info': logging.INFO,
-        'warning': logging.WARNING,
-        'error': logging.ERROR,
-        'critical': logging.CRITICAL,
+        "debug": logging.DEBUG,
+        "info": logging.INFO,
+        "warning": logging.WARNING,
+        "error": logging.ERROR,
+        "critical": logging.CRITICAL,
     }
     if level not in levels:
         raise ValueError(f"Invalid log level: {level}")
     prefect.context.logger.log(levels[level], msg)  # pylint: disable=E1101
+
 
 @prefect.task(checkpoint=False)
 def log_task(msg: Any, level: str = "info"):
@@ -29,6 +35,7 @@ def log_task(msg: Any, level: str = "info"):
     Logs a message to prefect's logger.
     """
     log(msg, level)
+
 
 def run_local(flow: prefect.Flow, parameters: Dict[str, Any] = None):
     """
@@ -43,3 +50,124 @@ def run_local(flow: prefect.Flow, parameters: Dict[str, Any] = None):
     if parameters:
         return flow.run(parameters=parameters)
     return flow.run()
+
+
+###############
+#
+# Upload to GCS
+#
+###############
+@task
+def create_header(path: Union[str, Path]):
+    """
+    Writes a header to a CSV file.
+    """
+    # Remove filename from path
+    path = Path(path)
+    dataframe = pd.read_csv(path, nrows=10)
+
+    # Create directory if it doesn't exist
+    save_header_path = Path("data/header.csv")
+    save_header_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write dataframe to CSV
+    dataframe.to_csv(save_header_path, index=False, encoding="utf-8")
+    log(f"Wrote header CSV: {path}")
+
+    return save_header_path
+
+
+@task
+def upload_to_gcs(
+    path: Union[str, Path],
+    dataset_id: str,
+    table_id: str,
+    wait=None,  # pylint: disable=unused-argument
+) -> None:
+    """
+    Uploads a bunch of CSVs using BD+
+    """
+    # pylint: disable=C0103
+    tb = bd.Table(dataset_id=dataset_id, table_id=table_id)
+    # st = bd.Storage(dataset_id=dataset_id, table_id=table_id)
+
+    if tb.table_exists(mode="staging"):
+        # the name of the files need to be the same or the data doesn't get overwritten
+        tb.append(
+            filepath=path,
+            if_exists="replace",
+        )
+
+        log(
+            f"Successfully uploaded {path} to {tb.bucket_name}.staging.{dataset_id}.{table_id}"
+        )
+
+    else:
+        # pylint: disable=C0301
+        log(
+            "Table does not exist in STAGING, need to create it in local first.\nCreate and publish the table in BigQuery first."
+        )
+
+
+@task
+def create_bd_table(
+    path: Union[str, Path],
+    dataset_id: str,
+    table_id: str,
+    dump_type: str,
+    wait=None,  # pylint: disable=unused-argument
+) -> None:
+    """
+    Create table using BD+
+    """
+    # pylint: disable=C0103
+    tb = bd.Table(dataset_id=dataset_id, table_id=table_id)
+
+    # pylint: disable=C0103
+    st = bd.Storage(dataset_id=dataset_id, table_id=table_id)
+
+    # full dump
+    if dump_type == "append":
+        if tb.table_exists(mode="staging"):
+            log(
+                f"Mode append: Table {st.bucket_name}.{dataset_id}.{table_id} already exists"
+            )
+        else:
+            tb.create(
+                path=path,
+                location="southamerica-east1",
+            )
+            log(
+                f"Mode append: Sucessfully created a new table {st.bucket_name}.{dataset_id}.{table_id}"
+            )  # pylint: disable=C0301
+
+            st.delete_table(
+                mode="staging", bucket_name=st.bucket_name, not_found_ok=True
+            )
+            log(
+                f"Mode append: Sucessfully remove header data from {st.bucket_name}.{dataset_id}.{table_id}"
+            )  # pylint: disable=C0301
+    elif dump_type == "overwrite":
+        if tb.table_exists(mode="staging"):
+            log(
+                f"Mode overwrite: Table {st.bucket_name}.{dataset_id}.{table_id} already exists, DELETING OLD DATA!"
+            )  # pylint: disable=C0301
+            st.delete_table(
+                mode="staging", bucket_name=st.bucket_name, not_found_ok=True
+            )
+        ## prod datasets is public if the project is datario. staging are private im both projects
+        tb.create(
+            path=path,
+            if_storage_data_exists="replace",
+            if_table_config_exists="replace",
+            if_table_exists="replace",
+            location="southamerica-east1",
+        )
+
+        log(
+            f"Mode overwrite: Sucessfully created table {st.bucket_name}.{dataset_id}.{table_id}"
+        )
+        st.delete_table(mode="staging", bucket_name=st.bucket_name, not_found_ok=True)
+        log(
+            f"Mode overwrite: Sucessfully remove header data from {st.bucket_name}.{dataset_id}.{table_id}"
+        )  # pylint: disable=C0301


### PR DESCRIPTION
**IMPORTANTE:** Esse PR já utiliza a versão atualizada do utils criada no #18 

Criei três datasets para os dados de índices de preços (IPCA, IPCA15, INPC). Testei as pipelines localmente, usando:

```python
from pipelines.utils import run_local
from functools import reduce
from pipelines.bases.br_ibge_ipca15 import (
    br_ibge_ipca15_br,
    br_ibge_ipca15_rm,
    br_ibge_ipca15_municipio,
    br_ibge_ipca15_geral,
)

from pipelines.bases.br_ibge_ipca import (
    br_ibge_ipca_br,
    br_ibge_ipca_rm,
    br_ibge_ipca_municipio,
    br_ibge_ipca_geral,
)

from pipelines.bases.br_ibge_inpc import (
    br_ibge_inpc_br,
    br_ibge_inpc_rm,
    br_ibge_inpc_municipio,
    br_ibge_inpc_geral,
)

flows_ipca = [br_ibge_ipca_br, br_ibge_ipca_rm, br_ibge_ipca_municipio, br_ibge_ipca_geral]
flows_ipca15 = [br_ibge_ipca15_br, br_ibge_ipca15_rm, br_ibge_ipca15_municipio, br_ibge_ipca15_geral]
flows_inpc = [br_ibge_inpc_br, br_ibge_inpc_rm, br_ibge_inpc_municipio, br_ibge_inpc_geral]

flows = reduce(lambda x,y: x+y, [flows_ipca,flows_inpc,flows_ipca15])

for flow in flows:
    run_local(flow)

```

Um problema, ao meu ver, é que as tasks para os 3 índices são idênticas. Idealmente, a gente deveria evitar replicação de código, mas não vi como fazer isso, dado que cada dataset deve ter dentro de sua pasta na pipeline os três arquivos do prefect (flows, schedules e tasks).