### PR TITLE
[chore] update code_owners: remove trick and equipe_pipelines references

### DIFF
--- a/pipelines/crawler/anatel/banda_larga_fixa/flows.py
+++ b/pipelines/crawler/anatel/banda_larga_fixa/flows.py
@@ -21,7 +21,7 @@ from pipelines.utils.tasks import (
 )
 
 with Flow(
-    name="BD template - Anatel Banda Larga Fixa", code_owners=["trick"]
+    name="BD template - Anatel Banda Larga Fixa", code_owners=["equipe_dados"]
 ) as flow_anatel_banda_larga_fixa:
     # Parameters
     dataset_id = Parameter(

--- a/pipelines/crawler/anatel/telefonia_movel/flows.py
+++ b/pipelines/crawler/anatel/telefonia_movel/flows.py
@@ -25,7 +25,7 @@ from pipelines.utils.tasks import (
 )
 
 with Flow(
-    name="BD template - Anatel Telefonia Móvel", code_owners=["trick"]
+    name="BD template - Anatel Telefonia Móvel", code_owners=["equipe_dados"]
 ) as flow_anatel_telefonia_movel:
     # Parameters
     dataset_id = Parameter(

--- a/pipelines/crawler/camara_dados_abertos/flows.py
+++ b/pipelines/crawler/camara_dados_abertos/flows.py
@@ -25,7 +25,7 @@ from pipelines.utils.tasks import (
 # ------------------------------ TABLES UNIVERSAL -------------------------------------
 
 with Flow(
-    name="BD template - Camara Dados Abertos", code_owners=["trick"]
+    name="BD template - Camara Dados Abertos", code_owners=["equipe_dados"]
 ) as flow_camara_dados_abertos:
     # Parameters
     dataset_id = Parameter(

--- a/pipelines/crawler/cgu/flows.py
+++ b/pipelines/crawler/cgu/flows.py
@@ -27,7 +27,7 @@ from pipelines.utils.tasks import (
 )
 
 with Flow(
-    name="CGU - Cartão de Pagamento", code_owners=["trick"]
+    name="CGU - Cartão de Pagamento", code_owners=["equipe_dados"]
 ) as flow_cgu_cartao_pagamento:
     dataset_id = Parameter(
         "dataset_id", default="br_cgu_cartao_pagamento", required=True
@@ -121,7 +121,7 @@ flow_cgu_cartao_pagamento.run_config = KubernetesRun(
 
 with Flow(
     name="CGU - Servidores Públicos do Executivo Federal",
-    code_owners=["trick"],
+    code_owners=["equipe_dados"],
 ) as flow_cgu_servidores_publicos:
     dataset_id = Parameter(
         "dataset_id",
@@ -219,7 +219,7 @@ flow_cgu_servidores_publicos.run_config = KubernetesRun(
 # ! ================================== CGU - Licitacao e Contrato =====================================
 
 with Flow(
-    name="CGU - Licitacão e Contrato", code_owners=["trick"]
+    name="CGU - Licitacão e Contrato", code_owners=["equipe_dados"]
 ) as flow_cgu_licitacao_contrato:
     dataset_id = Parameter(
         "dataset_id", default="br_cgu_licitacao_contrato", required=True
@@ -310,7 +310,7 @@ flow_cgu_licitacao_contrato.run_config = KubernetesRun(
 # ! ================================== CGU - Benefícios Cidadão ====================================
 
 with Flow(
-    name="CGU - Benefícios Cidadão", code_owners=["trick"]
+    name="CGU - Benefícios Cidadão", code_owners=["equipe_dados"]
 ) as flow_cgu_beneficios_cidadao:
     dataset_id = Parameter(
         "dataset_id", default="br_cgu_beneficios_cidadao", required=True

--- a/pipelines/crawler/datasus/flows.py
+++ b/pipelines/crawler/datasus/flows.py
@@ -228,7 +228,7 @@ flow_siasus.run_config = KubernetesRun(
 )
 
 
-with Flow(name="DATASUS-SIH", code_owners=["equipe_pipelines"]) as flow_sihsus:
+with Flow(name="DATASUS-SIH", code_owners=["equipe_dados"]) as flow_sihsus:
     # Parameters
     dataset_id = Parameter("dataset_id", default="br_ms_sih", required=False)
     table_id = Parameter("table_id", default="aihs_reduzidas", required=False)
@@ -325,7 +325,7 @@ flow_sihsus.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 flow_sihsus.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
 
 
-with Flow(name="DATASUS-SINAN", code_owners=["trick"]) as flow_sinan:
+with Flow(name="DATASUS-SINAN", code_owners=["equipe_dados"]) as flow_sinan:
     dataset_id = Parameter("dataset_id", default="br_ms_sinan", required=True)
     table_id = Parameter(
         "table_id", default="microdados_dengue", required=True

--- a/pipelines/datasets/br_anatel_banda_larga_fixa/flows.py
+++ b/pipelines/datasets/br_anatel_banda_larga_fixa/flows.py
@@ -23,7 +23,7 @@ br_anatel_banda_larga_fixa__microdados = deepcopy(flow_anatel_banda_larga_fixa)
 br_anatel_banda_larga_fixa__microdados.name = (
     "br_anatel_banda_larga_fixa.microdados"
 )
-br_anatel_banda_larga_fixa__microdados.code_owners = ["trick"]
+br_anatel_banda_larga_fixa__microdados.code_owners = ["equipe_dados"]
 br_anatel_banda_larga_fixa__microdados.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -41,7 +41,7 @@ br_anatel_banda_larga_fixa__densidade_uf = deepcopy(
 br_anatel_banda_larga_fixa__densidade_uf.name = (
     "br_anatel_banda_larga_fixa.densidade_uf"
 )
-br_anatel_banda_larga_fixa__densidade_uf.code_owners = ["trick"]
+br_anatel_banda_larga_fixa__densidade_uf.code_owners = ["equipe_dados"]
 br_anatel_banda_larga_fixa__densidade_uf.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -59,7 +59,7 @@ br_anatel_banda_larga_fixa__densidade_brasil = deepcopy(
 br_anatel_banda_larga_fixa__densidade_brasil.name = (
     "br_anatel_banda_larga_fixa.densidade_brasil"
 )
-br_anatel_banda_larga_fixa__densidade_brasil.code_owners = ["trick"]
+br_anatel_banda_larga_fixa__densidade_brasil.code_owners = ["equipe_dados"]
 br_anatel_banda_larga_fixa__densidade_brasil.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -77,7 +77,7 @@ br_anatel_banda_larga_fixa__densidade_municipio = deepcopy(
 br_anatel_banda_larga_fixa__densidade_municipio.name = (
     "br_anatel_banda_larga_fixa.densidade_municipio"
 )
-br_anatel_banda_larga_fixa__densidade_municipio.code_owners = ["trick"]
+br_anatel_banda_larga_fixa__densidade_municipio.code_owners = ["equipe_dados"]
 br_anatel_banda_larga_fixa__densidade_municipio.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )

--- a/pipelines/datasets/br_anatel_telefonia_movel/flows.py
+++ b/pipelines/datasets/br_anatel_telefonia_movel/flows.py
@@ -23,7 +23,7 @@ br_anatel_telefonia_movel__microdados = deepcopy(flow_anatel_telefonia_movel)
 br_anatel_telefonia_movel__microdados.name = (
     "br_anatel_telefonia_movel.microdados"
 )
-br_anatel_telefonia_movel__microdados.code_owners = ["trick"]
+br_anatel_telefonia_movel__microdados.code_owners = ["equipe_dados"]
 br_anatel_telefonia_movel__microdados.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -42,7 +42,7 @@ br_anatel_telefonia_movel__densidade_municipio = deepcopy(
 br_anatel_telefonia_movel__densidade_municipio.name = (
     "br_anatel_telefonia_movel.densidade_municipio"
 )
-br_anatel_telefonia_movel__densidade_municipio.code_owners = ["trick"]
+br_anatel_telefonia_movel__densidade_municipio.code_owners = ["equipe_dados"]
 br_anatel_telefonia_movel__densidade_municipio.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -59,7 +59,7 @@ br_anatel_telefonia_movel__densidade_uf = deepcopy(flow_anatel_telefonia_movel)
 br_anatel_telefonia_movel__densidade_uf.name = (
     "br_anatel_telefonia_movel.densidade_uf"
 )
-br_anatel_telefonia_movel__densidade_uf.code_owners = ["trick"]
+br_anatel_telefonia_movel__densidade_uf.code_owners = ["equipe_dados"]
 br_anatel_telefonia_movel__densidade_uf.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -78,7 +78,7 @@ br_anatel_telefonia_movel__densidade_brasil = deepcopy(
 br_anatel_telefonia_movel__densidade_brasil.name = (
     "br_anatel_telefonia_movel.densidade_brasil"
 )
-br_anatel_telefonia_movel__densidade_brasil.code_owners = ["trick"]
+br_anatel_telefonia_movel__densidade_brasil.code_owners = ["equipe_dados"]
 br_anatel_telefonia_movel__densidade_brasil.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )

--- a/pipelines/datasets/br_anp_precos_combustiveis/flows.py
+++ b/pipelines/datasets/br_anp_precos_combustiveis/flows.py
@@ -28,7 +28,7 @@ from pipelines.utils.tasks import (
 )
 
 with Flow(
-    name="br_anp_precos_combustiveis.microdados", code_owners=["trick"]
+    name="br_anp_precos_combustiveis.microdados", code_owners=["equipe_dados"]
 ) as anp_microdados:
     dataset_id = Parameter(
         "dataset_id", default="br_anp_precos_combustiveis", required=True

--- a/pipelines/datasets/br_b3_cotacoes/flows.py
+++ b/pipelines/datasets/br_b3_cotacoes/flows.py
@@ -17,7 +17,9 @@ from pipelines.utils.tasks import (
     run_dbt,
 )
 
-with Flow(name="br_b3_cotacoes.cotacoes", code_owners=["trick"]) as cotacoes:
+with Flow(
+    name="br_b3_cotacoes.cotacoes", code_owners=["equipe_dados"]
+) as cotacoes:
     # Parameters
     dataset_id = Parameter(
         "dataset_id", default="br_b3_cotacoes", required=True

--- a/pipelines/datasets/br_camara_dados_abertos/flows.py
+++ b/pipelines/datasets/br_camara_dados_abertos/flows.py
@@ -41,7 +41,7 @@ from pipelines.datasets.br_camara_dados_abertos.schedules import (
 # ! -- > Flow: br_camara_dados_abertos__votacao
 br_camara_dados_abertos__votacao = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__votacao.name = "br_camara_dados_abertos.votacao"
-br_camara_dados_abertos__votacao.code_owners = ["trick"]
+br_camara_dados_abertos__votacao.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__votacao.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -58,7 +58,7 @@ br_camara_dados_abertos__votacao_objeto = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__votacao_objeto.name = (
     "br_camara_dados_abertos.votacao_objeto"
 )
-br_camara_dados_abertos__votacao_objeto.code_owners = ["trick"]
+br_camara_dados_abertos__votacao_objeto.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__votacao_objeto.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -77,7 +77,9 @@ br_camara_dados_abertos__votacao_orientacao_bancada = deepcopy(
 br_camara_dados_abertos__votacao_orientacao_bancada.name = (
     "br_camara_dados_abertos.votacao_orientacao_bancada"
 )
-br_camara_dados_abertos__votacao_orientacao_bancada.code_owners = ["trick"]
+br_camara_dados_abertos__votacao_orientacao_bancada.code_owners = [
+    "equipe_dados"
+]
 br_camara_dados_abertos__votacao_orientacao_bancada.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -96,7 +98,7 @@ br_camara_dados_abertos__votacao_parlamentar = deepcopy(
 br_camara_dados_abertos__votacao_parlamentar.name = (
     "br_camara_dados_abertos.votacao_parlamentar"
 )
-br_camara_dados_abertos__votacao_parlamentar.code_owners = ["trick"]
+br_camara_dados_abertos__votacao_parlamentar.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__votacao_parlamentar.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -115,7 +117,7 @@ br_camara_dados_abertos__votacao_proposicao = deepcopy(
 br_camara_dados_abertos__votacao_proposicao.name = (
     "br_camara_dados_abertos.votacao_proposicao"
 )
-br_camara_dados_abertos__votacao_proposicao.code_owners = ["trick"]
+br_camara_dados_abertos__votacao_proposicao.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__votacao_proposicao.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -130,7 +132,7 @@ br_camara_dados_abertos__votacao_proposicao.schedule = (
 
 br_camara_dados_abertos__deputado = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__deputado.name = "br_camara_dados_abertos.deputado"
-br_camara_dados_abertos__deputado.code_owners = ["trick"]
+br_camara_dados_abertos__deputado.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__deputado.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -149,7 +151,7 @@ br_camara_dados_abertos__deputado_ocupacao = deepcopy(
 br_camara_dados_abertos__deputado_ocupacao.name = (
     "br_camara_dados_abertos.deputado_ocupacao"
 )
-br_camara_dados_abertos__deputado_ocupacao.code_owners = ["trick"]
+br_camara_dados_abertos__deputado_ocupacao.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__deputado_ocupacao.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -168,7 +170,7 @@ br_camara_dados_abertos__deputado_profissao = deepcopy(
 br_camara_dados_abertos__deputado_profissao.name = (
     "br_camara_dados_abertos.deputado_profissao"
 )
-br_camara_dados_abertos__deputado_profissao.code_owners = ["trick"]
+br_camara_dados_abertos__deputado_profissao.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__deputado_profissao.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -187,7 +189,7 @@ br_camara_dados_abertos__proposicao_microdados = deepcopy(
 br_camara_dados_abertos__proposicao_microdados.name = (
     "br_camara_dados_abertos.proposicao_microdados"
 )
-br_camara_dados_abertos__proposicao_microdados.code_owners = ["trick"]
+br_camara_dados_abertos__proposicao_microdados.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__proposicao_microdados.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -204,7 +206,7 @@ br_camara_dados_abertos__proposicao_autor = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__proposicao_autor.name = (
     "br_camara_dados_abertos.proposicao_autor"
 )
-br_camara_dados_abertos__proposicao_autor.code_owners = ["trick"]
+br_camara_dados_abertos__proposicao_autor.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__proposicao_autor.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -221,7 +223,7 @@ br_camara_dados_abertos__proposicao_tema = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__proposicao_tema.name = (
     "br_camara_dados_abertos.proposicao_tema"
 )
-br_camara_dados_abertos__proposicao_tema.code_owners = ["trick"]
+br_camara_dados_abertos__proposicao_tema.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__proposicao_tema.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -236,7 +238,7 @@ br_camara_dados_abertos__proposicao_tema.schedule = (
 
 br_camara_dados_abertos__orgao = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__orgao.name = "br_camara_dados_abertos.orgao"
-br_camara_dados_abertos__orgao.code_owners = ["trick"]
+br_camara_dados_abertos__orgao.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__orgao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_camara_dados_abertos__orgao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -251,7 +253,7 @@ br_camara_dados_abertos__orgao_deputado = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__orgao_deputado.name = (
     "br_camara_dados_abertos.orgao_deputado"
 )
-br_camara_dados_abertos__orgao_deputado.code_owners = ["trick"]
+br_camara_dados_abertos__orgao_deputado.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__orgao_deputado.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -266,7 +268,7 @@ br_camara_dados_abertos__orgao_deputado.schedule = (
 
 br_camara_dados_abertos__evento = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__evento.name = "br_camara_dados_abertos.evento"
-br_camara_dados_abertos__evento.code_owners = ["trick"]
+br_camara_dados_abertos__evento.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__evento.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_camara_dados_abertos__evento.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -281,7 +283,7 @@ br_camara_dados_abertos__evento_orgao = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__evento_orgao.name = (
     "br_camara_dados_abertos.evento_orgao"
 )
-br_camara_dados_abertos__evento_orgao.code_owners = ["trick"]
+br_camara_dados_abertos__evento_orgao.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__evento_orgao.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -300,7 +302,9 @@ br_camara_dados_abertos__evento_presenca_deputado = deepcopy(
 br_camara_dados_abertos__evento_presenca_deputado.name = (
     "br_camara_dados_abertos.evento_presenca_deputado"
 )
-br_camara_dados_abertos__evento_presenca_deputado.code_owners = ["trick"]
+br_camara_dados_abertos__evento_presenca_deputado.code_owners = [
+    "equipe_dados"
+]
 br_camara_dados_abertos__evento_presenca_deputado.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -319,7 +323,7 @@ br_camara_dados_abertos__evento_requerimento = deepcopy(
 br_camara_dados_abertos__evento_requerimento.name = (
     "br_camara_dados_abertos.evento_requerimento"
 )
-br_camara_dados_abertos__evento_requerimento.code_owners = ["trick"]
+br_camara_dados_abertos__evento_requerimento.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__evento_requerimento.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -336,7 +340,7 @@ br_camara_dados_abertos__funcionario = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__funcionario.name = (
     "br_camara_dados_abertos.funcionario"
 )
-br_camara_dados_abertos__funcionario.code_owners = ["trick"]
+br_camara_dados_abertos__funcionario.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__funcionario.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -351,7 +355,7 @@ br_camara_dados_abertos__funcionario.schedule = (
 
 br_camara_dados_abertos__frente = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__frente.name = "br_camara_dados_abertos.frente"
-br_camara_dados_abertos__frente.code_owners = ["trick"]
+br_camara_dados_abertos__frente.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__frente.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_camara_dados_abertos__frente.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -366,7 +370,7 @@ br_camara_dados_abertos__frente_deputado = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__frente_deputado.name = (
     "br_camara_dados_abertos.frente_deputado"
 )
-br_camara_dados_abertos__frente_deputado.code_owners = ["trick"]
+br_camara_dados_abertos__frente_deputado.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__frente_deputado.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -381,7 +385,7 @@ br_camara_dados_abertos__frente_deputado.schedule = (
 
 br_camara_dados_abertos__licitacao = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__licitacao.name = "br_camara_dados_abertos.licitacao"
-br_camara_dados_abertos__licitacao.code_owners = ["trick"]
+br_camara_dados_abertos__licitacao.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__licitacao.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -400,7 +404,7 @@ br_camara_dados_abertos__licitacao_contrato = deepcopy(
 br_camara_dados_abertos__licitacao_contrato.name = (
     "br_camara_dados_abertos.licitacao_contrato"
 )
-br_camara_dados_abertos__licitacao_contrato.code_owners = ["trick"]
+br_camara_dados_abertos__licitacao_contrato.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__licitacao_contrato.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -417,7 +421,7 @@ br_camara_dados_abertos__licitacao_item = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__licitacao_item.name = (
     "br_camara_dados_abertos.licitacao_item"
 )
-br_camara_dados_abertos__licitacao_item.code_owners = ["trick"]
+br_camara_dados_abertos__licitacao_item.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__licitacao_item.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -436,7 +440,7 @@ br_camara_dados_abertos__licitacao_proposta = deepcopy(
 br_camara_dados_abertos__licitacao_proposta.name = (
     "br_camara_dados_abertos.licitacao_proposta"
 )
-br_camara_dados_abertos__licitacao_proposta.code_owners = ["trick"]
+br_camara_dados_abertos__licitacao_proposta.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__licitacao_proposta.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -453,7 +457,7 @@ br_camara_dados_abertos__licitacao_pedido = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__licitacao_pedido.name = (
     "br_camara_dados_abertos.licitacao_pedido"
 )
-br_camara_dados_abertos__licitacao_pedido.code_owners = ["trick"]
+br_camara_dados_abertos__licitacao_pedido.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__licitacao_pedido.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -468,7 +472,7 @@ br_camara_dados_abertos__licitacao_pedido.schedule = (
 
 br_camara_dados_abertos__despesa = deepcopy(flow_camara_dados_abertos)
 br_camara_dados_abertos__despesa.name = "br_camara_dados_abertos.despesa"
-br_camara_dados_abertos__despesa.code_owners = ["trick"]
+br_camara_dados_abertos__despesa.code_owners = ["equipe_dados"]
 br_camara_dados_abertos__despesa.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )

--- a/pipelines/datasets/br_cgu_beneficios_cidadao/flows.py
+++ b/pipelines/datasets/br_cgu_beneficios_cidadao/flows.py
@@ -16,7 +16,7 @@ br_cgu_beneficios_cidadao_bolsa_familia = deepcopy(flow_cgu_beneficios_cidadao)
 br_cgu_beneficios_cidadao_bolsa_familia.name = (
     "br_cgu_beneficios_cidadao.novo_bolsa_familia"
 )
-br_cgu_beneficios_cidadao_bolsa_familia.code_owners = ["trick"]
+br_cgu_beneficios_cidadao_bolsa_familia.code_owners = ["equipe_dados"]
 br_cgu_beneficios_cidadao_bolsa_familia.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -33,7 +33,7 @@ br_cgu_beneficios_cidadao__garantia_safra = deepcopy(
 br_cgu_beneficios_cidadao__garantia_safra.name = (
     "br_cgu_beneficios_cidadao.garantia_safra"
 )
-br_cgu_beneficios_cidadao__garantia_safra.code_owners = ["trick"]
+br_cgu_beneficios_cidadao__garantia_safra.code_owners = ["equipe_dados"]
 br_cgu_beneficios_cidadao__garantia_safra.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -45,7 +45,7 @@ br_cgu_beneficios_cidadao__garantia_safra.schedule = every_day_garantia_safra
 # ! - > br_cgu_beneficios_cidadao__bpc
 br_cgu_beneficios_cidadao__bpc = deepcopy(flow_cgu_beneficios_cidadao)
 br_cgu_beneficios_cidadao__bpc.name = "br_cgu_beneficios_cidadao.bpc"
-br_cgu_beneficios_cidadao__bpc.code_owners = ["trick"]
+br_cgu_beneficios_cidadao__bpc.code_owners = ["equipe_dados"]
 br_cgu_beneficios_cidadao__bpc.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_cgu_beneficios_cidadao__bpc.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value

--- a/pipelines/datasets/br_cgu_cartao_pagamento/flows.py
+++ b/pipelines/datasets/br_cgu_cartao_pagamento/flows.py
@@ -15,7 +15,7 @@ br_cgu_cartao_pagamento__governo_federal = copy(flow_cgu_cartao_pagamento)
 br_cgu_cartao_pagamento__governo_federal.name = (
     "br_cgu_cartao_pagamento.governo_federal"
 )
-br_cgu_cartao_pagamento__governo_federal.code_owners = ["trick"]
+br_cgu_cartao_pagamento__governo_federal.code_owners = ["equipe_dados"]
 br_cgu_cartao_pagamento__governo_federal.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -30,7 +30,7 @@ br_cgu_cartao_pagamento__defesa_civil = copy(flow_cgu_cartao_pagamento)
 br_cgu_cartao_pagamento__defesa_civil.name = (
     "br_cgu_cartao_pagamento.defesa_civil"
 )
-br_cgu_cartao_pagamento__defesa_civil.code_owners = ["trick"]
+br_cgu_cartao_pagamento__defesa_civil.code_owners = ["equipe_dados"]
 br_cgu_cartao_pagamento__defesa_civil.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -47,7 +47,7 @@ br_cgu_cartao_pagamento__compras_centralizadas = copy(
 br_cgu_cartao_pagamento__compras_centralizadas.name = (
     "br_cgu_cartao_pagamento.compras_centralizadas"
 )
-br_cgu_cartao_pagamento__compras_centralizadas.code_owners = ["trick"]
+br_cgu_cartao_pagamento__compras_centralizadas.code_owners = ["equipe_dados"]
 br_cgu_cartao_pagamento__compras_centralizadas.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )

--- a/pipelines/datasets/br_cgu_licitacao_contrato/flows.py
+++ b/pipelines/datasets/br_cgu_licitacao_contrato/flows.py
@@ -26,7 +26,7 @@ br_cgu_licitacao_contrato__contrato_compra = deepcopy(
 br_cgu_licitacao_contrato__contrato_compra.name = (
     "br_cgu_licitacao_contrato.contrato_compra"
 )
-br_cgu_licitacao_contrato__contrato_compra.code_owners = ["trick"]
+br_cgu_licitacao_contrato__contrato_compra.code_owners = ["equipe_dados"]
 br_cgu_licitacao_contrato__contrato_compra.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -44,7 +44,7 @@ br_cgu_licitacao_contrato__contrato_item = deepcopy(
 br_cgu_licitacao_contrato__contrato_item.name = (
     "br_cgu_licitacao_contrato.contrato_item"
 )
-br_cgu_licitacao_contrato__contrato_item.code_owners = ["trick"]
+br_cgu_licitacao_contrato__contrato_item.code_owners = ["equipe_dados"]
 br_cgu_licitacao_contrato__contrato_item.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -61,7 +61,9 @@ br_cgu_licitacao_contrato__contrato_termo_aditivo = deepcopy(
 br_cgu_licitacao_contrato__contrato_termo_aditivo.name = (
     "br_cgu_licitacao_contrato.contrato_termo_aditivo"
 )
-br_cgu_licitacao_contrato__contrato_termo_aditivo.code_owners = ["trick"]
+br_cgu_licitacao_contrato__contrato_termo_aditivo.code_owners = [
+    "equipe_dados"
+]
 br_cgu_licitacao_contrato__contrato_termo_aditivo.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -79,7 +81,7 @@ br_cgu_licitacao_contrato__licitacao = deepcopy(flow_cgu_licitacao_contrato)
 br_cgu_licitacao_contrato__licitacao.name = (
     "br_cgu_licitacao_contrato.licitacao"
 )
-br_cgu_licitacao_contrato__licitacao.code_owners = ["trick"]
+br_cgu_licitacao_contrato__licitacao.code_owners = ["equipe_dados"]
 br_cgu_licitacao_contrato__licitacao.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -97,7 +99,7 @@ br_cgu_licitacao_contrato__licitacao_empenho = deepcopy(
 br_cgu_licitacao_contrato__licitacao_empenho.name = (
     "br_cgu_licitacao_contrato.licitacao_empenho"
 )
-br_cgu_licitacao_contrato__licitacao_empenho.code_owners = ["trick"]
+br_cgu_licitacao_contrato__licitacao_empenho.code_owners = ["equipe_dados"]
 br_cgu_licitacao_contrato__licitacao_empenho.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -114,7 +116,7 @@ br_cgu_licitacao_contrato__licitacao_item = deepcopy(
 br_cgu_licitacao_contrato__licitacao_item.name = (
     "br_cgu_licitacao_contrato.licitacao_item"
 )
-br_cgu_licitacao_contrato__licitacao_item.code_owners = ["trick"]
+br_cgu_licitacao_contrato__licitacao_item.code_owners = ["equipe_dados"]
 br_cgu_licitacao_contrato__licitacao_item.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -132,7 +134,9 @@ br_cgu_licitacao_contrato__licitacao_participante = deepcopy(
 br_cgu_licitacao_contrato__licitacao_participante.name = (
     "br_cgu_licitacao_contrato.licitacao_participante"
 )
-br_cgu_licitacao_contrato__licitacao_participante.code_owners = ["trick"]
+br_cgu_licitacao_contrato__licitacao_participante.code_owners = [
+    "equipe_dados"
+]
 br_cgu_licitacao_contrato__licitacao_participante.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )

--- a/pipelines/datasets/br_cgu_servidores_executivo_federal/flows.py
+++ b/pipelines/datasets/br_cgu_servidores_executivo_federal/flows.py
@@ -23,7 +23,7 @@ br_cgu_servidores_federal__afastamentos = deepcopy(
 br_cgu_servidores_federal__afastamentos.name = (
     "br_cgu_servidores_executivo_federal.afastamentos"
 )
-br_cgu_servidores_federal__afastamentos.code_owners = ["trick"]
+br_cgu_servidores_federal__afastamentos.code_owners = ["equipe_dados"]
 br_cgu_servidores_federal__afastamentos.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -40,7 +40,7 @@ br_cgu_servidores_federal__cadastro_aposentados = deepcopy(
 br_cgu_servidores_federal__cadastro_aposentados.name = (
     "br_cgu_servidores_executivo_federal.cadastro_aposentados"
 )
-br_cgu_servidores_federal__cadastro_aposentados.code_owners = ["trick"]
+br_cgu_servidores_federal__cadastro_aposentados.code_owners = ["equipe_dados"]
 br_cgu_servidores_federal__cadastro_aposentados.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -59,7 +59,7 @@ br_cgu_servidores_federal__cadastro_pensionistas = deepcopy(
 br_cgu_servidores_federal__cadastro_pensionistas.name = (
     "br_cgu_servidores_executivo_federal.cadastro_pensionistas"
 )
-br_cgu_servidores_federal__cadastro_pensionistas.code_owners = ["trick"]
+br_cgu_servidores_federal__cadastro_pensionistas.code_owners = ["equipe_dados"]
 br_cgu_servidores_federal__cadastro_pensionistas.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -99,7 +99,7 @@ br_cgu_servidores_federal__cadastro_servidores = deepcopy(
 br_cgu_servidores_federal__cadastro_servidores.name = (
     "br_cgu_servidores_executivo_federal.cadastro_servidores"
 )
-br_cgu_servidores_federal__cadastro_servidores.code_owners = ["trick"]
+br_cgu_servidores_federal__cadastro_servidores.code_owners = ["equipe_dados"]
 br_cgu_servidores_federal__cadastro_servidores.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -116,7 +116,7 @@ br_cgu_servidores_federal__observacoes = deepcopy(flow_cgu_servidores_publicos)
 br_cgu_servidores_federal__observacoes.name = (
     "br_cgu_servidores_executivo_federal.observacoes"
 )
-br_cgu_servidores_federal__observacoes.code_owners = ["trick"]
+br_cgu_servidores_federal__observacoes.code_owners = ["equipe_dados"]
 br_cgu_servidores_federal__observacoes.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -131,7 +131,7 @@ br_cgu_servidores_federal__remuneracao = deepcopy(flow_cgu_servidores_publicos)
 br_cgu_servidores_federal__remuneracao.name = (
     "br_cgu_servidores_executivo_federal.remuneracao"
 )
-br_cgu_servidores_federal__remuneracao.code_owners = ["trick"]
+br_cgu_servidores_federal__remuneracao.code_owners = ["equipe_dados"]
 br_cgu_servidores_federal__remuneracao.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )

--- a/pipelines/datasets/br_cvm_administradores_carteira/flows.py
+++ b/pipelines/datasets/br_cvm_administradores_carteira/flows.py
@@ -32,7 +32,7 @@ URL = "http://dados.cvm.gov.br/dados/ADM_CART/CAD/DADOS/cad_adm_cart.zip"
 
 with Flow(
     name="br_cvm_administradores_carteira.responsavel",
-    code_owners=["equipe_pipelines"],
+    code_owners=["equipe_dados"],
 ) as br_cvm_adm_car_res:
     # Parameters
     dataset_id = Parameter(
@@ -87,7 +87,7 @@ br_cvm_adm_car_res.schedule = schedule_responsavel
 
 with Flow(
     "br_cvm_administradores_carteira.pessoa_fisica",
-    code_owners=["equipe_pipelines"],
+    code_owners=["equipe_dados"],
 ) as br_cvm_adm_car_pes_fis:
     # Parameters
     dataset_id = Parameter(
@@ -161,7 +161,7 @@ br_cvm_adm_car_pes_fis.schedule = schedule_fisica
 
 with Flow(
     "br_cvm_administradores_carteira.pessoa_juridica",
-    code_owners=["equipe_pipelines"],
+    code_owners=["equipe_dados"],
 ) as br_cvm_adm_car_pes_jur:
     # Parameters
     dataset_id = Parameter(

--- a/pipelines/datasets/br_cvm_oferta_publica_distribuicao/flows.py
+++ b/pipelines/datasets/br_cvm_oferta_publica_distribuicao/flows.py
@@ -28,7 +28,7 @@ URL = "http://dados.cvm.gov.br/dados/OFERTA/DISTRIB/DADOS/oferta_distribuicao.zi
 
 with Flow(
     name="br_cvm_oferta_publica_distribuicao.dia",
-    code_owners=["equipe_pipelines"],
+    code_owners=["equipe_dados"],
 ) as br_cvm_ofe_pub_dis_dia:
     # Parameters
     dataset_id = Parameter(

--- a/pipelines/datasets/br_ibge_inpc/flows.py
+++ b/pipelines/datasets/br_ibge_inpc/flows.py
@@ -15,7 +15,7 @@ from pipelines.datasets.br_ibge_inpc.schedules import (
 
 br_ibge_inpc_mes_categoria_brasil = deepcopy(flow_ibge)
 br_ibge_inpc_mes_categoria_brasil.name = "br_ibge_inpc.mes_categoria_brasil"
-br_ibge_inpc_mes_categoria_brasil.code_owners = ["trick"]
+br_ibge_inpc_mes_categoria_brasil.code_owners = ["equipe_dados"]
 br_ibge_inpc_mes_categoria_brasil.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -29,7 +29,7 @@ br_ibge_inpc_mes_categoria_brasil.schedule = (
 
 br_ibge_inpc_mes_categoria_rm = deepcopy(flow_ibge)
 br_ibge_inpc_mes_categoria_rm.name = "br_ibge_inpc.mes_categoria_rm"
-br_ibge_inpc_mes_categoria_rm.code_owners = ["trick"]
+br_ibge_inpc_mes_categoria_rm.code_owners = ["equipe_dados"]
 br_ibge_inpc_mes_categoria_rm.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_inpc_mes_categoria_rm.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -40,7 +40,7 @@ br_ibge_inpc_mes_categoria_municipio = deepcopy(flow_ibge)
 br_ibge_inpc_mes_categoria_municipio.name = (
     "br_ibge_inpc.mes_categoria_municipio"
 )
-br_ibge_inpc_mes_categoria_municipio.code_owners = ["trick"]
+br_ibge_inpc_mes_categoria_municipio.code_owners = ["equipe_dados"]
 br_ibge_inpc_mes_categoria_municipio.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -54,7 +54,7 @@ br_ibge_inpc_mes_categoria_municipio.schedule = (
 
 br_ibge_inpc_mes_brasil = deepcopy(flow_ibge)
 br_ibge_inpc_mes_brasil.name = "br_ibge_inpc.mes_brasil"
-br_ibge_inpc_mes_brasil.code_owners = ["trick"]
+br_ibge_inpc_mes_brasil.code_owners = ["equipe_dados"]
 br_ibge_inpc_mes_brasil.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_inpc_mes_brasil.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value

--- a/pipelines/datasets/br_ibge_ipca/flows.py
+++ b/pipelines/datasets/br_ibge_ipca/flows.py
@@ -16,7 +16,7 @@ from pipelines.datasets.br_ibge_ipca.schedules import (
 
 br_ibge_ipca_mes_categoria_brasil = deepcopy(flow_ibge)
 br_ibge_ipca_mes_categoria_brasil.name = "br_ibge_ipca.mes_categoria_brasil"
-br_ibge_ipca_mes_categoria_brasil.code_owners = ["trick"]
+br_ibge_ipca_mes_categoria_brasil.code_owners = ["equipe_dados"]
 br_ibge_ipca_mes_categoria_brasil.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -30,7 +30,7 @@ br_ibge_ipca_mes_categoria_brasil.schedule = (
 
 br_ibge_ipca_mes_categoria_rm = deepcopy(flow_ibge)
 br_ibge_ipca_mes_categoria_rm.name = "br_ibge_ipca.mes_categoria_rm"
-br_ibge_ipca_mes_categoria_rm.code_owners = ["trick"]
+br_ibge_ipca_mes_categoria_rm.code_owners = ["equipe_dados"]
 br_ibge_ipca_mes_categoria_rm.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca_mes_categoria_rm.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -41,7 +41,7 @@ br_ibge_ipca_mes_categoria_municipio = deepcopy(flow_ibge)
 br_ibge_ipca_mes_categoria_municipio.name = (
     "br_ibge_ipca.mes_categoria_municipio"
 )
-br_ibge_ipca_mes_categoria_municipio.code_owners = ["trick"]
+br_ibge_ipca_mes_categoria_municipio.code_owners = ["equipe_dados"]
 br_ibge_ipca_mes_categoria_municipio.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -55,7 +55,7 @@ br_ibge_ipca_mes_categoria_municipio.schedule = (
 
 br_ibge_ipca_mes_brasil = deepcopy(flow_ibge)
 br_ibge_ipca_mes_brasil.name = "br_ibge_ipca.mes_brasil"
-br_ibge_ipca_mes_brasil.code_owners = ["trick"]
+br_ibge_ipca_mes_brasil.code_owners = ["equipe_dados"]
 br_ibge_ipca_mes_brasil.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca_mes_brasil.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value

--- a/pipelines/datasets/br_ibge_ipca15/flows.py
+++ b/pipelines/datasets/br_ibge_ipca15/flows.py
@@ -17,7 +17,7 @@ br_ibge_ipca15_mes_categoria_brasil = deepcopy(flow_ibge)
 br_ibge_ipca15_mes_categoria_brasil.name = (
     "br_ibge_ipca15.mes_categoria_brasil"
 )
-br_ibge_ipca15_mes_categoria_brasil.code_owners = ["trick"]
+br_ibge_ipca15_mes_categoria_brasil.code_owners = ["equipe_dados"]
 br_ibge_ipca15_mes_categoria_brasil.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -31,7 +31,7 @@ br_ibge_ipca15_mes_categoria_brasil.schedule = (
 
 br_ibge_ipca15_mes_categoria_rm = deepcopy(flow_ibge)
 br_ibge_ipca15_mes_categoria_rm.name = "br_ibge_ipca15.mes_categoria_rm"
-br_ibge_ipca15_mes_categoria_rm.code_owners = ["trick"]
+br_ibge_ipca15_mes_categoria_rm.code_owners = ["equipe_dados"]
 br_ibge_ipca15_mes_categoria_rm.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca15_mes_categoria_rm.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -44,7 +44,7 @@ br_ibge_ipca15_mes_categoria_municipio = deepcopy(flow_ibge)
 br_ibge_ipca15_mes_categoria_municipio.name = (
     "br_ibge_ipca15.mes_categoria_municipio"
 )
-br_ibge_ipca15_mes_categoria_municipio.code_owners = ["trick"]
+br_ibge_ipca15_mes_categoria_municipio.code_owners = ["equipe_dados"]
 br_ibge_ipca15_mes_categoria_municipio.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -58,7 +58,7 @@ br_ibge_ipca15_mes_categoria_municipio.schedule = (
 
 br_ibge_ipca15_mes_brasil = deepcopy(flow_ibge)
 br_ibge_ipca15_mes_brasil.name = "br_ibge_ipca15.mes_brasil"
-br_ibge_ipca15_mes_brasil.code_owners = ["trick"]
+br_ibge_ipca15_mes_brasil.code_owners = ["equipe_dados"]
 br_ibge_ipca15_mes_brasil.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ibge_ipca15_mes_brasil.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value

--- a/pipelines/datasets/br_inmet_bdmep/flows.py
+++ b/pipelines/datasets/br_inmet_bdmep/flows.py
@@ -19,7 +19,7 @@ from pipelines.utils.tasks import (
     run_dbt,
 )
 
-with Flow(name="br_inmet_bdmep", code_owners=["equipe_pipelines"]) as br_inmet:
+with Flow(name="br_inmet_bdmep", code_owners=["equipe_dados"]) as br_inmet:
     # Parameters
     dataset_id = Parameter(
         "dataset_id", default="br_inmet_bdmep", required=False

--- a/pipelines/datasets/br_mg_belohorizonte_smfa_iptu/flows.py
+++ b/pipelines/datasets/br_mg_belohorizonte_smfa_iptu/flows.py
@@ -25,7 +25,7 @@ from pipelines.utils.tasks import (
 )
 
 with Flow(
-    name="br_mg_belohorizonte_smfa_iptu.iptu", code_owners=["trick"]
+    name="br_mg_belohorizonte_smfa_iptu.iptu", code_owners=["equipe_dados"]
 ) as br_mg_belohorizonte_smfa_iptu_iptu:
     # Parameters
     dataset_id = Parameter(

--- a/pipelines/datasets/br_ms_cnes/flows.py
+++ b/pipelines/datasets/br_ms_cnes/flows.py
@@ -25,7 +25,7 @@ from pipelines.datasets.br_ms_cnes.schedules import (
 
 br_ms_cnes_profissional = deepcopy(flow_cnes)
 br_ms_cnes_profissional.name = "br_ms_cnes.profissional"
-br_ms_cnes_profissional.code_owners = ["equipe_pipelines"]
+br_ms_cnes_profissional.code_owners = ["equipe_dados"]
 br_ms_cnes_profissional.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_profissional.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -34,7 +34,7 @@ br_ms_cnes_profissional.schedule = schedule_br_ms_cnes_profissional
 
 br_ms_cnes_estabelecimento = deepcopy(flow_cnes)
 br_ms_cnes_estabelecimento.name = "br_ms_cnes.estabelecimento"
-br_ms_cnes_estabelecimento.code_owners = ["equipe_pipelines"]
+br_ms_cnes_estabelecimento.code_owners = ["equipe_dados"]
 br_ms_cnes_estabelecimento.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_estabelecimento.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -43,14 +43,14 @@ br_ms_cnes_estabelecimento.schedule = schedule_br_ms_cnes_estabelecimento
 
 br_ms_cnes_leito = deepcopy(flow_cnes)
 br_ms_cnes_leito.name = "br_ms_cnes.leito"
-br_ms_cnes_leito.code_owners = ["equipe_pipelines"]
+br_ms_cnes_leito.code_owners = ["equipe_dados"]
 br_ms_cnes_leito.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_leito.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
 br_ms_cnes_leito.schedule = schedule_br_ms_cnes_leito
 
 br_ms_cnes_equipamento = deepcopy(flow_cnes)
 br_ms_cnes_equipamento.name = "br_ms_cnes.equipamento"
-br_ms_cnes_equipamento.code_owners = ["equipe_pipelines"]
+br_ms_cnes_equipamento.code_owners = ["equipe_dados"]
 br_ms_cnes_equipamento.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_equipamento.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -59,7 +59,7 @@ br_ms_cnes_equipamento.schedule = schedule_br_ms_cnes_equipamento
 
 br_ms_cnes_equipe = deepcopy(flow_cnes)
 br_ms_cnes_equipe.name = "br_ms_cnes.equipe"
-br_ms_cnes_equipe.code_owners = ["equipe_pipelines"]
+br_ms_cnes_equipe.code_owners = ["equipe_dados"]
 br_ms_cnes_equipe.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_equipe.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -69,7 +69,7 @@ br_ms_cnes_equipe.schedule = schedule_br_ms_cnes_equipe
 
 br_ms_cnes_dados_complementares = deepcopy(flow_cnes)
 br_ms_cnes_dados_complementares.name = "br_ms_cnes.dados_complementares"
-br_ms_cnes_dados_complementares.code_owners = ["equipe_pipelines"]
+br_ms_cnes_dados_complementares.code_owners = ["equipe_dados"]
 br_ms_cnes_dados_complementares.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_dados_complementares.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -81,7 +81,7 @@ br_ms_cnes_dados_complementares.schedule = (
 
 br_ms_cnes_servico_especializado = deepcopy(flow_cnes)
 br_ms_cnes_servico_especializado.name = "br_ms_cnes.servico_especializado"
-br_ms_cnes_servico_especializado.code_owners = ["equipe_pipelines"]
+br_ms_cnes_servico_especializado.code_owners = ["equipe_dados"]
 br_ms_cnes_servico_especializado.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -94,7 +94,7 @@ br_ms_cnes_servico_especializado.schedule = (
 
 br_ms_cnes_habilitacao = deepcopy(flow_cnes)
 br_ms_cnes_habilitacao.name = "br_ms_cnes.habilitacao"
-br_ms_cnes_habilitacao.code_owners = ["equipe_pipelines"]
+br_ms_cnes_habilitacao.code_owners = ["equipe_dados"]
 br_ms_cnes_habilitacao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_habilitacao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -103,7 +103,7 @@ br_ms_cnes_habilitacao.schedule = schedule_br_ms_cnes_habilitacao
 
 br_ms_cnes_gestao_metas = deepcopy(flow_cnes)
 br_ms_cnes_gestao_metas.name = "br_ms_cnes.gestao_metas"
-br_ms_cnes_gestao_metas.code_owners = ["equipe_pipelines"]
+br_ms_cnes_gestao_metas.code_owners = ["equipe_dados"]
 br_ms_cnes_gestao_metas.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_gestao_metas.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -112,7 +112,7 @@ br_ms_cnes_gestao_metas.schedule = schedule_br_ms_cnes_gestao_metas
 
 br_ms_cnes_incentivos = deepcopy(flow_cnes)
 br_ms_cnes_incentivos.name = "br_ms_cnes.incentivos"
-br_ms_cnes_incentivos.code_owners = ["equipe_pipelines"]
+br_ms_cnes_incentivos.code_owners = ["equipe_dados"]
 br_ms_cnes_incentivos.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_incentivos.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -121,7 +121,7 @@ br_ms_cnes_incentivos.schedule = schedule_br_ms_cnes_incentivos
 
 br_ms_cnes_estabelecimento_ensino = deepcopy(flow_cnes)
 br_ms_cnes_estabelecimento_ensino.name = "br_ms_cnes.estabelecimento_ensino"
-br_ms_cnes_estabelecimento_ensino.code_owners = ["equipe_pipelines"]
+br_ms_cnes_estabelecimento_ensino.code_owners = ["equipe_dados"]
 br_ms_cnes_estabelecimento_ensino.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -134,7 +134,7 @@ br_ms_cnes_estabelecimento_filantropico = deepcopy(flow_cnes)
 br_ms_cnes_estabelecimento_filantropico.name = (
     "br_ms_cnes.estabelecimento_filantropico"
 )
-br_ms_cnes_estabelecimento_filantropico.code_owners = ["equipe_pipelines"]
+br_ms_cnes_estabelecimento_filantropico.code_owners = ["equipe_dados"]
 br_ms_cnes_estabelecimento_filantropico.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -147,7 +147,7 @@ br_ms_cnes_estabelecimento_filantropico.schedule = (
 
 br_ms_cnes_regra_contratual = deepcopy(flow_cnes)
 br_ms_cnes_regra_contratual.name = "br_ms_cnes.br_ms_cnes_regra_contratual"
-br_ms_cnes_regra_contratual.code_owners = ["equipe_pipelines"]
+br_ms_cnes_regra_contratual.code_owners = ["equipe_dados"]
 br_ms_cnes_regra_contratual.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_ms_cnes_regra_contratual.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value

--- a/pipelines/datasets/br_rj_isp_estatisticas_seguranca/flows.py
+++ b/pipelines/datasets/br_rj_isp_estatisticas_seguranca/flows.py
@@ -24,7 +24,7 @@ evolucao_mensal_cisp = deepcopy(flow_isp)
 evolucao_mensal_cisp.name = (
     "br_rj_isp_estatisticas_seguranca.evolucao_mensal_cisp"
 )
-evolucao_mensal_cisp.code_owners = ["trick"]
+evolucao_mensal_cisp.code_owners = ["equipe_dados"]
 evolucao_mensal_cisp.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 evolucao_mensal_cisp.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -33,7 +33,7 @@ evolucao_mensal_cisp.schedule = every_month_evolucao_mensal_cisp
 
 evolucao_mensal_uf = deepcopy(flow_isp)
 evolucao_mensal_uf.name = "br_rj_isp_estatisticas_seguranca.evolucao_mensal_uf"
-evolucao_mensal_uf.code_owners = ["trick"]
+evolucao_mensal_uf.code_owners = ["equipe_dados"]
 evolucao_mensal_uf.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 evolucao_mensal_uf.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -44,7 +44,7 @@ evolucao_mensal_municipio = deepcopy(flow_isp)
 evolucao_mensal_municipio.name = (
     "br_rj_isp_estatisticas_seguranca.evolucao_mensal_municipio  "
 )
-evolucao_mensal_municipio.code_owners = ["trick"]
+evolucao_mensal_municipio.code_owners = ["equipe_dados"]
 evolucao_mensal_municipio.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 evolucao_mensal_municipio.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -55,7 +55,7 @@ armas_apreendidas_mensal = deepcopy(flow_isp)
 armas_apreendidas_mensal.name = (
     "br_rj_isp_estatisticas_seguranca.armas_apreendidas_mensal"
 )
-armas_apreendidas_mensal.code_owners = ["trick"]
+armas_apreendidas_mensal.code_owners = ["equipe_dados"]
 armas_apreendidas_mensal.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 armas_apreendidas_mensal.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
@@ -66,7 +66,7 @@ evolucao_policial_morto_servico_mensal = deepcopy(flow_isp)
 evolucao_policial_morto_servico_mensal.name = (
     "br_rj_isp_estatisticas_seguranca.evolucao_policial_morto_servico_mensal"
 )
-evolucao_policial_morto_servico_mensal.code_owners = ["trick"]
+evolucao_policial_morto_servico_mensal.code_owners = ["equipe_dados"]
 evolucao_policial_morto_servico_mensal.storage = GCS(
     constants.GCS_FLOWS_BUCKET.value
 )
@@ -81,7 +81,7 @@ feminicidio_mensal_cisp = deepcopy(flow_isp)
 feminicidio_mensal_cisp.name = (
     "br_rj_isp_estatisticas_seguranca.feminicidio_mensal_cisp"
 )
-feminicidio_mensal_cisp.code_owners = ["trick"]
+feminicidio_mensal_cisp.code_owners = ["equipe_dados"]
 feminicidio_mensal_cisp.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 feminicidio_mensal_cisp.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value

--- a/pipelines/datasets/br_stf_corte_aberta/flows.py
+++ b/pipelines/datasets/br_stf_corte_aberta/flows.py
@@ -25,7 +25,7 @@ from pipelines.utils.tasks import (
 )
 
 with Flow(
-    name="br_stf_corte_aberta.decisoes", code_owners=["trick"]
+    name="br_stf_corte_aberta.decisoes", code_owners=["equipe_dados"]
 ) as br_stf:
     # Parameters
     dataset_id = Parameter(


### PR DESCRIPTION
Este PR atualiza o campo \`code_owners\` em 20 arquivos de flows, substituindo referências ao usuário \`trick\` (que saiu da equipe) e à tag \`equipe_pipelines\` (removida) pelo owner atual \`equipe_dados\`.

---

## Principais mudanças

### 1. Remoção de referências ao usuário \`trick\`
- Flows dos crawlers: \`anatel/banda_larga_fixa\`, \`anatel/telefonia_movel\`, \`camara_dados_abertos\`, \`cgu\`, \`datasus\`
- Flows dos datasets: \`br_anatel_banda_larga_fixa\`, \`br_anatel_telefonia_movel\`, \`br_anp_precos_combustiveis\`, \`br_b3_cotacoes\`, \`br_camara_dados_abertos\`, \`br_cgu_beneficios_cidadao\`, \`br_cgu_cartao_pagamento\`, \`br_cgu_licitacao_contrato\`, \`br_cgu_servidores_executivo_federal\`, \`br_ibge_inpc\`, \`br_ibge_ipca\`, \`br_ibge_ipca15\`, \`br_mg_belohorizonte_smfa_iptu\`, \`br_rj_isp_estatisticas_seguranca\`, \`br_stf_corte_aberta\`

### 2. Remoção da tag \`equipe_pipelines\`
- \`datasus/flows.py\` — flows \`DATASUS-SIH\` que ainda usavam a tag descontinuada

---

## Como testar

1. Verifique que nenhum flow ainda referencia os owners antigos:

```bash
grep -r "code_owners.*trick" pipelines/
grep -r "code_owners.*equipe_pipelines" pipelines/
```

2. Ambos os comandos devem retornar **sem resultados**.