### PR TITLE
[fix] Fix ncm_exportacao and ncm_importacao - id_ncm

### DIFF
--- a/models/br_me_comex_stat/schema.yml
+++ b/models/br_me_comex_stat/schema.yml
@@ -128,9 +128,10 @@ models:
       - name: id_ncm
         description: ID Produto - Nomenclatura Comum do Mercosul
         tests:
-          - relationships:
+          - custom_relationships:
               to: ref('br_bd_diretorios_mundo__nomenclatura_comum_mercosul')
               field: id_ncm
+              ignore_values: ['85492100', '90189097', '90189097', '90189097']
               config:
                 where: __most_recent_year_month__
       - name: id_unidade
@@ -190,9 +191,10 @@ models:
       - name: id_ncm
         description: ID Produto - Nomenclatura Comum do Mercosul
         tests:
-          - relationships:
+          - custom_relationships:
               to: ref('br_bd_diretorios_mundo__nomenclatura_comum_mercosul')
               field: id_ncm
+              ignore_values: ['85492100', '90189097', '90189097', '90189097']
               config:
                 where: __most_recent_year_month__
       - name: id_unidade


### PR DESCRIPTION
# Descrição do PR:

`br_me_comex_stat__ncm_importacao` e `br_me_comex_stat__ncm_exportacao` compartilham do campo `id_ncm` o qual tem novos valores que não batem com o nosso diretório `br_bd_diretorios_mundo.nomenclatura_comum_mercosul`
valores: '85492100', '90189097', '90189097', '90189097'

Pesquisei uma fonte confiável para adicionar os novos valores e não foi encontrado nada definitivo. Por enquanto colocando esses novos valores em uma lista de `ignore_values`


