### PR TITLE
[docs]: update before install r-base

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ poetry install --with dev --with test --no-root
 ```
 
 > [!WARNING]
-> Caso a instalação do `poetry` de erro no pacote do `R`, recomendado rodar a seguinte linha para instalar o R-base `sudo apt -y install r-base`
+> Caso a instalação do `poetry` de erro no pacote do `R`, recomendado rodar a seguinte linha para instalar o R-base `sudo apt-get update & apt-get install -y r-base`
 
 Instalar os hooks de pré-commit (ver https://pre-commit.com/ para entendimento dos hooks)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ poetry install --with dev --with test --no-root
 ```
 
 > [!WARNING]
-> Caso a instalação do `poetry` de erro no pacote do `R`, recomendado rodar a seguinte linha para instalar o R-base `sudo apt-get update & apt-get install -y r-base`
+> Caso a instalação do `poetry` de erro no pacote do `rpy2`, recomendado rodar a seguinte linha para instalar o R-base `sudo apt-get update & apt-get install -y r-base`
 
 Instalar os hooks de pré-commit (ver https://pre-commit.com/ para entendimento dos hooks)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ poetry install --with dev --with test --no-root
 ```
 
 > [!WARNING]
-> Caso a instalação do `poetry` de erro no pacote do `rpy2`, recomendado rodar a seguinte linha para instalar o R-base `sudo apt-get update & apt-get install -y r-base`
+> Caso a instalação do `poetry` de erro no pacote `rpy2`, é recomendado rodar a seguinte linha para instalar o `r-base`: `sudo apt-get update & apt-get install -y r-base`
 
 Instalar os hooks de pré-commit (ver https://pre-commit.com/ para entendimento dos hooks)
 


### PR DESCRIPTION
Antes de instalar o R precisamos sincronizar usando `sudo apt-get update`. Peguei esse erro testando o GitHub Codespaces.

```
- Installing rpy2 (3.5.17): Failed

  ChefBuildError

  Backend subprocess exited when trying to invoke get_requires_for_build_wheel
  
  Unable to determine R home: [Errno 2] No such file or directory: 'R'
  cffi mode is CFFI_MODE.ANY
  Looking for R home with: R RHOME
  Unable to determine R home: [Errno 2] No such file or directory: 'R'
  R home found: None
  Error: rpy2 in API mode cannot be built without R in the PATH or R_HOME defined. Correct this or force ABI mode-only by defining the environment variable RPY2_CFFI_MODE=ABI
  

  at ~/.local/share/pypoetry/venv/lib/python3.12/site-packages/poetry/installation/chef.py:164 in _prepare
      160│ 
      161│                 error = ChefBuildError("\n\n".join(message_parts))
      162│ 
      163│             if error is not None:
    → 164│                 raise error from None
      165│ 
      166│             return path
      167│ 
      168│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:

Note: This error originates from the build backend, and is likely not a problem with poetry but with rpy2 (3.5.17) not supporting PEP 517 builds. You can verify this by running 'pip wheel --no-cache-dir --use-pep517 "rpy2 (==3.5.17)"'.
```

Usando apenas `sudo apt -y install r-base`:

```
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package r-base
```