### PR TITLE
fix: substitui Dockerfile P0 pelo P3 e adiciona entrypoint.sh

### DIFF
--- a/.github/workflows/build-docker-prefect3.yaml
+++ b/.github/workflows/build-docker-prefect3.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - Dockerfile.prefect3
+      - Dockerfile
       - entrypoint.sh
       - pyproject.toml
       - uv.lock
@@ -43,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile.prefect3
+          file: Dockerfile
           push: true
           tags: ${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
       - name: Update work pool image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
-# Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
+FROM prefecthq/prefect:3-python3.12
 
-# Install the project into `/app`
 WORKDIR /app
 
-# Enable bytecode compilation
-ENV UV_COMPILE_BYTECODE=1
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Copy from the cache instead of linking since it's a mounted volume
-ENV UV_LINK_MODE=copy
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# Ensure installed tools can be executed out of the box
-ENV UV_TOOL_BIN_DIR=/usr/local/bin
-
-# Install gcc, Google Chrome, CLI tools, git, R and others libs Firefox
+# Install system dependencies (Chrome, SQL Server client, OCR, etc.)
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl gnupg && \
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && \
@@ -48,16 +39,22 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Then, add the rest of the project source code and install it
-# Installing separately from its dependencies allows optimal layer caching
-COPY . /app
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+# Install Python dependencies directly into the system Python
+COPY pyproject.toml uv.lock README.md ./
+RUN uv export --locked --no-dev --no-hashes --no-emit-project -o /tmp/requirements.txt && \
+    uv pip install --system --no-cache -r /tmp/requirements.txt
 
-# Place executables in the environment at the front of the path
-ENV PATH="/app/.venv/bin:$PATH"
+# dbt deps — copia só os arquivos de configuração do dbt, não o código dos flows
+COPY packages.yml dbt_project.yml profiles.yml README.md ./
+RUN dbt deps
 
-RUN uv run dbt deps && \
-mkdir -p /opt/prefect/app/bases && \
-mkdir -p /root/.basedosdados/templates && \
-mkdir -p /root/.basedosdados/credentials/
+# Diretórios necessários para basedosdados e prefect
+RUN mkdir -p /opt/prefect/app/bases && \
+    mkdir -p /root/.basedosdados/templates && \
+    mkdir -p /root/.basedosdados/credentials/
+
+# Entrypoint: decodifica credenciais antes de iniciar o flow
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["prefect", "worker", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /usr/local/bin/uv
 
 # Install system dependencies (Chrome, SQL Server client, OCR, etc.)
 RUN apt-get update && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Decode GCP credentials before starting the flow.
+# basedosdados lib reads BASEDOSDADOS_CREDENTIALS_* directly (base64).
+# dbt reads /credentials-dev/dev.json and /credentials-prod/prod.json.
+# If DBT_SERVICE_ACCOUNT is set, use it for both dbt targets (dbt-rpc@ SA).
+# Otherwise fall back to decoding BASEDOSDADOS_CREDENTIALS_* (dev worker behaviour).
+
+mkdir -p /credentials-dev /credentials-prod
+
+if [ -n "$DBT_SERVICE_ACCOUNT" ]; then
+    echo "$DBT_SERVICE_ACCOUNT" | base64 -d > /credentials-dev/dev.json
+    echo "$DBT_SERVICE_ACCOUNT" | base64 -d > /credentials-prod/prod.json
+else
+    [ -n "$BASEDOSDADOS_CREDENTIALS_STAGING" ] && \
+        echo "$BASEDOSDADOS_CREDENTIALS_STAGING" | base64 -d > /credentials-dev/dev.json
+    [ -n "$BASEDOSDADOS_CREDENTIALS_PROD" ] && \
+        echo "$BASEDOSDADOS_CREDENTIALS_PROD" | base64 -d > /credentials-prod/prod.json
+fi
+
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,17 +4,28 @@
 # dbt reads /credentials-dev/dev.json and /credentials-prod/prod.json.
 # If DBT_SERVICE_ACCOUNT is set, use it for both dbt targets (dbt-rpc@ SA).
 # Otherwise fall back to decoding BASEDOSDADOS_CREDENTIALS_* (dev worker behaviour).
+set -eu
 
+umask 077
 mkdir -p /credentials-dev /credentials-prod
 
-if [ -n "$DBT_SERVICE_ACCOUNT" ]; then
-    echo "$DBT_SERVICE_ACCOUNT" | base64 -d > /credentials-dev/dev.json
-    echo "$DBT_SERVICE_ACCOUNT" | base64 -d > /credentials-prod/prod.json
+decode() {
+    src="$1" dst="$2"
+    printf '%s' "$src" | base64 -d > "$dst" || {
+        echo "Erro ao decodificar credenciais para $dst" >&2
+        rm -f "$dst"
+        exit 1
+    }
+}
+
+if [ -n "${DBT_SERVICE_ACCOUNT:-}" ]; then
+    decode "$DBT_SERVICE_ACCOUNT" /credentials-dev/dev.json
+    decode "$DBT_SERVICE_ACCOUNT" /credentials-prod/prod.json
 else
-    [ -n "$BASEDOSDADOS_CREDENTIALS_STAGING" ] && \
-        echo "$BASEDOSDADOS_CREDENTIALS_STAGING" | base64 -d > /credentials-dev/dev.json
-    [ -n "$BASEDOSDADOS_CREDENTIALS_PROD" ] && \
-        echo "$BASEDOSDADOS_CREDENTIALS_PROD" | base64 -d > /credentials-prod/prod.json
+    [ -n "${BASEDOSDADOS_CREDENTIALS_STAGING:-}" ] && \
+        decode "$BASEDOSDADOS_CREDENTIALS_STAGING" /credentials-dev/dev.json
+    [ -n "${BASEDOSDADOS_CREDENTIALS_PROD:-}" ] && \
+        decode "$BASEDOSDADOS_CREDENTIALS_PROD" /credentials-prod/prod.json
 fi
 
 exec "$@"


### PR DESCRIPTION
## Problema

O `Dockerfile` no repositório era da stack Prefect 0 (Python 3.10, venv). O build da imagem Prefect 3 falhava porque o workflow `build-docker-prefect3.yaml` referenciava `Dockerfile.prefect3`, que não foi incluído no merge da migração.

## Solução

- Substitui o `Dockerfile` pelo conteúdo do `Dockerfile.prefect3` (base `prefecthq/prefect:3-python3.12`, pacotes instalados no Python do sistema)
- Adiciona `entrypoint.sh` (decodifica `BASEDOSDADOS_CREDENTIALS_STAGING/PROD` e `DBT_SERVICE_ACCOUNT` em `/credentials-{dev,prod}/*.json` antes de iniciar o flow)
- Atualiza `build-docker-prefect3.yaml` para referenciar `Dockerfile` e `entrypoint.sh` (sem `Dockerfile.prefect3`)
