### PR TITLE
use default arguments in tb.create for location and dataset_is_public

### DIFF
--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -91,9 +91,7 @@ def create_table_and_upload_to_gcs(
                 path=header_path,
                 if_storage_data_exists="replace",
                 if_table_config_exists="replace",
-                if_table_exists="replace",
-                location="southamerica-east1",
-                dataset_is_public=dataset_is_public,
+                if_table_exists="replace"
             )
 
             log(
@@ -142,9 +140,7 @@ def create_table_and_upload_to_gcs(
             path=header_path,
             if_storage_data_exists="replace",
             if_table_config_exists="replace",
-            if_table_exists="replace",
-            location="southamerica-east1",
-            dataset_is_public=dataset_is_public,
+            if_table_exists="replace"
         )
 
         log(


### PR DESCRIPTION
Os valores atuais de `location` e `dataset_is_public` em `tb.create` valem apenas para as pipelines da prefeitura. Em particular, usar uma localização do dataset do BQ diferente dos EUA para os datasets da BD gera um erro, uma vez que os buckets da BD estão nos EUA.

```python
tb.create(
    path=header_path,
    if_storage_data_exists="replace",
    if_table_config_exists="replace",
    if_table_exists="replace",
    location="southamerica-east1",
    dataset_is_public=dataset_is_public,
)
```