### PR TITLE
fix parse_datetime_ranges

### DIFF
--- a/pipelines/utils/metadata/utils.py
+++ b/pipelines/utils/metadata/utils.py
@@ -551,28 +551,26 @@ def parse_datetime_ranges(datetime_result: dict, date_format: str) -> dict:
 
     date_objects = {}
 
-    edges = datetime_result["allCoverage"]["edges"]
+    edges = datetime_result["allCoverage"]["items"]
 
     # iterates over each edge
     for edge in edges:
-        node = edge["node"]
-        datetime_ranges = node["datetimeRanges"]["edges"]
+        datetime_ranges = edge["datetimeRanges"]["items"]
 
         # iterates over each edge of datetime_ranges
 
         # ps: If the table has bd_pro coverage,
         # it will have more than one datetime_range
         for dt_range in datetime_ranges:
-            dt_node = dt_range["node"]
-            end_year = dt_node.get("endYear")
-            end_month = dt_node.get("endMonth")
-            end_day = dt_node.get("endDay")
+            end_year = dt_range.get("endYear")
+            end_month = dt_range.get("endMonth")
+            end_day = dt_range.get("endDay")
 
             date_values = (end_year, end_month, end_day)
 
             date_string = format_and_check_date(date_values, date_format)
             # log(f"The following coverage is being added {date_objects}")
-            date_objects[dt_node["id"]] = date_string
+            date_objects[dt_range["id"]] = date_string
 
     return date_objects
 


### PR DESCRIPTION
Depois de #931 apareceu alguns erros devido a alterações nas respostas do backend.

[Log de erro de br_ibge_ipca15.mes_categoria_municipio](https://prefect.basedosdados.org/default/flow-run/2231ae5f-4268-49e2-9536-273aaf9810f1?logs)

```
Task 'check_for_updates': Exception encountered during task execution!
Traceback (most recent call last):
  File "/opt/venv/lib/python3.10/site-packages/prefect/engine/task_runner.py", line 876, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "/opt/venv/lib/python3.10/site-packages/prefect/utilities/executors.py", line 454, in run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "/home/runner/work/pipelines/pipelines/pipelines/utils/crawler_ibge_inflacao/tasks.py", line 131, in check_for_updates
  File "/opt/venv/lib/python3.10/site-packages/pipelines/utils/metadata/utils.py", line 648, in get_api_most_recent_date
    coverages = get_coverage_value(
  File "/opt/venv/lib/python3.10/site-packages/pipelines/utils/metadata/utils.py", line 486, in get_coverage_value
    date_objects = parse_datetime_ranges(datetime_result, date_format)
  File "/opt/venv/lib/python3.10/site-packages/pipelines/utils/metadata/utils.py", line 554, in parse_datetime_ranges
    edges = datetime_result["allCoverage"]["edges"]
KeyError: 'edges'
```

