### PR TITLE
Fix/add credentials cvm

### DIFF
--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -182,6 +182,7 @@ def create_table_and_upload_to_gcs(
     max_retries=constants.TASK_MAX_RETRIES.value,
     retry_delay=timedelta(seconds=constants.TASK_RETRY_DELAY.value),
 )
+# pylint: disable=R0914
 def update_metadata(dataset_id: str, table_id: str, fields_to_update: list) -> None:
     """
     Update metadata for a selected table
@@ -200,9 +201,8 @@ def update_metadata(dataset_id: str, table_id: str, fields_to_update: list) -> N
     data['ckan']['api_key']=api_key
     data['ckan']['url']=url
 
-    f = open(toml_file,'w')
-    toml.dump(data, f)
-    f.close()
+    with open(toml_file, 'w', encoding="utf-8") as f:
+        toml.dump(data, f)
 
     handle = bd.Metadata(dataset_id=dataset_id, table_id=table_id)
     handle.create(if_exists="replace")

--- a/pipelines/utils/utils.py
+++ b/pipelines/utils/utils.py
@@ -71,7 +71,7 @@ def get_vault_secret(secret_path: str, client: hvac.Client = None) -> dict:
     return vault_client.secrets.kv.read_secret_version(secret_path)["data"]
 
 
-def get_username_and_password_from_secret(
+def get_credentials_from_secret(
     secret_path: str,
     client: hvac.Client = None,
 ) -> Tuple[str, str]:
@@ -79,9 +79,10 @@ def get_username_and_password_from_secret(
     Returns a username and password from a secret in Vault.
     """
     secret = get_vault_secret(secret_path, client)
+    keys = list(secret["data"].keys())
     return (
-        secret["data"]["username"],
-        secret["data"]["password"],
+        secret["data"][keys[0]],
+        secret["data"][keys[1]],
     )
 
 


### PR DESCRIPTION
Mudanças:

1) Eu tornei a função `get_username_password_from_secret` mais geral. A versão anterior especifricava as chaves `username` e `password`, mas as credenciais podem ter outras chaves. No caso dos metadados, as chaves são `url` e `api_key`, por exemplo
2) Editei a task de update_metadata para adicionar as credenciais necessárias no `config.toml`