### PR TITLE
[fix] br_me_cnpj

### DIFF
--- a/pipelines/datasets/br_me_cnpj/utils.py
+++ b/pipelines/datasets/br_me_cnpj/utils.py
@@ -50,10 +50,13 @@ def data_url(url, headers):
             link_data = requests.get(url, headers=headers, timeout=timeout)
             time.sleep(2)
             soup = BeautifulSoup(link_data.text, "html.parser")
-            span_element = soup.find_all("td", align="right")
+            log(soup)
 
+            span_element = soup.find_all("td", align="right")
+            log(span_element)
             # Extrai a segunda ocorrência
-            data_completa = span_element[1].text.strip()
+            data_completa = span_element[3].text.strip()
+            log(data_completa)
             # Extrai a parte da data no formato "YYYY-MM-DD"
             data_str = data_completa[0:10]
             # Converte a string da data em um objeto de data

--- a/pipelines/datasets/br_me_cnpj/utils.py
+++ b/pipelines/datasets/br_me_cnpj/utils.py
@@ -50,13 +50,10 @@ def data_url(url, headers):
             link_data = requests.get(url, headers=headers, timeout=timeout)
             time.sleep(2)
             soup = BeautifulSoup(link_data.text, "html.parser")
-            log(soup)
 
             span_element = soup.find_all("td", align="right")
-            log(span_element)
             # Extrai a segunda ocorrência
             data_completa = span_element[3].text.strip()
-            log(data_completa)
             # Extrai a parte da data no formato "YYYY-MM-DD"
             data_str = data_completa[0:10]
             # Converte a string da data em um objeto de data


### PR DESCRIPTION
**Problema:**
- O atributo HTML que estava sendo raspado estava errado. No lugar de raspar a data relativa a última atualização do conjunto br_me_cnpj, estava raspando a data inicial de disponibilização do conjunto pela Receita Federal.

**Solução:**
- Alterei a função data_url, utlizada pela task get_data_source_max_date, para extrair a data mais recente. Apenas modifiquei o índice que indicava qual data extrair.