### PR TITLE
[bugfix] br_me_cnpj.dicionario

### DIFF
--- a/models/br_me_cnpj/br_me_cnpj__dicionario.sql
+++ b/models/br_me_cnpj/br_me_cnpj__dicionario.sql
@@ -1,5 +1,5 @@
 {{ config(alias="dicionario", schema="br_me_cnpj") }}
-
+-- update 2026-02-12
 select
     safe_cast(id_tabela as string) id_tabela,
     safe_cast(nome_coluna as string) nome_coluna,


### PR DESCRIPTION
O dicionário do CNPJ estava com 3 pequenos problemas. Um deles foi relatads por um usuário via hubspot e os outros são pequenos ajustes que fiz revisando a tabela

1. existiam 2 colunas que estavam nos dicionários mas não existiam nas tabelas. `empresas - id_pais` e `empresas - motivo_situacao_cadastral
2. inclui o valor de uma chave que estava constando como não se não existisse nos dicionários atuais, mas que encontrei por lá (98 de motivo_situacao_cadastral)
3. padronizei o texto para todas as variáveis que não estão constando nos dicionários oficiais (tinham 2 redações)

Uma coisa que seria interessante para que a pipeline de CNPJ ficasse mais fechadinha seria abrir essas tabelas de dicionário de variáveis toda vez que rodasse a pipeline para atualizar os dicionários. Entendo que não é mega urgente, pq é algo que demora para ter atualizações, mas como é nossa principal tabela, sinto que pode valer a pena em algum momento olhar para isso. @folhesgabriel vc gostaria que eu registrasse essa questão de atualização dos dicionários em algum outro lugar além dessa issue?