### PR TITLE
[bugfix] fix(check_metadata): tratar incompatibilidade entre tipos bool (BQ) e boolean (API)

### DIFF
--- a/.github/workflows/scripts/check_metadata.py
+++ b/.github/workflows/scripts/check_metadata.py
@@ -6,6 +6,13 @@ import basedosdados as bd
 import pandas as pd
 from databasers_utils import get_architecture_table_from_api
 
+_TYPE_ALIASES: dict[str, str] = {
+    "boolean": "bool",
+    "integer": "int64",
+    "int": "int64",
+    "float": "float64",
+}
+
 
 def get_datasets_tables_from_modified_files(
     modified_files: list[str],  # type: ignore
@@ -88,15 +95,16 @@ def get_bigquery_columns(
     return columns
 
 
-_TYPE_ALIASES: dict[str, str] = {
-    "boolean": "bool",
-    "integer": "int64",
-    "int": "int64",
-    "float": "float64",
-}
-
-
 def normalize_type(t: str) -> str:
+    """
+    Normalize a BigQuery or API type string to a canonical form for comparison.
+
+    Args:
+        t (str): Type string returned by BigQuery or the backend API.
+
+    Returns:
+        str: Canonical type string (e.g. "boolean" -> "bool", "int" -> "int64").
+    """
     t = t.lower()
     return _TYPE_ALIASES.get(t, t)
 

--- a/.github/workflows/scripts/check_metadata.py
+++ b/.github/workflows/scripts/check_metadata.py
@@ -88,6 +88,19 @@ def get_bigquery_columns(
     return columns
 
 
+_TYPE_ALIASES: dict[str, str] = {
+    "boolean": "bool",
+    "integer": "int64",
+    "int": "int64",
+    "float": "float64",
+}
+
+
+def normalize_type(t: str) -> str:
+    t = t.lower()
+    return _TYPE_ALIASES.get(t, t)
+
+
 def evaluate_row(row: pd.Series) -> dict:
     """
     Evaluate a merged row from BigQuery vs API and return column status.
@@ -99,8 +112,8 @@ def evaluate_row(row: pd.Series) -> dict:
     elif row["_merge"] == "right_only":
         status.append("Column not found in BigQuery")
     else:
-        bq_type = str(row["data_type"]).lower()
-        api_type = str(row["bigquery_type"]).lower()
+        bq_type = normalize_type(str(row["data_type"]))
+        api_type = normalize_type(str(row["bigquery_type"]))
         if bq_type != api_type:
             status.append(f"Type differs (BQ: {bq_type} | API: {api_type})")
 


### PR DESCRIPTION
# [Bugfix] fix(check_metadata): tratar incompatibilidade entre tipos bool (BQ) e boolean (API)

Corrige falso positivo no CI ao comparar tipos de colunas booleanas entre BigQuery e a API do backend. O BigQuery retorna `bool` enquanto a API retorna `boolean`, causando divergência indevida.

---

## Principais mudanças

### 1. Função `normalize_type`

- Adicionada função `normalize_type(t: str) -> str` que normaliza aliases de tipo para uma forma canônica antes da comparação.
- Mapa de aliases (`_TYPE_ALIASES`):

| Alias | Canônico |
|-------|----------|
| `boolean` | `bool` |
| `integer` | `int64` |
| `int` | `int64` |
| `float` | `float64` |

### 2. Aplicação em `evaluate_row`

- `bq_type` e `api_type` agora passam por `normalize_type()` antes da comparação, eliminando falsos positivos por diferença de alias.

---

## Como testar

1. Certifique-se de que o CI passa no PR #1536 após o merge desta branch.

2. Para testar localmente, basta verificar que a função de normalização trata os aliases corretamente:

```python
from check_metadata import normalize_type

assert normalize_type("BOOL") == "bool"
assert normalize_type("boolean") == "bool"
assert normalize_type("INTEGER") == "int64"
assert normalize_type("int") == "int64"
assert normalize_type("FLOAT") == "float64"
assert normalize_type("float64") == "float64"
assert normalize_type("STRING") == "string"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced metadata validation to more accurately identify type mismatches by normalizing BigQuery and API type representations to consistent canonical forms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/basedosdados/pipelines/pull/1551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->