### PR TITLE
[chore]: switch to ubuntu-22.04

### DIFF
--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -86,7 +86,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'test-dev-model')
     needs: deploy-staging
     name: test dbt dev model
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/triggers-elementary-model.yaml
+++ b/.github/workflows/triggers-elementary-model.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   run_elementary_models:
     name: Run elementary model
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
`uv` instala `rpy2` mesmo quando quero instalar apenas as dependências de desenvolvimento `uv sync --locked --only-dev`.

Como `rpy2` não está disponível no runner mais recente isso gera um erro.