### PR TITLE
[Fix]Concertar imagem bd_minilogo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <p align="center">
     <a href="https://basedosdados.org">
-        <img src="https://basedosdados.org/favicon.ico">
+        <img src="https://github.com/basedosdados/sdk/blob/master/docs/docs/pt/images/bd_minilogo.png" width="340" alt="Base dos Dados">
     </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <a href="https://basedosdados.org">
-        <img src="https://basedosdados.org/favicon.ico">
+        <img src="https://github.com/basedosdados/sdk/blob/master/docs/docs/pt/images/bd_minilogo.png" width="340" alt="Base dos Dados">
     </a>
 </p>
 


### PR DESCRIPTION
# Consertar imagem bd_minilogo

## Descrição do PR:

Depois da atualização no site da BD para suporta múltiplos idiomas nossa imagem de logo da BD fico com o link quebrado.

PR altera o caminho da imagem para do logo que se encontra em [docs][docs]

[docs]: https://github.com/basedosdados/sdk/blob/master/docs/docs/pt/images/bd_minilogo.png
