### PR TITLE
[Deactivate] br_inmet_bdmep

### DIFF
--- a/pipelines/datasets/br_inmet_bdmep/flows.py
+++ b/pipelines/datasets/br_inmet_bdmep/flows.py
@@ -108,5 +108,4 @@ with Flow(name="br_inmet_bdmep", code_owners=["equipe_pipelines"]) as br_inmet:
 
 br_inmet.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_inmet.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
-br_inmet.schedule = every_month_inmet
-# flow.schedule = every_two_weeks
+#br_inmet.schedule = every_month_inmet


### PR DESCRIPTION
## Descrição do PR:

- Este flow tem uma configuração dinâmica no schedule. O parâmetro ano, utilizado para compor a URL de download do arquivo, é gerado com o ano corrente. Já estamos em 2025 e o dado na fonte original ainda está em 2024. Logo, a requisição toma 404
. Desativar a pipeline por enquanto e reativa quando a nova atualização sair na [fonte original](https://portal.inmet.gov.br/dadoshistoricos/)