### PR TITLE
[fix] br_ms_cnes__profissional, ano e mes

### DIFF
--- a/models/br_ms_cnes/br_ms_cnes__profissional.sql
+++ b/models/br_ms_cnes/br_ms_cnes__profissional.sql
@@ -35,8 +35,8 @@ with
             and pf.mes = st.mes1
     )
 select
-    cast(substr(competen, 1, 4) as int64) as ano,
-    cast(substr(competen, 5, 2) as int64) as mes,
+    safe_cast(ano as int64) ano,
+    safe_cast(mes as int64) mes,
     safe_cast(sigla_uf as string) sigla_uf,
     safe_cast(id_municipio as string) id_municipio,
     safe_cast(cnes as string) id_estabelecimento_cnes,


### PR DESCRIPTION
# [fix] br_ms_cnes__profissional, ano e mes

## Descrição do PR:

## Descrição da Pull Request

### Alteração:
Substituição do uso de `substr` e `cast` para obter os valores de `ano` e `mes` a partir da coluna `competen`, para uma abordagem mais direta utilizando `safe_cast` nos campos `ano` e `mes`.

*`competen` nas ultimas extrações tiveram casos dele vim como `000000` impossibilitando a extração do ano e mes usando o   `substr`*

Teste:

```sql
with tabela_validar as (SELECT 
ano, 
mes,
safe_cast(ano as int64) as ano_int,
safe_cast(mes as int64) as mes_int,
cast(substr(competen, 1, 4) as int64) as ano_competen,
cast(substr(competen, 5, 2) as int64) as mes_competen, 
competen,
FROM `basedosdados-dev.br_ms_cnes_staging.profissional`
where ano = "2020")
select * from tabela_validar
where ano_int != ano_competen and mes_int != mes_competen
```

Usando código a cima foi testando em diversos anos que a utilização direta do ano e mes não compromete o resultado. 

