### PR TITLE
[chore]: action setup-python read `.python-version`

### DIFF
--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           cache: poetry
-          python-version: '3.10'
+          python-version-file: .python-version
       - uses: google-github-actions/auth@v2
         with:
           export_environment_variables: true
@@ -108,7 +108,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           cache: poetry
-          python-version: '3.10'
+          python-version-file: .python-version
       - name: Install requirements
         run: poetry install --only=dev
       - name: Run script to test dbt dev model

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           cache: poetry
-          python-version: '3.10'
+          python-version-file: .python-version
       - uses: google-github-actions/auth@v2
         with:
           export_environment_variables: true
@@ -150,7 +150,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           cache: poetry
-          python-version: '3.10'
+          python-version-file: .python-version
       - name: Install requirements
         if: steps.check_label.outputs.table-approve == 'true'
         run: poetry install --only=dev

--- a/.github/workflows/triggers-elementary-model.yaml
+++ b/.github/workflows/triggers-elementary-model.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           cache: poetry
-          python-version: '3.10'
+          python-version-file: .python-version
       - name: Install requirements
         run: poetry install --only=dev
       - name: Run script to test DBT model


### PR DESCRIPTION
A action setup-python pode fazer o setup do python lendo o arquivo `.python-version` que já é usado pelo pyenv.

[skip ci]