### PR TITLE
fixing cross_update

### DIFF
--- a/pipelines/datasets/cross_update/schedules.py
+++ b/pipelines/datasets/cross_update/schedules.py
@@ -4,8 +4,10 @@ Schedules for br_tse_eleicoes
 """
 
 from datetime import timedelta, datetime
+
 from prefect.schedules import Schedule
 from prefect.schedules.clocks import IntervalClock
+
 from pipelines.constants import constants
 
 schedule_nrows = Schedule(
@@ -14,12 +16,13 @@ schedule_nrows = Schedule(
             interval=timedelta(days=7),
             start_date=datetime(2021, 1, 1, 9, 45),
             labels=[
-                constants.BASEDOSDADOS_PROD_AGENT_LABEL.value,
+                str(constants.BASEDOSDADOS_PROD_AGENT_LABEL.value),
             ],
             parameter_defaults={
                 "dump_to_gcs": True,
                 "days": 7,
                 "mode": "prod",
+                "page_size": 100,
             },
         ),
     ],

--- a/pipelines/datasets/cross_update/tasks.py
+++ b/pipelines/datasets/cross_update/tasks.py
@@ -96,7 +96,7 @@ def crawler_tables(
         > seven_days_ago
     ]
 
-    log(f"Found {len(to_update)} tables updated in last 7 days")
+    log(f"Found {len(to_update)} tables updated in last {days} days")
 
     to_zip = []
     for bdm_table in to_update:


### PR DESCRIPTION
When the flow runs, it returns up to 100 pages (`page_size`), while looping over a range of all datasets (returned in `json_response['result']['count']`. Thus, it led to an error when there were more than 100 datasets in the complete result (from basedosdados api)