### PR TITLE
[update]: br_inep_censo_escolar - 2024

### DIFF
--- a/models/br_inep_censo_escolar/br_inep_censo_escolar__escola.sql
+++ b/models/br_inep_censo_escolar/br_inep_censo_escolar__escola.sql
@@ -5,7 +5,7 @@
         partition_by={
             "field": "ano",
             "data_type": "int64",
-            "range": {"start": 2007, "end": 2023, "interval": 1},
+            "range": {"start": 2007, "end": 2024, "interval": 1},
         },
         cluster_by="sigla_uf",
     )

--- a/models/br_inep_censo_escolar/br_inep_censo_escolar__turma.sql
+++ b/models/br_inep_censo_escolar/br_inep_censo_escolar__turma.sql
@@ -5,7 +5,7 @@
         partition_by={
             "field": "ano",
             "data_type": "int64",
-            "range": {"start": 2009, "end": 2022, "interval": 1},
+            "range": {"start": 2009, "end": 2024, "interval": 1},
         },
         cluster_by="sigla_uf",
     )
@@ -91,4 +91,3 @@ select
     ) disciplina_atendimento_especiais,
     safe_cast(disciplina_diver_socio_cultural as int64) disciplina_diver_socio_cultural,
 from {{ set_datalake_project("br_inep_censo_escolar_staging.turma") }} as t
-where safe_cast(ano as int64) < 2023

--- a/models/br_inep_censo_escolar/schema.yml
+++ b/models/br_inep_censo_escolar/schema.yml
@@ -1174,9 +1174,6 @@ models:
       - name: rede
         description: Rede Escolar
         tests:
-          - relationships:
-              to: ref('br_bd_diretorios_brasil__escola')
-              field: rede
           - accepted_values:
               values: [municipal, estadual, federal, privada]
       - name: id_escola


### PR DESCRIPTION
Atualizando duas tabelas do Censo Escolar para 2024, `escola` e `turma`.

Fiz em https://github.com/basedosdados/queries-basedosdados/pull/943 mas teve um erro no table approve e não tinha incluido a tabela turma.

A tabela turma está sendo atualizada para 2023 e 2024. Não publicamos a atualização de 2023 porque estavamos aguardando o pedido LAI, mas a Laura falou que pode publicar.