### PR TITLE
[fix] sigla_uf para NULL em presidência (bens_candidato, despesas_candidato)

### DIFF
--- a/models/br_tse_eleicoes/br_tse_eleicoes__bens_candidato.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__bens_candidato.sql
@@ -13,7 +13,7 @@
 
 select
     safe_cast(ano as int64) ano,
-    safe_cast(sigla_uf as string) sigla_uf,
+    nullif(safe_cast(sigla_uf as string), '') sigla_uf,
     safe_cast(id_eleicao as string) id_eleicao,
     safe_cast(tipo_eleicao as string) tipo_eleicao,
     safe_cast(data_eleicao as date) data_eleicao,

--- a/models/br_tse_eleicoes/br_tse_eleicoes__despesas_candidato.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__despesas_candidato.sql
@@ -17,7 +17,7 @@ select
     safe_cast(id_eleicao as string) id_eleicao,
     safe_cast(tipo_eleicao as string) tipo_eleicao,
     safe_cast(data_eleicao as date) data_eleicao,
-    safe_cast(sigla_uf as string) sigla_uf,
+    nullif(safe_cast(sigla_uf as string), '') sigla_uf,
     safe_cast(id_municipio as string) id_municipio,
     safe_cast(id_municipio_tse as string) id_municipio_tse,
     safe_cast(titulo_eleitoral_candidato as string) titulo_eleitoral_candidato,


### PR DESCRIPTION
## Summary

- Aplica `nullif(safe_cast(sigla_uf as string), '')` nos modelos DBT de `bens_candidato` e `despesas_candidato`.
- Garante que candidaturas presidenciais (`SG_UF='BR'` no TSE, normalizadas para string vazia na staging) resultem em `sigla_uf NULL` na tabela final, conforme convenção do modelo BD: `sigla_uf` aceita apenas as 27 UFs reais (26 estados + DF).
- Sem essa normalização, o teste DBT `relationships` contra `br_bd_diretorios_brasil.uf` falha para todas as linhas de presidência (string vazia não é uma UF válida no diretório).

## Contexto

- Closes #1560 — gap dos bens de candidatos a presidência (ex.: Lula 2006/2018/2022, Bolsonaro 2018/2022) que não apareciam na tabela `br_tse_eleicoes.bens_candidato`.
- O fix de upstream (extração no TSE) está na branch `feat/refactor_eleicoes` (PR #1476) — três commits: incluir `_UFS_FED_BR` no loop, corrigir mapeamento posicional para anos ≤ 2012, e normalizar `SG_UF='BR'` → vazio.
- Este PR apenas ajusta os modelos DBT que materializam as tabelas finais a partir da staging.

## Validação em dev

`basedosdados-dev.br_tse_eleicoes.bens_candidato` (já populado com a staging corrigida via upload manual):

| Candidato | Título eleitoral | Ano | sigla_uf | Bens | Valor declarado |
|---|---|---:|---|---:|---:|
| Lula | 122418060191 | 2006 | NULL (presidente) | 16 | R$ 839.034 |
| Lula | 122418060191 | 2018 | NULL (presidente) | 19 | R$ 7.987.922 |
| Lula | 122418060191 | 2022 | NULL (presidente) | 23 | R$ 7.423.726 |
| Bolsonaro | 015564190337 | 2006 | RJ (deputado fed) | 7 | R$ 433.934 |
| Bolsonaro | 015564190337 | 2010 | RJ (deputado fed) | 11 | R$ 826.670 |
| Bolsonaro | 015564190337 | 2018 | NULL (presidente) | 16 | R$ 2.286.779 |
| Bolsonaro | 015564190337 | 2022 | NULL (presidente) | 13 | R$ 2.317.555 |

`dbt run` e `dbt test` no modelo em dev: ✅ 4/4 testes PASS.

## Test plan

- [x] Adicionar label `table-approve` para materializar `br_tse_eleicoes.bens_candidato` e `br_tse_eleicoes.despesas_candidato` em produção.
- [ ] Após materialização em prod, conferir que a query original do issue #1560 retorna as linhas de presidência:

  ```sql
  SELECT titulo_eleitoral_candidato, ano, sigla_uf, COUNT(*) bens, SUM(valor_item) total
  FROM `basedosdados.br_tse_eleicoes.bens_candidato`
  WHERE titulo_eleitoral_candidato IN ('122418060191', '015564190337')
  GROUP BY 1,2,3 ORDER BY 1,2;
  ```

- [ ] Conferir `COUNTIF(sigla_uf IS NULL) > 0` para anos federais (2006/2010/2014/2018/2022) na tabela final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)