### PR TITLE
[chore]: deploy-production remove step delete archieved flow runs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -76,8 +76,9 @@ jobs:
       - name: Register Prefect flows
         run: |-
           poetry run python .github/workflows/scripts/register_flows.py --project $PREFECT__SERVER__PROJECT --path pipelines/ --schedule
-      - name: Delete archieved flow runs
-        run: poetry run python .github/workflows/scripts/delete_archieved_flow_runs.py
+      # TODO: https://github.com/basedosdados/pipelines/pull/1017
+      # - name: Delete archieved flow runs
+      #   run: poetry run python .github/workflows/scripts/delete_archieved_flow_runs.py
   table-approve:
     needs: deploy-production
     name: table approve


### PR DESCRIPTION
Esse step leva ~5min/6min para deletar flows arquivados. Se alguém for mesclar um PR com o table-approve tem que esperar esse step. Até mesmo para quem mexe em pipelines para ser desnecessário no momento.

Acho que podemos fazer em um job separado, mas é melhor investigar como é processo de deletar flows arquivados. Atualmente ele parece deletar os mesmos flow toda vez que roda.