### PR TITLE
[bugfix]: remove `seed-paths` from dbt

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -20,7 +20,6 @@ vars:
 model-paths: [models]
 analysis-paths: [analysis]
 test-paths: [tests-dbt]
-seed-paths: [data]
 macro-paths: [macros]
 snapshot-paths: [snapshots]
 target-path: target  # directory which will store compiled SQL files


### PR DESCRIPTION
O principal motivo é que ao executar um pipeline a função `dump_header_to_csv` usada em `create_table_and_upload_to_gcs` salva arquivos no diretório `data` e o `dbt` reporta o seguinte erro.

`dump_header_to_csv`:
https://github.com/basedosdados/pipelines/blob/700f35d36c2382f08ee7e4c2094d432f53c785ea/pipelines/utils/utils.py#L605

```
$ dbt run --select models/test_dataset/test_dataset__test_table.sql
/home/pedro/Desktop/bd/pipelines/.venv/lib/python3.10/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.20) or chardet (5.2.0)/charset_normalizer (2.0.9) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
01:12:00  Running with dbt=1.5.6
01:12:01  Registered adapter: bigquery=1.5.9
01:12:02  Unable to do partial parsing because a project config has changed
01:12:11  Encountered an error:
Compilation Error
  dbt found two seeds with the name "header".

  Since these resources have the same name, dbt will be unable to find the correct resource
  when looking for ref("header").

  To fix this, change the name of one of these resources:
  - seed.basedosdados.header (data/7924975c-236e-40da-a075-7da86723f9ae/header.csv)
  - seed.basedosdados.header (data/84ed1b33-a365-4243-a41a-a7b3941b5fbe/header.csv)
```

`data/` dir:

```
$ tree data
data
├── 30ed6a6a-b9fc-4ed3-a80a-91c122996469
│   └── header.csv
├── 664e4c58-4ab7-4323-888e-2d04563c75cc
│   └── header.csv
├── 6f7620b8-c31e-4740-ad72-4db67fbfe56a
│   └── header.csv
├── 7924975c-236e-40da-a075-7da86723f9ae
│   └── header.csv
├── 84ed1b33-a365-4243-a41a-a7b3941b5fbe
│   └── header.csv
└── be5f20f5-0b3b-450f-a523-afd2e8f61530
    └── header.csv
```

Pode ocorrer se o dbt for executado na cloud.