### PR TITLE
Fix: historical_database = False e adicionar explicitamente coverage_…

### DIFF
--- a/pipelines/datasets/br_inmet_bdmep/flows.py
+++ b/pipelines/datasets/br_inmet_bdmep/flows.py
@@ -168,8 +168,9 @@ with Flow(
             update_django_metadata(
                 dataset_id=dataset_id,
                 table_id=table_id,
+                coverage_type="all_free",
                 bq_project="basedosdados",
-                historical_database=historical_database,
+                historical_database=False,
                 upstream_tasks=[
                     wait_upload_prod_estacoes,
                 ],


### PR DESCRIPTION
PR para ajuste do update de metadados do flow de estações. A ausência de um coverage_type explícito estava gerando erro porque o valor default é `"part_bdpro"`, incompatível com  uma tabela que não tem coluna de data e tem o parâmetro `historical_database=False`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Dataset coverage now provides all available free data, ensuring more complete recent data availability.
  * Historical database processing is disabled for this dataset, so historical-only processing will no longer be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->