### PR TITLE
[data] Update br_tse_filiacao_partidaria__microdados - 2026

### DIFF
--- a/models/br_tse_filiacao_partidaria/br_tse_filiacao_partidaria__microdados.sql
+++ b/models/br_tse_filiacao_partidaria/br_tse_filiacao_partidaria__microdados.sql
@@ -11,6 +11,7 @@
         cluster_by=["sigla_uf"],
     )
 }}
+
 with
     tabela as (
         select

--- a/models/br_tse_filiacao_partidaria/schema.yml
+++ b/models/br_tse_filiacao_partidaria/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: br_tse_filiacao_partidaria__microdados_antigos
     description: Microdados antigos de filiação partidária do TSE.
     tests:
-      - custom_not_null_proportion_multiple_columns:
+      - not_null_proportion_multiple_columns:
           at_least: 0.10
           ignore_values: [data_regularizacao]
     columns:
@@ -72,7 +72,7 @@ models:
   - name: br_tse_filiacao_partidaria__microdados
     description: Microdados de filiação partidária do TSE.
     tests:
-      - custom_not_null_proportion_multiple_columns:
+      - not_null_proportion_multiple_columns:
           at_least: 0.55
           ignore_values:
             - data_desfiliacao
@@ -159,7 +159,7 @@ models:
               to: ref('br_bd_diretorios_data_tempo__data')
               field: data.data
       - name: data_extracao
-        description: Data de extração da linha
+        description: Data de extração
         tests:
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__data')


### PR DESCRIPTION
# [data] Update br_tse_filiacao_partidaria__microdados - 2026
## Descrição

Este PR atualiza o modelo `microdados` (`br_tse_filiacao_partidaria`) com a inclusão de uma nova carga de dados mais recente.

Anteriormente, o modelo considerava dados com `data_extracao = '2024-10-21'`, cobrindo informações até o ano de 2024.
Com esta atualização, passa a incluir também a extração com `data_extracao = '2026-04-01'`, incorporando dados atualizados até 2026.

---

* Inclusão de nova partição de dados:

  * `data_extracao = '2026-04-01'`
* Expansão do período histórico disponível no modelo (de 2024 para 2026)
* Manutenção da lógica atual de transformação e deduplicação

---

## Observações

O modelo continua utilizando a lógica de deduplicação baseada em:

```sql
row_number() over (
  partition by registro_filiacao 
  order by data_extracao desc
)
```
