### PR TITLE
[feature]: log `project_id` and `client_email`

### DIFF
--- a/pipelines/utils/execute_dbt_model/tasks.py
+++ b/pipelines/utils/execute_dbt_model/tasks.py
@@ -88,6 +88,15 @@ def run_dbt(
 
     log_file_path = os.path.join("logs", "dbt.log")
 
+    if target == "prod":
+        with open("/credentials-prod/prod.json", "r") as f:
+            service_account = json.loads(f.read())
+            project_id = service_account["project_id"]
+            client_email = service_account["client_email"]
+            log(
+                f"Service account for prod: project_id: `{project_id}`, client_email: `${client_email}`"
+            )
+
     for cmd in commands_to_run:
         cli_args = [cmd, "--select", selected_table, "--target", target]
 


### PR DESCRIPTION
Esse PR adiciona log para dois campos da conta de serviço de prod, `project_id` e `client_email`.

Algumas pipelines estão falhando com o seguinte erro:

[DBT Model run/test: br_camara_dados_abertos.deputado_profissao](https://prefect.basedosdados.org/default/flow-run/071b5e76-c453-46e6-86b3-2b571091c852?logs=&logId=6649540b-0008-48eb-9d1f-b28a4f5f33a2)

```
Runtime Error in model br_camara_dados_abertos__deputado_profissao (models/br_camara_dados_abertos/br_camara_dados_abertos__deputado_profissao.sql)\n  412 GET https://bigquery.googleapis.com/bigquery/v2/projects/basedosdados/queries/d823f9f3-a292-4d36-aaeb-5ba4b1f68dfa?maxResults=0&location=US&prettyPrint=false: IAM setPolicy failed for Table basedosdados:br_camara_dados_abertos.deputado_profissao: There were concurrent policy changes. Please retry the whole read-modify-write with exponential backoff
```

Quero verificar se o arquivo correto da conta de serviço está sendo utilizado. Quando testo localmente com o arquivo de prod não pego esse erro.

@trick marcando você porque acho que a pipeline que falhou é sua