### PR TITLE
[chore]: deploy-production register only modified flows

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -75,7 +75,12 @@ jobs:
           verbose: true
       - name: Register Prefect flows
         run: |-
-          poetry run python .github/workflows/scripts/register_flows.py --project $PREFECT__SERVER__PROJECT --path pipelines/ --schedule
+          poetry run python .github/workflows/scripts/register_flows.py \
+            --project $PREFECT__SERVER__PROJECT \
+            --path pipelines/ \
+            --schedule \
+            --filter-affected-flows \
+            --modified-files "${{ steps.files.outputs.all }}"
       - name: Delete archieved flow runs
         run: poetry run python .github/workflows/scripts/delete_archieved_flow_runs.py
   table-approve:


### PR DESCRIPTION
O comportamento atual é registrar todos os flows em prod quando um PR é mesclado, isso leva ~6min. Se o PR mesclado for apenas um modificação em um .sql para rodar o table-approve tem que esperar todos os registros dos flows.

Em staging só registramos os flows que foram alterados ou afetado por uma alteração.

Em `cd-staging` é usado o parâmetro `--filter-affected-flows`.

Não sei porque em prod é forçado o registro de todos os flows, parece uma medida de segurança, mas não parece ser necessário, só em alguns casos.

Nesse PR adiciono `--filter-affected-flows` para registrar apenas os flows afetados. No entanto, se `pyproject.toml` ou `poetry.lock` for modificado todos os flows serão registrados porque pode existir uma atualização de dependência que não sabemos qual flows será afetado.

Obs: Nem toda modificação em `pyproject.toml` é uma atualização de uma dependência, mesmo assim todos os flows serão registrados porque a verificação é apenas se o arquivo foi modificado.

Close #1086