### PR TITLE
[fix] br_rf_cafir

### DIFF
--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -42,7 +42,7 @@ with Flow(
         "materialization_mode", default="dev", required=False
     )
     materialize_after_dump = Parameter(
-        "materialize after dump", default=True, required=False
+        "materialize_after_dump", default=True, required=False
     )
     dbt_alias = Parameter("dbt_alias", default=False, required=False)
 

--- a/pipelines/datasets/br_rf_cafir/utils.py
+++ b/pipelines/datasets/br_rf_cafir/utils.py
@@ -36,7 +36,7 @@ def extract_last_date(
     """
 
     query_bd = f"""
-    SELECT MAX(data) as max_date
+    SELECT MAX(data_referencia) as max_date
     FROM
     `{billing_project_id}.{dataset_id}.{table_id}`
     """


### PR DESCRIPTION
Corrige:
- nome da variável data_referencia na função extract_last_date
- Insere underlines '_' no parâmetro materialize_after_dump