### PR TITLE
[bugfix]: AttributeError: 'list' object has no attribute 'split'

### DIFF
--- a/.github/workflows/scripts/prefect_run_dbt.py
+++ b/.github/workflows/scripts/prefect_run_dbt.py
@@ -331,12 +331,9 @@ def sync_bucket(
 
 
 def get_datasets_and_tables_for_modified_files(
-    modified_files: str,
+    modified_files: list[str],
 ) -> list[tuple[str, str, bool]]:
-    modified_files_list = modified_files.split(",")
-    datasets_tables = get_datasets_tables_from_modified_files(
-        modified_files_list
-    )
+    datasets_tables = get_datasets_tables_from_modified_files(modified_files)
 
     existing_datasets_tables = []
 


### PR DESCRIPTION
Bug adicionado em #1106.

```
Traceback (most recent call last):
  File "/home/runner/work/pipelines/pipelines/.github/workflows/scripts/prefect_run_dbt.py", line 443, in <module>
    else get_datasets_and_tables_for_modified_files(
  File "/home/runner/work/pipelines/pipelines/.github/workflows/scripts/prefect_run_dbt.py", line 336, in get_datasets_and_tables_for_modified_files
    modified_files_list = modified_files.split(",")
AttributeError: 'list' object has no attribute 'split'
```