### PR TITLE
fix: disable Prefect 0 schedules for flows migrated to Prefect 3

### DIFF
--- a/pipelines/datasets/br_anp_precos_combustiveis/flows.py
+++ b/pipelines/datasets/br_anp_precos_combustiveis/flows.py
@@ -7,9 +7,6 @@ from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 
 from pipelines.constants import constants
-from pipelines.datasets.br_anp_precos_combustiveis.schedules import (
-    every_week_anp_microdados,
-)
 from pipelines.datasets.br_anp_precos_combustiveis.tasks import (
     download_and_transform,
     get_data_source_anp_max_date,
@@ -105,4 +102,4 @@ with Flow(
 
 anp_microdados.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 anp_microdados.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
-anp_microdados.schedule = every_week_anp_microdados
+# anp_microdados.schedule = every_week_anp_microdados

--- a/pipelines/datasets/br_bcb_agencia/flows.py
+++ b/pipelines/datasets/br_bcb_agencia/flows.py
@@ -6,7 +6,6 @@ from pipelines.constants import constants
 from pipelines.datasets.br_bcb_agencia.constants import (
     constants as agencia_constants,
 )
-from pipelines.datasets.br_bcb_agencia.schedules import every_month_agencia
 from pipelines.datasets.br_bcb_agencia.tasks import (
     clean_data,
     download_table,
@@ -143,4 +142,4 @@ br_bcb_agencia_agencia.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_bcb_agencia_agencia.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_agencia_agencia.schedule = every_month_agencia
+# br_bcb_agencia_agencia.schedule = every_month_agencia

--- a/pipelines/datasets/br_bcb_estban/flows.py
+++ b/pipelines/datasets/br_bcb_estban/flows.py
@@ -7,10 +7,6 @@ from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 
 from pipelines.constants import constants
-from pipelines.datasets.br_bcb_estban.schedules import (
-    every_month_agencia,
-    every_month_municipio,
-)
 from pipelines.datasets.br_bcb_estban.tasks import (
     cleaning_data,
     download_table,
@@ -156,7 +152,7 @@ br_bcb_estban_municipio.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_bcb_estban_municipio.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_estban_municipio.schedule = every_month_municipio
+# br_bcb_estban_municipio.schedule = every_month_municipio
 
 
 with Flow(
@@ -276,4 +272,4 @@ br_bcb_estban_agencia.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_bcb_estban_agencia.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_estban_agencia.schedule = every_month_agencia
+# br_bcb_estban_agencia.schedule = every_month_agencia

--- a/pipelines/datasets/br_bcb_sicor/flows.py
+++ b/pipelines/datasets/br_bcb_sicor/flows.py
@@ -14,18 +14,6 @@ from pipelines.crawler.bcb.flows import br_bcb_sicor_template
 from pipelines.crawler.bcb.tasks import (
     create_load_dictionary,
 )
-from pipelines.datasets.br_bcb_sicor.schedules import (
-    every_day_empreendimento,
-    every_day_liberacao,
-    every_day_operacao,
-    every_day_operacoes_desclassificadas,
-    every_day_recurso_publico_complemento_operacao,
-    every_day_recurso_publico_cooperado,
-    every_day_recurso_publico_gleba,
-    every_day_recurso_publico_mutuario,
-    every_day_recurso_publico_propriedade,
-    every_day_saldo,
-)
 from pipelines.utils.decorators import Flow
 from pipelines.utils.tasks import (
     create_table_dev_and_upload_to_gcs,
@@ -42,7 +30,7 @@ br_bcb_sicor__operacao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_bcb_sicor__operacao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__operacao.schedule = every_day_operacao
+# br_bcb_sicor__operacao.schedule = every_day_operacao
 
 # br_bcb_sicor__saldo
 br_bcb_sicor__saldo = deepcopy(br_bcb_sicor_template)
@@ -52,7 +40,7 @@ br_bcb_sicor__saldo.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_bcb_sicor__saldo.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__saldo.schedule = every_day_saldo
+# br_bcb_sicor__saldo.schedule = every_day_saldo
 
 # br_bcb_sicor__liberacao
 br_bcb_sicor__liberacao = deepcopy(br_bcb_sicor_template)
@@ -62,7 +50,7 @@ br_bcb_sicor__liberacao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_bcb_sicor__liberacao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__liberacao.schedule = every_day_liberacao
+# br_bcb_sicor__liberacao.schedule = every_day_liberacao
 
 # br_bcb_sicor__recurso_publico_complemento_operacao
 br_bcb_sicor__recurso_publico_complemento_operacao = deepcopy(
@@ -80,9 +68,9 @@ br_bcb_sicor__recurso_publico_complemento_operacao.storage = GCS(
 br_bcb_sicor__recurso_publico_complemento_operacao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__recurso_publico_complemento_operacao.schedule = (
-    every_day_recurso_publico_complemento_operacao
-)
+# br_bcb_sicor__recurso_publico_complemento_operacao.schedule = (
+#     every_day_recurso_publico_complemento_operacao
+# )
 
 # br_bcb_sicor__recurso_publico_cooperado
 br_bcb_sicor__recurso_publico_cooperado = deepcopy(br_bcb_sicor_template)
@@ -96,9 +84,9 @@ br_bcb_sicor__recurso_publico_cooperado.storage = GCS(
 br_bcb_sicor__recurso_publico_cooperado.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__recurso_publico_cooperado.schedule = (
-    every_day_recurso_publico_cooperado
-)
+# br_bcb_sicor__recurso_publico_cooperado.schedule = (
+#     every_day_recurso_publico_cooperado
+# )
 
 # br_bcb_sicor__recurso_publico_gleba
 br_bcb_sicor__recurso_publico_gleba = deepcopy(br_bcb_sicor_template)
@@ -112,7 +100,7 @@ br_bcb_sicor__recurso_publico_gleba.storage = GCS(
 br_bcb_sicor__recurso_publico_gleba.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__recurso_publico_gleba.schedule = every_day_recurso_publico_gleba
+# br_bcb_sicor__recurso_publico_gleba.schedule = every_day_recurso_publico_gleba
 
 # br_bcb_sicor__recurso_publico_mutuario
 br_bcb_sicor__recurso_publico_mutuario = deepcopy(br_bcb_sicor_template)
@@ -126,9 +114,9 @@ br_bcb_sicor__recurso_publico_mutuario.storage = GCS(
 br_bcb_sicor__recurso_publico_mutuario.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__recurso_publico_mutuario.schedule = (
-    every_day_recurso_publico_mutuario
-)
+# br_bcb_sicor__recurso_publico_mutuario.schedule = (
+#     every_day_recurso_publico_mutuario
+# )
 
 # br_bcb_sicor__recurso_publico_propriedade
 br_bcb_sicor__recurso_publico_propriedade = deepcopy(br_bcb_sicor_template)
@@ -142,9 +130,9 @@ br_bcb_sicor__recurso_publico_propriedade.storage = GCS(
 br_bcb_sicor__recurso_publico_propriedade.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__recurso_publico_propriedade.schedule = (
-    every_day_recurso_publico_propriedade
-)
+# br_bcb_sicor__recurso_publico_propriedade.schedule = (
+#     every_day_recurso_publico_propriedade
+# )
 
 # br_bcb_sicor__operacoes_desclassificadas
 br_bcb_sicor__operacoes_desclassificadas = deepcopy(br_bcb_sicor_template)
@@ -158,9 +146,9 @@ br_bcb_sicor__operacoes_desclassificadas.storage = GCS(
 br_bcb_sicor__operacoes_desclassificadas.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__operacoes_desclassificadas.schedule = (
-    every_day_operacoes_desclassificadas
-)
+# br_bcb_sicor__operacoes_desclassificadas.schedule = (
+#     every_day_operacoes_desclassificadas
+# )
 
 # br_bcb_sicor__empreendimento
 br_bcb_sicor__empreendimento = deepcopy(br_bcb_sicor_template)
@@ -170,7 +158,7 @@ br_bcb_sicor__empreendimento.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_bcb_sicor__empreendimento.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_bcb_sicor__empreendimento.schedule = every_day_empreendimento
+# br_bcb_sicor__empreendimento.schedule = every_day_empreendimento
 
 
 with Flow(

--- a/pipelines/datasets/br_bcb_taxa_cambio/flows.py
+++ b/pipelines/datasets/br_bcb_taxa_cambio/flows.py
@@ -7,9 +7,6 @@ from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 
 from pipelines.constants import constants
-from pipelines.datasets.br_bcb_taxa_cambio.schedules import (
-    schedule_every_weekday_taxa_cambio,
-)
 from pipelines.datasets.br_bcb_taxa_cambio.tasks import (
     get_data_taxa_cambio,
     treat_data_taxa_cambio,
@@ -100,6 +97,6 @@ datasets_br_bcb_taxa_cambio_moeda_flow.storage = GCS(
 datasets_br_bcb_taxa_cambio_moeda_flow.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-datasets_br_bcb_taxa_cambio_moeda_flow.schedule = (
-    schedule_every_weekday_taxa_cambio
-)
+# datasets_br_bcb_taxa_cambio_moeda_flow.schedule = (
+#     schedule_every_weekday_taxa_cambio
+# )

--- a/pipelines/datasets/br_cvm_oferta_publica_distribuicao/flows.py
+++ b/pipelines/datasets/br_cvm_oferta_publica_distribuicao/flows.py
@@ -7,9 +7,6 @@ from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 
 from pipelines.constants import constants
-from pipelines.datasets.br_cvm_oferta_publica_distribuicao.schedules import (
-    schedule_dia,
-)
 from pipelines.datasets.br_cvm_oferta_publica_distribuicao.tasks import (
     clean_table_oferta_distribuicao,
     crawl,
@@ -99,4 +96,4 @@ br_cvm_ofe_pub_dis_dia.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_cvm_ofe_pub_dis_dia.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_cvm_ofe_pub_dis_dia.schedule = schedule_dia
+# br_cvm_ofe_pub_dis_dia.schedule = schedule_dia

--- a/pipelines/datasets/br_denatran_frota/flows.py
+++ b/pipelines/datasets/br_denatran_frota/flows.py
@@ -6,10 +6,6 @@ from pipelines.constants import constants as pipelines_constants
 from pipelines.datasets.br_denatran_frota.constants import (
     constants as denatran_constants,
 )
-from pipelines.datasets.br_denatran_frota.schedules import (
-    every_month_municipio,
-    every_month_uf,
-)
 from pipelines.datasets.br_denatran_frota.tasks import (
     crawl_task,
     get_desired_file_task,
@@ -140,7 +136,7 @@ br_denatran_frota_uf_tipo.storage = GCS(
 br_denatran_frota_uf_tipo.run_config = KubernetesRun(
     image=pipelines_constants.DOCKER_IMAGE.value
 )
-br_denatran_frota_uf_tipo.schedule = every_month_uf
+# br_denatran_frota_uf_tipo.schedule = every_month_uf
 
 
 with Flow(
@@ -256,4 +252,4 @@ br_denatran_frota_municipio_tipo.storage = GCS(
 br_denatran_frota_municipio_tipo.run_config = KubernetesRun(
     image=pipelines_constants.DOCKER_IMAGE.value
 )
-br_denatran_frota_municipio_tipo.schedule = every_month_municipio
+# br_denatran_frota_municipio_tipo.schedule = every_month_municipio

--- a/pipelines/datasets/br_inmet_bdmep/flows.py
+++ b/pipelines/datasets/br_inmet_bdmep/flows.py
@@ -3,9 +3,6 @@ from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 
 from pipelines.constants import constants
-from pipelines.datasets.br_inmet_bdmep.schedules import (
-    every_month_inmet,
-)
 from pipelines.datasets.br_inmet_bdmep.tasks import (
     extract_last_date_from_source,
     get_base_inmet,
@@ -179,7 +176,7 @@ br_inmet_microdados.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_inmet_microdados.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_inmet_microdados.schedule = every_month_inmet
+# br_inmet_microdados.schedule = every_month_inmet
 br_inmet_estacao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_inmet_estacao.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
-br_inmet_estacao.schedule = every_month_inmet
+# br_inmet_estacao.schedule = every_month_inmet

--- a/pipelines/datasets/br_me_caged/flows.py
+++ b/pipelines/datasets/br_me_caged/flows.py
@@ -7,11 +7,6 @@ from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 
 from pipelines.constants import constants
-from pipelines.datasets.br_me_caged.schedules import (
-    every_month_movimentacao,
-    every_month_movimentacao_excluida,
-    every_month_movimentacao_fora_prazo,
-)
 from pipelines.datasets.br_me_caged.tasks import (
     build_partitions,
     build_table_paths,
@@ -157,7 +152,7 @@ br_me_caged_microdados_movimentacao.storage = GCS(
 br_me_caged_microdados_movimentacao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_me_caged_microdados_movimentacao.schedule = every_month_movimentacao
+# br_me_caged_microdados_movimentacao.schedule = every_month_movimentacao
 
 with Flow(
     "br_me_caged.microdados_movimentacao_excluida", code_owners=["Luiza"]
@@ -268,9 +263,9 @@ br_me_caged_microdados_movimentacao_excluida.storage = GCS(
 br_me_caged_microdados_movimentacao_excluida.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_me_caged_microdados_movimentacao_excluida.schedule = (
-    every_month_movimentacao_excluida
-)
+# br_me_caged_microdados_movimentacao_excluida.schedule = (
+#     every_month_movimentacao_excluida
+# )
 
 with Flow(
     "br_me_caged.microdados_movimentacao_fora_prazo", code_owners=["Luiza"]
@@ -381,6 +376,6 @@ br_me_caged_microdados_movimentacao_fora_prazo.storage = GCS(
 br_me_caged_microdados_movimentacao_fora_prazo.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_me_caged_microdados_movimentacao_fora_prazo.schedule = (
-    every_month_movimentacao_fora_prazo
-)
+# br_me_caged_microdados_movimentacao_fora_prazo.schedule = (
+#     every_month_movimentacao_fora_prazo
+# )

--- a/pipelines/datasets/br_me_comex_stat/flows.py
+++ b/pipelines/datasets/br_me_comex_stat/flows.py
@@ -10,12 +10,6 @@ from pipelines.constants import constants
 from pipelines.datasets.br_me_comex_stat.constants import (
     constants as comex_constants,
 )
-from pipelines.datasets.br_me_comex_stat.schedules import (
-    schedule_municipio_exportacao,
-    schedule_municipio_importacao,
-    schedule_ncm_exportacao,
-    schedule_ncm_importacao,
-)
 from pipelines.datasets.br_me_comex_stat.tasks import (
     clean_br_me_comex_stat,
     download_br_me_comex_stat,
@@ -132,7 +126,7 @@ br_comex_municipio_exportacao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_comex_municipio_exportacao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_comex_municipio_exportacao.schedule = schedule_municipio_exportacao
+# br_comex_municipio_exportacao.schedule = schedule_municipio_exportacao
 
 
 with Flow(
@@ -232,7 +226,7 @@ br_comex_municipio_importacao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_comex_municipio_importacao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_comex_municipio_importacao.schedule = schedule_municipio_importacao
+# br_comex_municipio_importacao.schedule = schedule_municipio_importacao
 
 
 with Flow(
@@ -331,7 +325,7 @@ br_comex_ncm_exportacao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_comex_ncm_exportacao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_comex_ncm_exportacao.schedule = schedule_ncm_exportacao
+# br_comex_ncm_exportacao.schedule = schedule_ncm_exportacao
 
 
 with Flow(
@@ -428,4 +422,4 @@ br_comex_ncm_importacao.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_comex_ncm_importacao.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_comex_ncm_importacao.schedule = schedule_ncm_importacao
+# br_comex_ncm_importacao.schedule = schedule_ncm_importacao

--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -10,9 +10,6 @@ from pipelines.constants import constants
 from pipelines.datasets.br_rf_cafir.constants import (
     constants as br_rf_cafir_constants,
 )
-from pipelines.datasets.br_rf_cafir.schedules import (
-    schedule_br_rf_cafir_imoveis_rurais,
-)
 from pipelines.datasets.br_rf_cafir.tasks import (
     task_decide_files_to_download,
     task_download_files,
@@ -125,4 +122,4 @@ br_rf_cafir_imoveis_rurais.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_rf_cafir_imoveis_rurais.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_rf_cafir_imoveis_rurais.schedule = schedule_br_rf_cafir_imoveis_rurais
+# br_rf_cafir_imoveis_rurais.schedule = schedule_br_rf_cafir_imoveis_rurais

--- a/pipelines/datasets/br_sfb_sicar/flows.py
+++ b/pipelines/datasets/br_sfb_sicar/flows.py
@@ -10,9 +10,6 @@ from pipelines.constants import constants
 from pipelines.datasets.br_sfb_sicar.constants import (
     Constants,
 )
-from pipelines.datasets.br_sfb_sicar.schedules import (
-    schedule_br_sfb_sicar_area_imovel,
-)
 from pipelines.datasets.br_sfb_sicar.tasks import (
     download_car,
     get_each_uf_release_date,
@@ -120,4 +117,4 @@ br_sfb_sicar_area_imovel.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 br_sfb_sicar_area_imovel.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value
 )
-br_sfb_sicar_area_imovel.schedule = schedule_br_sfb_sicar_area_imovel
+# br_sfb_sicar_area_imovel.schedule = schedule_br_sfb_sicar_area_imovel


### PR DESCRIPTION
## Summary

- Comenta as linhas `flow.schedule = ...` em 12 datasets cujos flows já estão rodando com schedule ativo no Prefect 3 (pool `basedosdados`)
- Sem essa mudança, o próximo build do Prefect 0 re-registra os flows com o schedule original, causando execuções duplicadas

## Datasets afetados

`br_anp_precos_combustiveis`, `br_bcb_agencia`, `br_bcb_estban`, `br_bcb_sicor` (10 flows), `br_bcb_taxa_cambio`, `br_cvm_oferta_publica_distribuicao`, `br_denatran_frota`, `br_inmet_bdmep`, `br_me_caged`, `br_me_comex_stat`, `br_rf_cafir`, `br_sfb_sicar`

> Outros 5 datasets (`br_bcb_taxa_selic`, `br_cnj_improbidade_administrativa`, `br_mp_pep`, `br_poder360_pesquisas`, `br_stf_corte_aberta`) já estavam com schedule comentado no código.
