### PR TITLE
[chore]: remove group test from `pyproject.toml`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ poetry shell
 #### Instalar as dependências
 
 ```sh
-poetry install --with dev --with test --no-root
+poetry install --with dev --no-root
 ```
 
 > [!WARNING]

--- a/poetry.lock
+++ b/poetry.lock
@@ -6571,4 +6571,4 @@ heapdict = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "4ea0e98a6ef0e223f8efd70c16e879554d025a3a647af6f1895a9b071c5cec48"
+content-hash = "a28bed40c7d86805f6e222154e393be863762958168ab1d6e05657ddf1723b81"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,12 +142,6 @@ databasers-utils = {git = "https://github.com/basedosdados/databasers-utils.git"
 ipykernel = "^6.29.5" # Required to run notebook jupyter
 basedosdados = {extras = ["all"], version = "^2.0.2"}
 
-[tool.poetry.group.test]
-optional = true
-
-[tool.poetry.group.test.dependencies]
-networkx = "^2.6.3"
-parameterized = "^0.9.0"
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
O grupo test tem duas dependências: networkx e parameterized. networkx já está no grupo dev e parameterized já uma dependência de pipelines.

Parte de #1008.