### PR TITLE
[infra] [fix] Pipeline cgu pessoal executivo

### DIFF
--- a/pipelines/datasets/br_cgu_pessoal_executivo_federal/schedules.py
+++ b/pipelines/datasets/br_cgu_pessoal_executivo_federal/schedules.py
@@ -1,18 +1,17 @@
 """
 Schedules for br_cgu_terceirizados
 """
-
 from datetime import datetime
-from dateutil.rrule import rrule, MONTHLY
+
 from prefect.schedules import Schedule
-from prefect.schedules.clocks import RRuleClock
+from prefect.schedules.clocks import CronClock
 from pipelines.constants import constants
 
 
 every_four_months = Schedule(
     clocks=[
-        RRuleClock(
-            rrule(freq=MONTHLY, count=4),
+        CronClock(
+            cron="0 0 28 2/4 *",
             start_date=datetime(2021, 1, 1),
             labels=[
                 constants.BASEDOSDADOS_PROD_AGENT_LABEL.value


### PR DESCRIPTION
RRule Schedule não estava sendo reconhecido pelo Prefect, deixando os agendamentos de Runs errados. Troquei por CronClock baseado em testes na UI do Prefect:
![image](https://user-images.githubusercontent.com/67998510/166090159-4ce981fa-d581-4d63-bafd-434ac3eed972.png)
![image](https://user-images.githubusercontent.com/67998510/166090173-ada5f2d7-9b55-416b-8a24-cb0655306b5d.png)



PS: Dia 28 do próximo mês do dado, para ter mais chances do dataset ter sido atualizado na fonte.