### PR TITLE
[chore] fix remaining equipe_pipelines references missed in #1499

### DIFF
--- a/pipelines/datasets/br_me_cnpj/flows.py
+++ b/pipelines/datasets/br_me_cnpj/flows.py
@@ -33,7 +33,7 @@ from pipelines.utils.tasks import (
 with Flow(
     name="br_me_cnpj.empresas",
     code_owners=[
-        "equipe_pipelines",
+        "equipe_dados",
     ],
 ) as br_me_cnpj_empresas:
     dataset_id = Parameter("dataset_id", default="br_me_cnpj", required=False)
@@ -116,7 +116,7 @@ br_me_cnpj_empresas.schedule = every_day_empresas
 with Flow(
     name="br_me_cnpj.socios",
     code_owners=[
-        "equipe_pipelines",
+        "equipe_dados",
     ],
 ) as br_me_cnpj_socios:
     dataset_id = Parameter("dataset_id", default="br_me_cnpj", required=False)
@@ -198,7 +198,7 @@ br_me_cnpj_socios.schedule = every_day_socios
 with Flow(
     name="br_me_cnpj.estabelecimentos",
     code_owners=[
-        "equipe_pipelines",
+        "equipe_dados",
     ],
     executor=LocalDaskExecutor(),
 ) as br_me_cnpj_estabelecimentos:
@@ -311,7 +311,7 @@ br_me_cnpj_estabelecimentos.schedule = every_day_estabelecimentos
 with Flow(
     name="br_me_cnpj.simples",
     code_owners=[
-        "equipe_pipelines",
+        "equipe_dados",
     ],
 ) as br_me_cnpj_simples:
     dataset_id = Parameter("dataset_id", default="br_me_cnpj", required=True)

--- a/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
@@ -30,7 +30,7 @@ from pipelines.utils.tasks import (
 with Flow(
     name="mundo_transfermarkt_competicoes.brasileirao_serie_a",
     code_owners=[
-        "equipe_pipelines",
+        "equipe_dados",
     ],
 ) as transfermarkt_brasileirao_flow:
     dataset_id = Parameter(

--- a/pipelines/datasets/mundo_transfermarkt_competicoes_internacionais/flows.py
+++ b/pipelines/datasets/mundo_transfermarkt_competicoes_internacionais/flows.py
@@ -30,7 +30,7 @@ from pipelines.utils.tasks import (
 with Flow(
     name="mundo_transfermarkt_competicoes_internacionais.champions_league",
     code_owners=[
-        "equipe_pipelines",
+        "equipe_dados",
     ],
 ) as transfermarkt_flow:
     dataset_id = Parameter(

--- a/pipelines/utils/materialize_prod/flows.py
+++ b/pipelines/utils/materialize_prod/flows.py
@@ -19,7 +19,7 @@ from pipelines.utils.tasks import (
 with Flow(
     name="BD Utils: Transfere arquivos do bucket basedosdados-dev para basedosdados",
     code_owners=[
-        "equipe_pipelines",
+        "equipe_dados",
     ],
 ) as transfer_files_to_prod_flow:
     dataset_id = Parameter(

--- a/pipelines/utils/to_download/flows.py
+++ b/pipelines/utils/to_download/flows.py
@@ -13,7 +13,7 @@ from pipelines.utils.to_download.tasks import download_async
 with Flow(
     name="test_to_download_task",
     code_owners=[
-        "equipe_pipelines",
+        "equipe_dados",
     ],
 ) as utils_to_download_flow:
     url = Parameter(


### PR DESCRIPTION
## Summary

- Complemento do #1499: substitui as referências a `equipe_pipelines` que ficaram de fora
- 5 arquivos atualizados, 8 ocorrências substituídas por `equipe_dados`

## Arquivos alterados

| Arquivo | Ocorrências |
|---------|-------------|
| `datasets/br_me_cnpj/flows.py` | 4 (empresas, socios, estabelecimentos, simples) |
| `datasets/mundo_transfermarkt_competicoes/flows.py` | 1 (brasileirao_serie_a) |
| `datasets/mundo_transfermarkt_competicoes_internacionais/flows.py` | 1 (champions_league) |
| `utils/materialize_prod/flows.py` | 1 |
| `utils/to_download/flows.py` | 1 |

## Como testar

```bash
grep -r "equipe_pipelines" pipelines/
```

Deve retornar sem resultados.

