### PR TITLE
[fix]: `br_transfermarkt_competicoes.brasileirao_serie_a`

### DIFF
--- a/pipelines/datasets/br_cgu_beneficios_cidadao/tasks.py
+++ b/pipelines/datasets/br_cgu_beneficios_cidadao/tasks.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 import pandas as pd
 from prefect import task
-
+from pipelines.constants import constants as constants_root
 from pipelines.datasets.br_cgu_beneficios_cidadao.constants import constants
 from pipelines.datasets.br_cgu_beneficios_cidadao.utils import (
     download_unzip_csv,
@@ -23,7 +23,10 @@ from datetime import datetime, date
 def print_last_file(file):
     log(f"Arquivo baixado --> {file}")
 
-@task
+@task(
+    max_retries=constants_root.TASK_MAX_RETRIES.value,
+    retry_delay=timedelta(seconds=constants_root.TASK_RETRY_DELAY.value),
+)
 def scrape_download_page(table_id):
     dates = extract_dates(table=table_id)
 
@@ -37,8 +40,8 @@ def get_updated_files(files_df, table_last_date):
 
 
 @task(
-    max_retries=constants.TASK_MAX_RETRIES.value,
-    retry_delay=timedelta(seconds=constants.TASK_RETRY_DELAY.value),
+    max_retries=constants_root.TASK_MAX_RETRIES.value,
+    retry_delay=timedelta(seconds=constants_root.TASK_RETRY_DELAY.value),
 )
 def get_source_max_date(files_df) -> list:
     """
@@ -63,8 +66,8 @@ def get_source_max_date(files_df) -> list:
 
 
 @task(
-    max_retries=constants.TASK_MAX_RETRIES.value,
-    retry_delay=timedelta(seconds=constants.TASK_RETRY_DELAY.value),
+    max_retries=constants_root.TASK_MAX_RETRIES.value,
+    retry_delay=timedelta(seconds=constants_root.TASK_RETRY_DELAY.value),
 )  # noqa
 def crawler_beneficios_cidadao(table_id: str,
                                url: str,

--- a/pipelines/datasets/br_cgu_beneficios_cidadao/utils.py
+++ b/pipelines/datasets/br_cgu_beneficios_cidadao/utils.py
@@ -148,13 +148,13 @@ def extract_dates(table: str) -> pd.DataFrame:
 
     if table == "novo_bolsa_familia":
         driver.get(constants.ROOT_URL.value)
-        driver.implicitly_wait(10)
+        driver.implicitly_wait(15)
     elif table == "garantia_safra":
         driver.get(constants.ROOT_URL_GARANTIA_SAFRA.value)
-        driver.implicitly_wait(10)
+        driver.implicitly_wait(15)
     else:
         driver.get(constants.ROOT_URL_BPC.value)
-        driver.implicitly_wait(10)
+        driver.implicitly_wait(15)
 
     page_source = driver.page_source
     BeautifulSoup(page_source, "html.parser")
@@ -169,7 +169,7 @@ def extract_dates(table: str) -> pd.DataFrame:
 
         select_anos.select_by_value(valor_ano)
 
-        driver.implicitly_wait(5)
+        driver.implicitly_wait(10)
 
         select_meses = Select(driver.find_element(By.ID, "links-meses"))
 

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
@@ -27,7 +27,7 @@ from pipelines.datasets.mundo_transfermarkt_competicoes.tasks import (
 from pipelines.utils.constants import constants as utils_constants
 from pipelines.utils.decorators import Flow
 from pipelines.utils.execute_dbt_model.constants import constants as dump_db_constants
-from pipelines.utils.metadata.tasks import update_django_metadata
+from pipelines.utils.metadata.tasks import update_django_metadata, check_if_data_is_outdated
 from pipelines.utils.tasks import (
     create_table_and_upload_to_gcs,
     get_current_flow_labels,
@@ -52,64 +52,73 @@ with Flow(
     )
     dbt_alias = Parameter("dbt_alias", default=True, required=False)
 
-    # rename_flow_run = rename_current_flow_run_dataset_table(
-    #     prefix="Dump: ", dataset_id=dataset_id, table_id=table_id, wait=table_id
-    # )
-    #data = get_data_source_transfermarkt_max_date()
-    df = execucao_coleta_sync(table_id,
-        #upstream_tasks=[data]
+    rename_flow_run = rename_current_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=dataset_id, table_id=table_id, wait=table_id
     )
-    output_filepath = make_partitions(df, upstream_tasks=[df])
-
-    wait_upload_table = create_table_and_upload_to_gcs(
-        data_path=output_filepath,
+    data_source_max_date = get_data_source_transfermarkt_max_date()
+    dados_desatualizados = check_if_data_is_outdated(
         dataset_id=dataset_id,
         table_id=table_id,
-        dump_mode="append",
-        wait=output_filepath,
+        data_source_max_date=data_source_max_date,
+        date_format="%Y-%m-%d",
+        upstream_tasks=[data_source_max_date],
     )
 
-    with case(materialize_after_dump, True):
-        # Trigger DBT flow run
-        current_flow_labels = get_current_flow_labels()
-        materialization_flow = create_flow_run(
-            flow_name=utils_constants.FLOW_EXECUTE_DBT_MODEL_NAME.value,
-            project_name=constants.PREFECT_DEFAULT_PROJECT.value,
-            parameters={
-                "dataset_id": dataset_id,
-                "table_id": table_id,
-                "mode": materialization_mode,
-                "dbt_alias": dbt_alias,
-                "dbt_command": "run/test",
-            },
-            labels=current_flow_labels,
-            run_name=r"Materialize {dataset_id}.{table_id}",
-        )
+    df = execucao_coleta_sync(table_id,
+        upstream_tasks=[dados_desatualizados]
+    )
+    with case(dados_desatualizados, True):
+        output_filepath = make_partitions(df, upstream_tasks=[df])
 
-        wait_for_materialization = wait_for_flow_run(
-            materialization_flow,
-            stream_states=True,
-            stream_logs=True,
-            raise_final_state=True,
-        )
-        wait_for_materialization.max_retries = (
-            dump_db_constants.WAIT_FOR_MATERIALIZATION_RETRY_ATTEMPTS.value
-        )
-        wait_for_materialization.retry_delay = timedelta(
-            seconds=dump_db_constants.WAIT_FOR_MATERIALIZATION_RETRY_INTERVAL.value
-        )
-
-        update_django_metadata(
+        wait_upload_table = create_table_and_upload_to_gcs(
+            data_path=output_filepath,
             dataset_id=dataset_id,
             table_id=table_id,
-            date_column_name={"date": "data"},
-            date_format="%Y-%m-%d",
-            coverage_type="part_bdpro",
-            time_delta={"weeks": 6},
-            prefect_mode=materialization_mode,
-            bq_project="basedosdados",
-            upstream_tasks=[wait_for_materialization],
+            dump_mode="append",
+            wait=output_filepath,
         )
+
+        with case(materialize_after_dump, True):
+            # Trigger DBT flow run
+            current_flow_labels = get_current_flow_labels()
+            materialization_flow = create_flow_run(
+                flow_name=utils_constants.FLOW_EXECUTE_DBT_MODEL_NAME.value,
+                project_name=constants.PREFECT_DEFAULT_PROJECT.value,
+                parameters={
+                    "dataset_id": dataset_id,
+                    "table_id": table_id,
+                    "mode": materialization_mode,
+                    "dbt_alias": dbt_alias,
+                    "dbt_command": "run/test",
+                },
+                labels=current_flow_labels,
+                run_name=r"Materialize {dataset_id}.{table_id}",
+            )
+
+            wait_for_materialization = wait_for_flow_run(
+                materialization_flow,
+                stream_states=True,
+                stream_logs=True,
+                raise_final_state=True,
+            )
+            wait_for_materialization.max_retries = (
+                dump_db_constants.WAIT_FOR_MATERIALIZATION_RETRY_ATTEMPTS.value
+            )
+            wait_for_materialization.retry_delay = timedelta(
+                seconds=dump_db_constants.WAIT_FOR_MATERIALIZATION_RETRY_INTERVAL.value
+            )
+
+            update_django_metadata(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                date_column_name={"date": "data"},
+                date_format="%Y-%m-%d",
+                coverage_type="part_bdpro",
+                time_delta={"weeks": 6},
+                prefect_mode=materialization_mode,
+                bq_project="basedosdados",
+                upstream_tasks=[wait_for_materialization],
+            )
 
 transfermarkt_brasileirao_flow.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 transfermarkt_brasileirao_flow.run_config = KubernetesRun(

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
@@ -22,6 +22,7 @@ from pipelines.datasets.mundo_transfermarkt_competicoes.schedules import (
 from pipelines.datasets.mundo_transfermarkt_competicoes.tasks import (
     execucao_coleta_sync,
     make_partitions,
+    get_data_source_transfermarkt_max_date,
 )
 from pipelines.utils.constants import constants as utils_constants
 from pipelines.utils.decorators import Flow
@@ -54,7 +55,8 @@ with Flow(
     # rename_flow_run = rename_current_flow_run_dataset_table(
     #     prefix="Dump: ", dataset_id=dataset_id, table_id=table_id, wait=table_id
     # )
-    df = execucao_coleta_sync(table_id)
+    data = get_data_source_transfermarkt_max_date()
+    df = execucao_coleta_sync(table_id, upstream_tasks=[data])
     output_filepath = make_partitions(df, upstream_tasks=[df])
 
     wait_upload_table = create_table_and_upload_to_gcs(

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
@@ -48,7 +48,7 @@ with Flow(
         "materialization_mode", default="dev", required=False
     )
     materialize_after_dump = Parameter(
-        "materialize_after_dump", default=False, required=False
+        "materialize_after_dump", default=True, required=False
     )
     dbt_alias = Parameter("dbt_alias", default=True, required=False)
 

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
@@ -55,8 +55,10 @@ with Flow(
     # rename_flow_run = rename_current_flow_run_dataset_table(
     #     prefix="Dump: ", dataset_id=dataset_id, table_id=table_id, wait=table_id
     # )
-    data = get_data_source_transfermarkt_max_date()
-    df = execucao_coleta_sync(table_id, upstream_tasks=[data])
+    #data = get_data_source_transfermarkt_max_date()
+    df = execucao_coleta_sync(table_id,
+        #upstream_tasks=[data]
+    )
     output_filepath = make_partitions(df, upstream_tasks=[df])
 
     wait_upload_table = create_table_and_upload_to_gcs(

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
@@ -64,10 +64,10 @@ with Flow(
         upstream_tasks=[data_source_max_date],
     )
 
-    df = execucao_coleta_sync(table_id,
-        upstream_tasks=[dados_desatualizados]
-    )
     with case(dados_desatualizados, True):
+        df = execucao_coleta_sync(table_id,
+            upstream_tasks=[dados_desatualizados]
+        )
         output_filepath = make_partitions(df, upstream_tasks=[df])
 
         wait_upload_table = create_table_and_upload_to_gcs(

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
@@ -40,20 +40,20 @@ with Flow(
     ],
 ) as transfermarkt_brasileirao_flow:
     dataset_id = Parameter(
-        "dataset_id", default="mundo_transfermarkt_competicoes", required=True
+        "dataset_id", default="mundo_transfermarkt_competicoes", required=False
     )
-    table_id = Parameter("table_id", default="brasileirao_serie_a", required=True)
+    table_id = Parameter("table_id", default="brasileirao_serie_a", required=False)
     materialization_mode = Parameter(
         "materialization_mode", default="dev", required=False
     )
     materialize_after_dump = Parameter(
-        "materialize_after_dump", default=True, required=False
+        "materialize_after_dump", default=False, required=False
     )
     dbt_alias = Parameter("dbt_alias", default=True, required=False)
 
-    rename_flow_run = rename_current_flow_run_dataset_table(
-        prefix="Dump: ", dataset_id=dataset_id, table_id=table_id, wait=table_id
-    )
+    # rename_flow_run = rename_current_flow_run_dataset_table(
+    #     prefix="Dump: ", dataset_id=dataset_id, table_id=table_id, wait=table_id
+    # )
     df = execucao_coleta_sync(table_id)
     output_filepath = make_partitions(df, upstream_tasks=[df])
 

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
@@ -48,7 +48,7 @@ with Flow(
         "materialization_mode", default="dev", required=False
     )
     materialize_after_dump = Parameter(
-        "materialize_after_dump", default=True, required=False
+        "materialize_after_dump", default=False, required=False
     )
     dbt_alias = Parameter("dbt_alias", default=True, required=False)
 

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/tasks.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/tasks.py
@@ -35,6 +35,7 @@ def execucao_coleta_sync(tabela: str) -> pd.DataFrame:
     """
     Executa a coleta de dados de uma tabela especificada de forma síncrona.
 
+
     Args:
         tabela (str): O nome da tabela de dados a ser coletada. Deve ser 'brasileirao_serie_a' ou outro valor.
 

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/tasks.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/tasks.py
@@ -8,14 +8,26 @@ import asyncio
 import pandas as pd
 from pandas import DataFrame
 from prefect import task
-
+from datetime import timedelta
+from pipelines.constants import constants
 from pipelines.datasets.mundo_transfermarkt_competicoes.utils import (
     execucao_coleta,
     execucao_coleta_copa,
+    data_url,
 )
 from pipelines.utils.utils import log, to_partitions
 
 ###############################################################################
+
+@task(
+    max_retries=constants.TASK_MAX_RETRIES.value,
+    retry_delay=timedelta(seconds=constants.TASK_RETRY_DELAY.value),
+)
+def get_data_source_transfermarkt_max_date():
+    # Obtém a data mais recente do site
+    data_obj = data_url().strftime("%Y-%m-%d")
+
+    return data_obj
 
 
 @task

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py
@@ -259,6 +259,7 @@ def pegar_valor(df, content):
     Returns:
         pandas.DataFrame: O DataFrame atualizado com os dados gerais da partida processados.
     """
+
     valor_content = {
         "valor_equipe_titular_man": content.find_all("div", class_="table-footer")[0]
         .find_all("td")[3]
@@ -276,8 +277,8 @@ def pegar_valor(df, content):
         .find_all("td")[1]
         .get_text()
         .split(":", 1)[1],
-        "tecnico_man": content.find_all("a", attrs={"id": "0"})[1].get_text(),
-        "tecnico_vis": content.find_all("a", attrs={"id": "0"})[3].get_text(),
+        "tecnico_man": content.find_all("a", attrs={"id": "0"})[0].get_text(),
+        "tecnico_vis": content.find_all("a", attrs={"id": "0"})[1].get_text(),
     }
     df = pd.concat([df, pd.DataFrame([valor_content])], ignore_index=True)
     return df

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py
@@ -1170,5 +1170,4 @@ def obter_data(link):
         re.compile(r"\d+/\d+/\d+"),
         content.find("a", text=re.compile(r"\d+/\d+/\d")).get_text().strip(),
     ).group(0)
-    print(data)
     return datetime.strptime(data, '%d/%m/%y')

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py
@@ -347,6 +347,11 @@ def rename_columns(df):
     df = df.rename(columns=mundo_constants.COLUMNS_MAPPING.value)
     return df
 
+def extract_avg_age_and_value(column):
+    parts = column.split(":")
+    age_str = parts[-1].strip()
+    return age_str
+
 
 def clean_column(column):
     column = column.str.replace(r"['\":.mTh]", "", regex=True)
@@ -355,18 +360,10 @@ def clean_column(column):
 
 
 def extract_additional_columns(df_valor):
-    df_valor["idade_media_titular_vis"] = clean_column(
-        df_valor["idade_media_titular_vis"]
-    )
-    df_valor["idade_media_titular_man"] = clean_column(
-        df_valor["idade_media_titular_man"]
-    )
-    df_valor["valor_equipe_titular_man"] = clean_column(
-        df_valor["valor_equipe_titular_man"]
-    )
-    df_valor["valor_equipe_titular_vis"] = clean_column(
-        df_valor["valor_equipe_titular_vis"]
-    )
+    df_valor["idade_media_titular_vis"] = df_valor["idade_media_titular_vis"].apply(extract_avg_age_and_value)
+    df_valor["idade_media_titular_man"] = df_valor["idade_media_titular_man"].apply(extract_avg_age_and_value)
+    df_valor["valor_equipe_titular_man"] = df_valor["valor_equipe_titular_man"].apply(extract_avg_age_and_value)
+    df_valor["valor_equipe_titular_vis"] = df_valor["valor_equipe_titular_vis"].apply(extract_avg_age_and_value)
     return df_valor
 
 

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py
@@ -431,7 +431,8 @@ async def execucao_coleta():
                 )  # iterando sobre cada linha
                 at_tag.append(cells[6].findAll(text=True))  # iterando sobre cada linha
 
-    for time in range(380):
+
+    for time in range(0, len(links)):
         try:
             ht.append(str(ht_tag[time][2]))
             col_home.append(str(ht_tag[time][0]))
@@ -439,7 +440,7 @@ async def execucao_coleta():
             ht.append(str(ht_tag[time][0]))
             str_vazio = ""
             col_home.append(str(str_vazio))
-    for time in range(380):
+    for time in range(0, len(links)):
         at.append(str(at_tag[time][0]))
         try:
             col_away.append(str(at_tag[time][2]))

--- a/pipelines/utils/metadata/tasks.py
+++ b/pipelines/utils/metadata/tasks.py
@@ -5,7 +5,8 @@ Tasks for metadata
 import asyncio
 from datetime import datetime
 import basedosdados as bd
-
+from datetime import timedelta
+from pipelines.constants import constants as constants_root
 import pandas as pd
 from prefect import task
 
@@ -156,7 +157,10 @@ def update_django_metadata(
         )
 
 
-@task
+@task(
+    max_retries=constants_root.TASK_MAX_RETRIES.value,
+    retry_delay=timedelta(seconds=constants_root.TASK_RETRY_DELAY.value),
+)
 def check_if_data_is_outdated(
     dataset_id: str,
     table_id: str,


### PR DESCRIPTION
close #753
- Dentro da função `execucao_coleta` a lista de times visitantes e mandantes estava com um tamanho maior do que a quantidade total de partidas do campeonato.

**v1.0**
- Corrige o tamanho da lista dos times/partidas
- Adiciona task que retorna a data do último jogo e verifica se há a necessidade de atualização
- Corrige a lista de times, removendo os jogos que estão com a `class="matchresult rescheduled"`, agora o crawler só itera pelos jogos que já aconteceram. Antes iterava por todos os jogos da temporada
- Corrige lógica para pegar o nome dos técnicos
- Também adiciona retry em uma task no flow `br_cgu_beneficios_cidadao`

**v1.1**
- Corrige idade média dos jogadores e valor do clube mandante e visitante