### PR TITLE
[fix] br_rf_cafir

### DIFF
--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -57,7 +57,9 @@ with Flow(
     is_outdated = check_if_bq_data_is_outdated(
         dataset_id=dataset_id, table_id=table_id, data=info[0], upstream_tasks=[info]
     )
-    update_metadata_strig_date = convert_datetime_to_string(data=info[0])
+    update_metadata_strig_date = convert_datetime_to_string(
+        data=info[0], upstream_tasks=[info, is_outdated]
+    )
 
     with case(update_metadata, True):
         update = update_django_metadata(
@@ -72,7 +74,7 @@ with Flow(
             is_free=True,
             time_delta=6,
             time_unit="months",
-            upstream_tasks=[is_outdated, info],
+            upstream_tasks=[update_metadata_strig_date],
         )
 
     with case(is_outdated, False):

--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -120,7 +120,7 @@ with Flow(
                     dataset_id,
                     table_id,
                     metadata_type="DateTimeRange",
-                    _last_date=info[0],
+                    _last_date=update_metadata_strig_date,
                     bq_last_update=False,
                     api_mode="prod",
                     date_format="yy-mm-dd",

--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -57,6 +57,22 @@ with Flow(
         dataset_id=dataset_id, table_id=table_id, data=info[0], upstream_tasks=[info]
     )
 
+    with case(update_metadata, True):
+        update = update_django_metadata(
+            dataset_id,
+            table_id,
+            metadata_type="DateTimeRange",
+            _last_date=info[0],
+            bq_last_update=False,
+            api_mode="prod",
+            date_format="yy-mm-dd",
+            is_bd_pro=True,
+            is_free=True,
+            time_delta=6,
+            time_unit="months",
+            upstream_tasks=[info],
+        )
+
     with case(is_outdated, False):
         log_task(f"Não há atualizações para a tabela de {table_id}!")
 

--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -70,7 +70,7 @@ with Flow(
             is_free=True,
             time_delta=6,
             time_unit="months",
-            upstream_tasks=[info],
+            upstream_tasks=[is_outdated, info],
         )
 
     with case(is_outdated, False):

--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -16,6 +16,7 @@ from pipelines.datasets.br_rf_cafir.tasks import (
     parse_files_parse_date,
     parse_data,
     check_if_bq_data_is_outdated,
+    convert_datetime_to_string,
 )
 
 from pipelines.utils.constants import constants as utils_constants
@@ -56,13 +57,14 @@ with Flow(
     is_outdated = check_if_bq_data_is_outdated(
         dataset_id=dataset_id, table_id=table_id, data=info[0], upstream_tasks=[info]
     )
+    update_metadata_strig_date = convert_datetime_to_string(data=info[0])
 
     with case(update_metadata, True):
         update = update_django_metadata(
             dataset_id,
             table_id,
             metadata_type="DateTimeRange",
-            _last_date=info[0],
+            _last_date=update_metadata_strig_date,
             bq_last_update=False,
             api_mode="prod",
             date_format="yy-mm-dd",

--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -61,22 +61,6 @@ with Flow(
         data=info[0], upstream_tasks=[info, is_outdated]
     )
 
-    with case(update_metadata, True):
-        update = update_django_metadata(
-            dataset_id,
-            table_id,
-            metadata_type="DateTimeRange",
-            _last_date=update_metadata_strig_date,
-            bq_last_update=False,
-            api_mode="prod",
-            date_format="yy-mm-dd",
-            is_bd_pro=True,
-            is_free=True,
-            time_delta=6,
-            time_unit="months",
-            upstream_tasks=[update_metadata_strig_date],
-        )
-
     with case(is_outdated, False):
         log_task(f"Não há atualizações para a tabela de {table_id}!")
 
@@ -126,6 +110,10 @@ with Flow(
             wait_for_materialization.retry_delay = timedelta(
                 seconds=dump_db_constants.WAIT_FOR_MATERIALIZATION_RETRY_INTERVAL.value
             )
+            # TODO: Quando a nova fotografia for liberada setar is_free como True
+            # is_free como true. Não setei agora pq a task update_django_metadata depende
+            # de um coverage já criado na API. Como a lag entre fotográfias é de 5 meses (6 é o padrão no monento)
+            # não há necessidade de atualizar o coverage agora.
 
             with case(update_metadata, True):
                 update = update_django_metadata(

--- a/pipelines/datasets/br_rf_cafir/tasks.py
+++ b/pipelines/datasets/br_rf_cafir/tasks.py
@@ -155,8 +155,7 @@ def parse_data(url: str, other_task_output: tuple[list[datetime], list[str]]) ->
         # save new file as csv
         df.to_csv(save_path, index=False, sep=",", na_rep="", encoding="utf-8")
 
-        # resolve ASCII 0 no momento da leitura do BQ
-        # ler e salvar de novo
+        # resolve ASCII 0 no momento da leitura do BQ. Ler e salvar de novo.
         df = pd.read_csv(save_path, dtype=str)
         df.to_csv(save_path, index=False, sep=",", na_rep="", encoding="utf-8")
 

--- a/pipelines/datasets/br_rf_cafir/tasks.py
+++ b/pipelines/datasets/br_rf_cafir/tasks.py
@@ -178,3 +178,16 @@ def parse_data(url: str, other_task_output: tuple[list[datetime], list[str]]) ->
     )
 
     return files_path
+
+
+@task
+def convert_datetime_to_string(data: datetime):
+    """Converte a data para string
+
+    Args:
+        date (datetime): Data
+
+    Returns:
+        string: Data no formato string
+    """
+    return str(data)


### PR DESCRIPTION
- Conserta task update_django_metadata
- Tira coverage grátis: a distância entre as fotografias é de 5 meses. Como 6 é o padrão os dados estão restritos pra bdpro.

closes #470 