### PR TITLE
[BugFix] br_camara_dados_abertos.proposicao_microdados

### DIFF
--- a/models/br_camara_dados_abertos/schema.yml
+++ b/models/br_camara_dados_abertos/schema.yml
@@ -325,9 +325,9 @@ models:
       mais recente, proposições a que se relacionam, etc.
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: [id_proposicao, data_hora_ultimo_status]
+          combination_of_columns: [id_proposicao, ano]
       - not_null_proportion_multiple_columns:
-          at_least: 0.01
+          at_least: 0.001
     columns:
       - name: ano
         description: Ano


### PR DESCRIPTION
## Descrição do PR:

- O teste da pipeline está quebrando devido a coluna `url_anterior` ter se reduzido a proporção de nulos para menor que 1%. Dessa forma, estou consertando a `not_null_proportion_multiple_columns`. 

- Alterei o combination_of_columns para ano, acredito que combine mais e esteja mais certo do que data_hora_ultimo_status

