### PR TITLE
[BugFix] 

### DIFF
--- a/pipelines/utils/crawler_datasus/flows.py
+++ b/pipelines/utils/crawler_datasus/flows.py
@@ -423,7 +423,7 @@ with Flow(name="DATASUS-SINAN", code_owners=["trick"]) as flow_sinan:
             file_list=dbc_files,
             dataset_id=dataset_id,
             table_id=table_id,
-            chunk_size = 150000,
+            chunk_size = 100000,
             upstream_tasks=[dbf_files, dbc_files],
         )
 


### PR DESCRIPTION
# Template Pull Requests - Pipeline


  - [x]  **[Bugfix]**: Para correções de bugs.


## Descrição do PR:

    - Testando a otimização da pipeline do Sinan diminuindo o valor do chunksize que é ingerido.


## Detalhes Técnicos:

    - A pipeline do Sinan está enfrentando um problema de consumo excessivo de memória, resultando no erro [137 do Kubernetes](https://stackoverflow.com/questions/59729917/kubernetes-pods-terminated-exit-code-137). A solução proposta é reduzir o tamanho dos chunks processados, permitindo que o contêiner consuma menos memória e, assim, garantir a conclusão bem-sucedida da pipeline.
