### PR TITLE
[inflatio_data] fix file life-cycle inside temp folder

### DIFF
--- a/pipelines/utils/crawler_ibge_inflacao/tasks.py
+++ b/pipelines/utils/crawler_ibge_inflacao/tasks.py
@@ -20,6 +20,8 @@ def crawler(indice: str, folder: str) -> None:
     Crawler for IBGE Inflacao
     """
     log(f"Crawling {indice}")
+    os.system("[ -e /tmp/data/input/ ] && rm -r /tmp/data/input/")
+    os.system("[ -e /tmp/data/output/ ] && rm -r /tmp/data/output/")
     os.system('mkdir -p "/tmp/data"')
     os.system('mkdir -p "/tmp/data/input"')
     os.system('mkdir -p "/tmp/data/input/br"')


### PR DESCRIPTION
O erro estava ocorrendo porque o nome dos arquivos na pasta temporária estava sendo alterado quando o prefect tentava rodar uma task novamente. Como consequência esse filtro não funcionava:

```python
arquivos = [
        arquivo
        for arquivo in glob.iglob("/tmp/data/input/mes/*")
        if arquivo.split("/")[-1].split("_")[0] == indice
    ]
```

Incluí um código para apagar (se existir) a pasta temporária toda vez que o crawler começar novamente:

```python
os.system("[ -e /tmp/data/input/ ] && rm -r /tmp/data/input/")
os.system("[ -e /tmp/data/output/ ] && rm -r /tmp/data/output/")
```