### PR TITLE
[fix] br_me_cnpj

### DIFF
--- a/pipelines/datasets/br_me_cnpj/tasks.py
+++ b/pipelines/datasets/br_me_cnpj/tasks.py
@@ -93,7 +93,8 @@ def main(tabelas):
         for i in range(0, 10):
             if tabela != "Simples":
                 nome_arquivo = f"{tabela}{i}"
-                url_download = f"http://200.152.38.155/CNPJ/{tabela}{i}.zip"
+                url_download = f"https://dadosabertos.rfb.gov.br/CNPJ/dados_abertos_cnpj/2024-08/{tabela}{i}.zip"
+                #url_download = f"http://200.152.38.155/CNPJ/{tabela}{i}.zip"
                 if nome_arquivo not in arquivos_baixados:
                     arquivos_baixados.append(nome_arquivo)
                     asyncio.run((download_unzip_csv(url_download, input_path)))
@@ -107,7 +108,8 @@ def main(tabelas):
                         process_csv_empresas(input_path, output_path, data_coleta, i)
             else:
                 nome_arquivo = f"{tabela}"
-                url_download = f"http://200.152.38.155/CNPJ/{tabela}.zip"
+                url_download = f"https://dadosabertos.rfb.gov.br/CNPJ/dados_abertos_cnpj/2024-08/{tabela}.zip"
+                #url_download = f"http://200.152.38.155/CNPJ/{tabela}.zip"
                 if nome_arquivo not in arquivos_baixados:
                     arquivos_baixados.append(nome_arquivo)
                     asyncio.run((download_unzip_csv(url_download, input_path)))

--- a/pipelines/datasets/br_me_cnpj/utils.py
+++ b/pipelines/datasets/br_me_cnpj/utils.py
@@ -113,6 +113,7 @@ async def download(
     timeout: int = 3 * 60 * 2,
 ) -> bytes:
     request_head = httpx.head(url)
+    log(request_head)
 
     assert request_head.status_code == 200
     assert request_head.headers["accept-ranges"] == "bytes"


### PR DESCRIPTION
Este PR modifica a URL de download para a URL temporária.

- A rota default do FTP está em manutenção. Eles criaram uma espécie de rota espelho para ofertar os dados.

![image](https://github.com/user-attachments/assets/8540d7af-82c4-4080-bb2f-5c5c7a2e84ab)
