### PR TITLE
fix(br_me_rais): aceitar header 'CNAE 2.0 Subclasse - Codigo' (sem acento) em vínculos 2025

### DIFF
--- a/pipelines/datasets/br_me_rais/constants.py
+++ b/pipelines/datasets/br_me_rais/constants.py
@@ -189,6 +189,7 @@ class constants(Enum):
         "CNAE 2.0 Classe - Código": "cnae_2",
         "CNAE 2.0 Subclasse": "cnae_2_subclasse",
         "CNAE 2.0 Subclasse - Código": "cnae_2_subclasse",
+        "CNAE 2.0 Subclasse - Codigo": "cnae_2_subclasse",
         "Tamanho Estabelecimento": "tamanho_estabelecimento",
         "Tamanho Estabelecimento - Código": "tamanho_estabelecimento",
         "Tipo Estab": "tipo_estabelecimento",


### PR DESCRIPTION
## Contexto

Closes #1556.

A partir do ano-base 2025, o arquivo `.COMT` distribuído pelo Ministério do Trabalho/PDET passou a usar `Codigo` (sem acento) no cabeçalho da CNAE 2.0 Subclasse:

```
..., "CNAE 2.0 Subclasse - Codigo", ...
```

O dicionário `VINCULOS_RENAME` em `pipelines/datasets/br_me_rais/constants.py` só mapeava a variante acentuada (`"... - Código"`). Sem match no `df.rename(...)`, a coluna `cnae_2_subclasse` desaparecia de `df.columns` e caía no fallback de `tasks.py:419-421`, que preenche com `""`. No staging do BigQuery isso vira NULL, e como o macro `macros/br_me_rais_vinculos_select.sql` deriva **tanto `cnae_2` quanto `cnae_2_subclasse`** via `lpad(cnae_2_subclasse, 7, '0')`, ambas colunas finais ficavam 100% nulas em 2025.

## Evidência (antes do fix)

```sql
SELECT
  ano,
  COUNT(*) AS total,
  COUNTIF(cnae_2_subclasse IS NULL) AS cnae_nula,
  ROUND(100 * COUNTIF(cnae_2_subclasse IS NULL) / COUNT(*), 2) AS pct_nula
FROM `basedosdados-dev.br_me_rais.microdados_vinculos`
WHERE ano >= 2023
GROUP BY ano
ORDER BY ano
```

| ano  | total       | cnae_nula     | pct_nula |
|------|-------------|---------------|----------|
| 2023 | 82.966.522  | 0             | 0%       |
| 2024 | 87.747.220  | 0             | 0%       |
| 2025 | 91.710.262  | 91.710.262    | **100%** |

## Mudança

Adicionada uma única entrada ao `VINCULOS_RENAME`:

```python
"CNAE 2.0 Subclasse - Codigo": "cnae_2_subclasse",
```

Mantém retrocompatibilidade — as duas variantes (`Código` e `Codigo`) passam a ser aceitas.

## Próximos passos pós-merge

- Reprocessar a partição `ano=2025` da `br_me_rais.microdados_vinculos` (download → clean → upload → `dbt run` incremental).
- Validar com a mesma query acima que `pct_nula` cai para ~0% em 2025.

## Checklist

- [x] Causa raiz identificada e documentada na issue #1556
- [x] Fix mínimo, sem efeito colateral nos anos anteriores
- [x] Pre-commit hooks passaram (ruff)
- [ ] Reprocessamento de 2025 agendado após merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended data field mapping configuration to support an additional column name variant, improving compatibility and consistency when processing data from different sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/basedosdados/pipelines/pull/1557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->