### PR TITLE
Update size limits for data download criteria

### DIFF
--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -819,9 +819,9 @@ def download_data_to_gcs(
     Get data from BigQuery.
 
     As regras de negócio são:
-        - Se a tabela for maior que 1GB: Não tem download disponível
-        - Se a tabela for entre 100MB e 1GB: Tem downalod apenas para assinante BDPro
-        - Se a tabela for menor que 100MB: Tem download para assinante BDPro e aberto
+        - Se a tabela for maior que 1GiB: Não tem download disponível
+        - Se a tabela for entre 100MiB e 1GiB: Tem download apenas para assinante BDPro
+        - Se a tabela for menor que 100MiB: Tem download para assinante BDPro e aberto
             - Se for parcialmente BDPro faz o download de arquivos diferentes para o público pagante e não pagante
 
     """
@@ -917,12 +917,12 @@ def download_data_to_gcs(
 
     log(num_bytes)
     if num_bytes > 1_073_741_824:  # 1GB em unidades binárias
-        log("Table is bigger than 1GB it is not in the download criteria")
+        log("Table is bigger than 1GiB it is not in the download criteria")
         return None
 
     if (
         104_857_600 <= num_bytes <= 1_073_741_824
-    ):  # Entre 1 GB e 100 MB (binário) , apenas BD pro
+    ):  # Entre 1 GiB e 100 MiB (binário) , apenas BD pro
         log("Querying data for BDpro user")
 
         blob_path = f"{secret_path_url_closed}{dataset_id}/{table_id}/{table_id}_bdpro.csv.gz"
@@ -935,7 +935,7 @@ def download_data_to_gcs(
 
         log("BDPro Data was loaded successfully")
 
-    if num_bytes < 104_857_600:  # valor menor que 100 MB
+    if num_bytes < 104_857_600:  # valor menor que 100 MiB
         # Try to remove bdpro access
         log("Trying to remove BDpro filter")
         try:

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -916,12 +916,12 @@ def download_data_to_gcs(
     secret_path_url_closed = url_path["URL_DOWNLOAD_CLOSED"]
 
     log(num_bytes)
-    if num_bytes > 104_857_600: #100Mb em unidades binárias
+    if num_bytes > 104_857_600:  # 100Mb em unidades binárias
         log("Table is bigger than 1GB it is not in the download criteria")
         return None
 
     if (
-        104_857_600 <= num_bytes <= 1_073_741_824 
+        104_857_600 <= num_bytes <= 1_073_741_824
     ):  # Entre 1 GB e 100 MB (binário) , apenas BD pro
         log("Querying data for BDpro user")
 

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -916,13 +916,13 @@ def download_data_to_gcs(
     secret_path_url_closed = url_path["URL_DOWNLOAD_CLOSED"]
 
     log(num_bytes)
-    if num_bytes > 1_000_000_000:
+    if num_bytes > 104_857_600: #100Mb em unidades binárias
         log("Table is bigger than 1GB it is not in the download criteria")
         return None
 
     if (
-        100_000_000 <= num_bytes <= 1_000_000_000
-    ):  # Entre 1 GB e 100 MB, apenas BD pro
+        104_857_600 <= num_bytes <= 1_073_741_824 
+    ):  # Entre 1 GB e 100 MB (binário) , apenas BD pro
         log("Querying data for BDpro user")
 
         blob_path = f"{secret_path_url_closed}{dataset_id}/{table_id}/{table_id}_bdpro.csv.gz"

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -819,8 +819,8 @@ def download_data_to_gcs(
     Get data from BigQuery.
 
     As regras de negócio são:
-        - Se a tabela for maior que 5GB: Não tem download disponível
-        - Se a tabela for entre 100MB e 5GB: Tem downalod apenas para assinante BDPro
+        - Se a tabela for maior que 1GB: Não tem download disponível
+        - Se a tabela for entre 100MB e 1GB: Tem downalod apenas para assinante BDPro
         - Se a tabela for menor que 100MB: Tem download para assinante BDPro e aberto
             - Se for parcialmente BDPro faz o download de arquivos diferentes para o público pagante e não pagante
 

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -916,7 +916,7 @@ def download_data_to_gcs(
     secret_path_url_closed = url_path["URL_DOWNLOAD_CLOSED"]
 
     log(num_bytes)
-    if num_bytes > 104_857_600:  # 100Mb em unidades binárias
+    if num_bytes > 1_073_741_824:  # 1GB em unidades binárias
         log("Table is bigger than 1GB it is not in the download criteria")
         return None
 
@@ -935,7 +935,7 @@ def download_data_to_gcs(
 
         log("BDPro Data was loaded successfully")
 
-    if num_bytes < 100_000_000:  # valor menor que 100 MB
+    if num_bytes < 104_857_600:  # valor menor que 100 MB
         # Try to remove bdpro access
         log("Trying to remove BDpro filter")
         try:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized file-size thresholds to binary units (MiB/GiB). This changes which table sizes qualify for direct downloads, BDPro-only downloads (100 MiB–1 GiB), or are marked unavailable (>1 GiB).
  * Users may notice different download availability or routing for some medium-to-large tables; small-table behavior is adjusted to the new 100 MiB binary cutoff.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/basedosdados/pipelines/pull/1559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->