### PR TITLE
br_inep_avaliacao_alfabetizacao

### DIFF
--- a/models/br_inep_avaliacao_alfabetizacao/br_inep_avaliacao_alfabetizacao__meta_alfabetizacao_uf.sql
+++ b/models/br_inep_avaliacao_alfabetizacao/br_inep_avaliacao_alfabetizacao__meta_alfabetizacao_uf.sql
@@ -19,5 +19,8 @@ select
     safe_cast(meta_alfabetizacao_2030 as float64) meta_alfabetizacao_2030,
     safe_cast(percentual_participacao as float64) percentual_participacao,
 from
-    {{ set_datalake_project("br_inep_avaliacao_alfabetizacao.meta_alfabetizacao_uf") }}
-    as t
+    {{
+        set_datalake_project(
+            "br_inep_avaliacao_alfabetizacao_staging.meta_alfabetizacao_uf"
+        )
+    }} as t


### PR DESCRIPTION
Adicionando o sufixo `_staging` na tabela `br_inep_avaliacao_alfabetizacao__meta_alfabetizacao_uf` pois ao realizar o merge do PR #1225 deu [erro](https://github.com/basedosdados/pipelines/actions/runs/20997067911/job/60357718321) no dbt dessa tabela e ela não foi p/ prod