### PR TITLE
[fix] register flows in staging

### DIFF
--- a/.github/workflows/cd_staging.yaml
+++ b/.github/workflows/cd_staging.yaml
@@ -80,4 +80,4 @@ jobs:
 
       - name: Register Prefect flows
         run: |-
-          python .github/workflows/scripts/register_flows.py --project $PREFECT__SERVER__PROJECT --path pipelines/ --no-schedule --filter-affected-flows
+          python .github/workflows/scripts/register_flows.py --project $PREFECT__SERVER__PROJECT --path pipelines/ --no-schedule


### PR DESCRIPTION
O fluxo de registrar flows está pulando alguns flows. O lucas tinha indicado que ao remover esse parametro da action ela funcionava sem problemas. Se for só remover esse parametro mesmo, queria ver se não podemos já removê-lo. 