### PR TITLE
Fix: erro em update_django_metadata com o parâmetro historical_databa…

### DIFF
--- a/pipelines/datasets/br_inmet_bdmep/flows.py
+++ b/pipelines/datasets/br_inmet_bdmep/flows.py
@@ -126,7 +126,9 @@ with Flow(
         "materialize_after_dump", default=False, required=False
     )
     dbt_alias = Parameter("dbt_alias", default=True, required=False)
-    historical_database = Parameter("historical_database", default=False, required=False)
+    historical_database = Parameter(
+        "historical_database", default=False, required=False
+    )
     rename_flow_run = rename_current_flow_run_dataset_table(
         prefix="Dump: ",
         dataset_id=dataset_id,

--- a/pipelines/datasets/br_inmet_bdmep/flows.py
+++ b/pipelines/datasets/br_inmet_bdmep/flows.py
@@ -126,7 +126,7 @@ with Flow(
         "materialize_after_dump", default=False, required=False
     )
     dbt_alias = Parameter("dbt_alias", default=True, required=False)
-
+    historical_database = Parameter("historical_database", default=False, required=False)
     rename_flow_run = rename_current_flow_run_dataset_table(
         prefix="Dump: ",
         dataset_id=dataset_id,
@@ -167,6 +167,7 @@ with Flow(
                 dataset_id=dataset_id,
                 table_id=table_id,
                 bq_project="basedosdados",
+                historical_database=historical_database,
                 upstream_tasks=[
                     wait_upload_prod_estacoes,
                 ],


### PR DESCRIPTION
PR para resolver o Update Django Metadata

Como a tabela de estações não tem coluna de data, é necessário mudar a forma de chamar o update_django_ metadata. 
Adicionei o parâmetro historical_database ao flow para isso.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional historical database processing parameter to the weather data pipeline. This allows users to enable historical database handling during metadata updates. The feature is disabled by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/basedosdados/pipelines/pull/1535)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->