### PR TITLE
[Refactor] br_cvm_fi

### DIFF
--- a/pipelines/datasets/br_cvm_fi/tasks.py
+++ b/pipelines/datasets/br_cvm_fi/tasks.py
@@ -225,10 +225,9 @@ def clean_data_and_make_partitions(path: str, table_id: str) -> str:
     for file in files:
         df = pd.read_csv(f"{path}{file}", sep=";")
         log(f"File {file} read.")
+        log(df.columns)
 
-        df.rename(columns={'CNPJ_FUNDO_CLASSE':'CNPJ_FUNDO'}, inplace=True)
-
-        df["CNPJ_FUNDO"] = df["CNPJ_FUNDO"].str.replace(r"[/.-]", "")
+        df["CNPJ_FUNDO_CLASSE"] = df["CNPJ_FUNDO_CLASSE"].str.replace(r"[/.-]", "")
 
         df = rename_columns(df_arq, df)
 

--- a/pipelines/datasets/br_cvm_fi/tasks.py
+++ b/pipelines/datasets/br_cvm_fi/tasks.py
@@ -225,9 +225,10 @@ def clean_data_and_make_partitions(path: str, table_id: str) -> str:
     for file in files:
         df = pd.read_csv(f"{path}{file}", sep=";")
         log(f"File {file} read.")
-        log(df.columns)
 
         df["CNPJ_FUNDO_CLASSE"] = df["CNPJ_FUNDO_CLASSE"].str.replace(r"[/.-]", "")
+
+        df.drop("ID_SUBCLASSE",axis=1, inplace=True)
 
         df = rename_columns(df_arq, df)
 


### PR DESCRIPTION
## Descrição do PR:

- Este PR dropa colunas da fonte original que são inteiramente nulas e não presentes na tabela final documentos_informe_diario
- Este flow usa as colunas mapeadas na tabela de arquitetura para renomear  as variáveis. Como as colunas CNPJ_FUNDO e TP_FUNDO mudaram para, CNPJ_FUNDO_CLASSE e TP_FUNDO_CLASSE, apliquei estas mudanças na tabela de arquitetura
- Atualizei os últimos 12 meses de dados no Storage de dev com a [run](https://prefect.basedosdados.org/default/flow-run/cefd3b57-3009-44da-aa7f-0613a2a20875)
- Testei os dados em Dev
- Levei os dados para produção com o flow transfer_files_to_production [run](https://prefect.basedosdados.org/default/flow-run/e9b471ac-09b9-4130-a6e5-56daa6170dfb)  
- Materializei a tabela com o [flow](https://prefect.basedosdados.org/default/flow-run/850d9a3d-db7f-4a70-ad44-0851d96d61c4)
