### PR TITLE
[fix]: `br_ans_beneficiario` update

### DIFF
--- a/pipelines/datasets/br_ans_beneficiario/flows.py
+++ b/pipelines/datasets/br_ans_beneficiario/flows.py
@@ -17,6 +17,7 @@ from pipelines.datasets.br_ans_beneficiario.tasks import (
     crawler_ans,
     extract_links_and_dates,
     is_empty,
+    force_update,
     return_last_date,
 )
 from pipelines.utils.constants import constants as utils_constants
@@ -54,23 +55,30 @@ with Flow(
     )
     dbt_alias = Parameter("dbt_alias", default=False, required=False)
 
+    update = Parameter("update", default=True, required=False)
+
     rename_flow_run = rename_current_flow_run_dataset_table(
         prefix="Dump: ", dataset_id=dataset_id, table_id=table_id, wait=table_id
     )
 
-    hrefs = extract_links_and_dates(url=url)
-    last_date = return_last_date(hrefs, upstream_tasks=[hrefs])
-    update = check_if_data_is_outdated(dataset_id,
-        table_id,
-        data_source_max_date=last_date,
-        date_format= "%Y-%m-%d", upstream_tasks=[hrefs, last_date])
 
+    hrefs = extract_links_and_dates(url=url)
+    # last_date = return_last_date(hrefs, upstream_tasks=[hrefs])
+    # update = check_if_data_is_outdated(dataset_id,
+    #     table_id,
+    #     data_source_max_date=last_date,
+    #     date_format= "%Y-%m-%d", upstream_tasks=[hrefs, last_date])
 
     with case(update, False):
-        log_task(f"Não houveram atualizações em {url.default}!")
+        files = check_for_updates(hrefs, upstream_tasks=[hrefs])
 
     with case(update, True):
-        files = check_for_updates(hrefs)
+        files = force_update(hrefs, upstream_tasks=[hrefs])
+
+    with case(is_empty(files), True):
+        log_task(f"Não houveram atualizações em {url.default}!")
+
+    with case(is_empty(files), False):
         output_filepath = crawler_ans(files, upstream_tasks=[files])
         wait_upload_table = create_table_and_upload_to_gcs(
             data_path=output_filepath,

--- a/pipelines/datasets/br_ans_beneficiario/tasks.py
+++ b/pipelines/datasets/br_ans_beneficiario/tasks.py
@@ -64,6 +64,7 @@ def extract_links_and_dates(url) -> pd.DataFrame:
 
     df["desatualizado"] = df["data_hoje"] == df["ultima_atualizacao"]
     # df['desatualizado'] = df['arquivo'].apply(lambda x: True if x in ['inf_diario_fi_202201.zip','inf_diario_fi_202305.zip'] else False)
+
     return df
 
 @task
@@ -76,9 +77,15 @@ def check_for_updates(df):
     """
     Checks for outdated tables.
     """
+    log(f"Data de hoje --> {max(df['data_hoje'])}")
+    log(f"Data de atualização --> {max(df['ultima_atualizacao'])}")
+    return df.query("desatualizado == True").arquivo.to_list()
+
+
+@task
+def force_update(df):
     log(df[df['ultima_atualizacao'] == max(df['ultima_atualizacao'])].arquivo.to_list())
     return df[df['ultima_atualizacao'] == max(df['ultima_atualizacao'])].arquivo.to_list()
-
 
 @task
 def crawler_ans(files):


### PR DESCRIPTION
closes #702 

- Retorna com o formato antigo de `check_for_updates`, comparando a data atual com a data de atualização no FTP.
- Adiciona um parâmetro para a atualização "forçada" dos dados, caso ocorra algum erro durante a execução do flow.