### PR TITLE
chore(br_ibge_pnadc): trigger dicionario deploy

### DIFF
--- a/models/br_ibge_pnadc/br_ibge_pnadc__dicionario.sql
+++ b/models/br_ibge_pnadc/br_ibge_pnadc__dicionario.sql
@@ -6,4 +6,5 @@ select
     safe_cast(chave as string) chave,
     safe_cast(cobertura_temporal as string) cobertura_temporal,
     safe_cast(valor as string) valor,
+
 from {{ set_datalake_project("br_ibge_pnadc_staging.dicionario") }} as t


### PR DESCRIPTION
## Summary
- Whitespace-only change in `models/br_ibge_pnadc/br_ibge_pnadc__dicionario.sql` to trigger the dicionario deploy workflow via the `table-approve` label.

## Test plan
- [ ] PR receives `table-approve` label
- [ ] Deployment workflow runs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated database query formatting to improve code readability and maintain consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/basedosdados/pipelines/pull/1547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->