### PR TITLE
[feat]: notifies to discord when a flow fails in prod only.

### DIFF
--- a/pipelines/utils/utils.py
+++ b/pipelines/utils/utils.py
@@ -28,6 +28,7 @@ import requests
 from google.cloud import storage
 from google.cloud.storage.blob import Blob
 from google.oauth2 import service_account
+from prefect.backend import FlowRunView
 from prefect.client import Client
 from prefect.engine.state import State
 from prefect.run_configs import KubernetesRun, VertexRun
@@ -108,6 +109,34 @@ def set_default_parameters(
         if parameter.name in default_parameters:
             parameter.default = default_parameters[parameter.name]
     return flow
+
+
+def is_running_in_prod() -> bool:
+    """
+    Determines if the current Prefect flow is running in the production environment.
+
+    Returns:
+      bool: True if the flow is running with the "basedosdados" label, indicating production; False otherwise.
+
+    Notes:
+      - Relies on Prefect's context to obtain the current flow run ID.
+      - Uses FlowRunView to retrieve labels associated with the flow run.
+    """
+    flow_run_id = prefect.context.get("flow_run_id")
+
+    if flow_run_id is None:
+        return False
+
+    try:
+        labels = FlowRunView.from_flow_run_id(flow_run_id).labels
+    except ValueError:
+        return False
+
+    for label in labels:
+        if label.strip() == constants.BASEDOSDADOS_PROD_AGENT_LABEL.value:
+            return True
+
+    return False
 
 
 def run_local(flow: prefect.Flow, parameters: Dict[str, Any] = None):
@@ -198,8 +227,12 @@ def notify_discord_on_failure(
     code_owners: Optional[List[str]] = None,
 ):
     """
-    Notifies a Discord channel when a flow fails.
+    Notifies a Discord channel when a flow fails in prod only.
     """
+
+    if not is_running_in_prod():
+        return None
+
     url = get_vault_secret(secret_path)["data"]["url"]
     flow_run_id = prefect.context.get("flow_run_id")
     labels = prefect.context.config.cloud.agent.labels
@@ -246,6 +279,9 @@ def notify_discord(
     """
     Notifies a Discord channel.
     """
+    if not is_running_in_prod():
+        return None
+
     url = get_vault_secret(secret_path)["data"]["url"]
     code_owners = code_owners or constants.DEFAULT_CODE_OWNERS.value
     code_owner_dict = constants.OWNERS_DISCORD_MENTIONS.value


### PR DESCRIPTION
### Resumo

Quando um flow falha enviamos um notificação para o discord. No entanto quando estamos testando um flow local e ele falha esse erro é lançado poluindo a stacktrace. Isso ocorre porque não temos as credenciais e `notify_discord_on_failure` falha.

Exemplo:

```python
from prefect import task

from pipelines.utils.decorators import Flow
from pipelines.utils.utils import run_local


@task
def error():
    raise Exception


with Flow(name="test") as test_flow:
    erro = error()

run_local(test_flow)
```

```
/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.20) or chardet (5.2.0)/charset_normalizer (2.0.9) doesn'
t match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
[2025-09-24 21:46:49-0300] INFO - prefect.FlowRunner | Beginning Flow run for 'test'
[2025-09-24 21:46:49-0300] INFO - prefect.TaskRunner | Task 'error': Starting task run...
[2025-09-24 21:46:49-0300] ERROR - prefect.TaskRunner | Task 'error': Exception encountered during task execution!
Traceback (most recent call last):
  File "/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/prefect/engine/task_runner.py", line 876, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/prefect/utilities/executors.py", line 454, in run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "/home/pedro/Desktop/bd/pipelines/input/pipelines/test_flow.py", line 10, in error
    raise Exception
Exception
[2025-09-24 21:46:49-0300] INFO - prefect.TaskRunner | Task 'error': Finished task run for task with final state: 'Failed'
[2025-09-24 21:46:49-0300] INFO - prefect.FlowRunner | Flow run FAILED: some reference tasks failed.
[2025-09-24 21:46:49-0300] ERROR - prefect.FlowRunner | Unexpected error while calling state handlers: AttributeError("'NoneType' object has no attribute 'strip'")
Traceback (most recent call last):
  File "/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/prefect/engine/runner.py", line 161, in handle_state_change
    new_state = self.call_runner_target_handlers(old_state, new_state)
  File "/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/prefect/engine/flow_runner.py", line 116, in call_runner_target_handlers
    new_state = handler(self.flow, old_state, new_state) or new_state
  File "/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/prefect/utilities/notifications/notifications.py", line 71, in state_handler
    fn(obj, new_state)
  File "/home/pedro/Desktop/bd/pipelines/pipelines/utils/utils.py", line 203, in notify_discord_on_failure
    url = get_vault_secret(secret_path)["data"]["url"]
  File "/home/pedro/Desktop/bd/pipelines/pipelines/utils/utils.py", line 86, in get_vault_secret
    vault_client = client if client else get_vault_client()
  File "/home/pedro/Desktop/bd/pipelines/pipelines/utils/utils.py", line 77, in get_vault_client
    url=getenv("VAULT_ADDRESS").strip(),
AttributeError: 'NoneType' object has no attribute 'strip'
[2025-09-24 21:46:49-0300] ERROR - prefect.test | Unexpected error occured in FlowRunner: AttributeError("'NoneType' object has no attribute 'strip'")
```

Com essa alteração:

```
/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.20) or chardet (5.2.0)/charset_normalizer (2.0.9) doesn'
t match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
[2025-09-24 21:46:25-0300] INFO - prefect.FlowRunner | Beginning Flow run for 'test'
[2025-09-24 21:46:25-0300] INFO - prefect.TaskRunner | Task 'error': Starting task run...
[2025-09-24 21:46:25-0300] ERROR - prefect.TaskRunner | Task 'error': Exception encountered during task execution!
Traceback (most recent call last):
  File "/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/prefect/engine/task_runner.py", line 876, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/prefect/utilities/executors.py", line 454, in run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "/home/pedro/Desktop/bd/pipelines/input/pipelines/test_flow.py", line 10, in error
    raise Exception
Exception
[2025-09-24 21:46:25-0300] INFO - prefect.TaskRunner | Task 'error': Finished task run for task with final state: 'Failed'
[2025-09-24 21:46:25-0300] INFO - prefect.FlowRunner | Flow run FAILED: some reference tasks failed.
```