### PR TITLE
fix: corrige AttributeError datetime.datetime em tasks.py

### DIFF
--- a/pipelines/utils/metadata/tasks.py
+++ b/pipelines/utils/metadata/tasks.py
@@ -9,7 +9,7 @@ só precisa escolher um `CoverageSpec` e os identificadores da tabela.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 
 import basedosdados as bd
 from prefect import task
@@ -44,7 +44,7 @@ def get_today_date():
     Sem parâmetros. Útil em flows que precisam carimbar a execução com a data
     corrente (ex.: nomear partições, registrar a data de extração).
     """
-    d = datetime.datetime.today()
+    d = datetime.today()
     return d.strftime("%Y-%m-%d")
 
 
@@ -92,12 +92,12 @@ def _coerce_to_date(value: object, date_format: str) -> datetime.date | None:
     """
     if value is None:
         return None
-    if isinstance(value, datetime.datetime):
+    if isinstance(value, datetime):
         return value.date()
-    if isinstance(value, datetime.date):
+    if isinstance(value, date):
         return value
     if isinstance(value, str):
-        return datetime.datetime.strptime(value, date_format).date()
+        return datetime.strptime(value, date_format).date()
     raise TypeError(f"source_max_date inesperado: {type(value).__name__}")
 
 


### PR DESCRIPTION
## Problema

`tasks.py` importa `from datetime import datetime`, o que faz `datetime` ser a **classe**, não o módulo. Chamadas como `datetime.datetime.today()` e `isinstance(value, datetime.datetime)` falham com:

```
AttributeError: type object 'datetime.datetime' has no attribute 'datetime'
```

O bug só aparecia em prod quando `force_run=False` — nesse caso, `register_source_poll_task` é chamada antes do dbt, e `_coerce_to_date` executa os `isinstance` problemáticos.

## Fix

- Adicionado `date` ao import: `from datetime import date, datetime`
- `datetime.datetime.today()` → `datetime.today()`
- `isinstance(value, datetime.datetime)` → `isinstance(value, datetime)`
- `isinstance(value, datetime.date)` → `isinstance(value, date)`
- `datetime.datetime.strptime(...)` → `datetime.strptime(...)`

As anotações de tipo (`datetime.date | None`) continuam funcionando via `from __future__ import annotations`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal date type validation and coercion logic in metadata processing to enhance robustness and consistency when handling various date input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->