### PR TITLE
[fix].github/workflows

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   build-container:
     name: Build Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -26,7 +26,7 @@ jobs:
   build-container:
     if: startsWith(github.head_ref, 'staging/')
     name: Register flows (staging)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   build-container:
     name: Register flows (production)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-docker.yaml
+++ b/.github/workflows/ci-docker.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name: Lint dockerfile
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   lint:
     name: Lint python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -13,7 +13,7 @@ jobs:
         uses: chartboost/ruff-action@v1
   test:
     name: Test python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
         with:
           cache: poetry
           architecture: x64
-          python-version: '3.11'
+          python-version: '3.10'
       - name: Install requirements
         run: poetry install --only=test
       - name: Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         arch: [x64]
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version: [3.10.x]
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   docs:
     name: Deploy docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Recentemente houve uma atualização na [ultima versão do Ubuntu 24.04.1][ubuntu-patch] disponível para gerar os containers dos nossos Actions.
Porém, com a versão nova o [python padrão vem com a versão 3.12][python-change]. O que causa [incompatibilidade com nosso repositório][poetry-lock] e também a versão mais recente do [ultima versão do Ubuntu 24.04.1][ubuntu-patch] está dando erro em um pacote referente ao [R][r].

- Erro python-version: [Log completo][exemplo-erro-python]
> Run poetry install --only=test
The currently activated Python version 3.12.3 is not supported by the project (>=3.10,<3.11).
Trying to find and use a compatible version. 
Poetry was unable to find a compatible version. If you have one, you can explicitly use it via the "env use" command.
Error: Process completed with exit code 1.

A Action apesar de ter uma alteração de versão do python incluída nela para evitar esse erro, ela estava colocando o python na versão 3.11.X o que acaba sendo superior a permitida atualmente pelo repositório.

[Arquivos de solução][fix-python-version]


- Exemplo [R][r] erro: [Log completo][exemplo-erro]
>    ChefBuildError
  Backend subprocess exited when trying to invoke get_requires_for_build_wheel 
  Unable to determine R home: [Errno 2] No such file or directory: 'R'
  cffi mode is CFFI_MODE.ANY
  Looking for R home with: R RHOME
  Unable to determine R home: [Errno 2] No such file or directory: 'R'
  R home found: None
  Error: rpy2 in API mode cannot be built without R in the PATH or R_HOME defined. Correct this or force ABI mode-only by defining the environment variable RPY2_CFFI_MODE=ABI

Há [ultima versão do Ubuntu 24.04.1][ubuntu-patch] remove o [R][r] da sua lista de Softwares. [Detalhes][r-excluido]

Como não há garantia de que não teremos que resolver outros problemas em referencia a atualização do [Ubuntu 24.04.1][ubuntu-patch], acredito que seja melhor temporariamente a gente deixa ela fixada na versão que usamos anteriormente.

## Nota
*Não fiz alterações no Action que cria a [imagem dockers][action-imagem]. Ela ainda está pegando a ultima versão disponível do Ubuntu, não foi apresentados problemas por ela ainda.*


[ubuntu-patch]: https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890
[poetry-lock]: https://github.com/basedosdados/pipelines/blob/main/pyproject.toml#L73C1-L73C24
[r]: https://www.r-project.org/
[exemplo-erro]: https://github.com/basedosdados/pipelines/actions/runs/11297427483/job/31424290475
[exemplo-erro-python]: https://github.com/basedosdados/pipelines/actions/runs/11348295967/job/31561723255
[fix-python-version]: .github/workflows/ci-python.yaml
[action-imagem]: https://github.com/basedosdados/pipelines/blob/main/.github/workflows/build-docker.yaml#L26
[python-change]: https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#toolchain-upgrades
[r-excluido]: https://github.com/actions/runner-images/issues/10636