### PR TITLE
[bugfix]: remove `apt-key`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,12 @@ ENV PYTHONUNBUFFERED=1
 
 # Install gcc, Google Chrome, CLI tools, git, R and others libs Firefox
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y wget gnupg && \
-    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
+    apt-get install --no-install-recommends -y curl gnupg && \
+    curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
     build-essential \
-    curl \
     freetds-dev \
     ftp \
     gcc \


### PR DESCRIPTION
O workflow [Build Docker image](https://github.com/basedosdados/pipelines/actions/workflows/build-docker.yaml) está falhando.

O comando `apt-key` foi removido