### PR TITLE
fix: correções pós-migração Prefect 3 — utils, gcs, ibge_inflacao, schema_validator

### DIFF
--- a/pipelines/crawler/ibge_inflacao/utils.py
+++ b/pipelines/crawler/ibge_inflacao/utils.py
@@ -375,7 +375,7 @@ def get_date_api(dataset_id: str, table_id: str) -> tuple[date, str]:
 
     except Exception as e:
         log(f"Não há dados recentes na API: {e}")
-        return task_get_api_most_recent_date.run(
+        return task_get_api_most_recent_date.fn(
             dataset_id=dataset_id, table_id=table_id, date_format="%Y-%m"
         )
 
@@ -384,7 +384,7 @@ def next_date_update(
     dataset_id: str,
     table_id: str,
 ) -> str:
-    dt = task_get_api_most_recent_date.run(
+    dt = task_get_api_most_recent_date.fn(
         dataset_id=dataset_id, table_id=table_id, date_format="%Y-%m"
     )
 

--- a/pipelines/datasets/br_anatel_telefonia_movel/flows.py
+++ b/pipelines/datasets/br_anatel_telefonia_movel/flows.py
@@ -1,6 +1,4 @@
-"""
-Flows for br_anatel_telefonia_movel — Prefect 3.
-"""
+"""Flows for br_anatel_telefonia_movel — Prefect 3."""
 
 from prefect import flow
 

--- a/pipelines/utils/gcs.py
+++ b/pipelines/utils/gcs.py
@@ -172,7 +172,14 @@ class DBTArtifactUploader:
         )
 
     def _init_gcs(self) -> None:
-        self._client = storage.Client()
+        # target=prod usa SA prod; demais targets usam SA staging — necessário
+        # porque o bucket basedosdados-dev é requester-pays e a SA prod não tem
+        # serviceusage.services.use no projeto basedosdados-dev.
+        mode = "prod" if self.target == "prod" else "staging"
+        credentials = get_credentials_from_env(mode=mode)
+        self._client = storage.Client(
+            project=self.user_project, credentials=credentials
+        )
         self._bucket = self._client.bucket(
             bucket_name=self.bucket_name, user_project=self.user_project
         )

--- a/pipelines/utils/schema_validator.py
+++ b/pipelines/utils/schema_validator.py
@@ -4,18 +4,17 @@ Deffining table schemas in constants.py is a common practice in our repo
 This validator should be easily integrated within several pipelines
 """
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, model_validator
 
 
 class TableSchemaValidator(BaseModel):
     source_columns: set[str]
     expected_columns: set[str]
 
-    @root_validator(pre=False, skip_on_failure=True)
-    @classmethod
-    def validate_columns(cls, values):
-        source = values.get("source_columns")
-        expected = values.get("expected_columns")
+    @model_validator(mode="after")
+    def validate_columns(self):
+        source = self.source_columns
+        expected = self.expected_columns
 
         missing = expected - source
 
@@ -31,7 +30,7 @@ class TableSchemaValidator(BaseModel):
                 f"There are columns in the source schema being ignorated. {extra}"
             )
 
-        return values
+        return self
 
 
 def validate_schema(source_columns: list[str], expected_columns: list[str]):

--- a/pipelines/utils/schema_validator.py
+++ b/pipelines/utils/schema_validator.py
@@ -11,7 +11,7 @@ class TableSchemaValidator(BaseModel):
     source_columns: set[str]
     expected_columns: set[str]
 
-    @root_validator(pre=False)
+    @root_validator(pre=False, skip_on_failure=True)
     @classmethod
     def validate_columns(cls, values):
         source = values.get("source_columns")

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -62,11 +62,21 @@ def _upload_to_gcs(
     dump_mode: str = "append",
     source_format: str = "csv",
 ) -> None:
+    # billing_project_id casado com o bucket: a SA do pod tem
+    # serviceusage.services.use apenas no próprio projeto; o default
+    # basedosdados-staging da lib dispara 403 em blob.exists().
+    billing_project_id = bucket_name
     tb = bd.Table(
-        dataset_id=dataset_id, table_id=table_id, bucket_name=bucket_name
+        dataset_id=dataset_id,
+        table_id=table_id,
+        bucket_name=bucket_name,
+        billing_project_id=billing_project_id,
     )
     st = bd.Storage(
-        dataset_id=dataset_id, table_id=table_id, bucket_name=bucket_name
+        dataset_id=dataset_id,
+        table_id=table_id,
+        bucket_name=bucket_name,
+        billing_project_id=billing_project_id,
     )
     storage_link = (
         f"https://console.cloud.google.com/storage/browser/"

--- a/pipelines/utils/utils.py
+++ b/pipelines/utils/utils.py
@@ -3,9 +3,13 @@ Utilitários gerais — logging, detecção de ambiente, helpers de string.
 """
 
 import logging
+import zipfile
+from io import BytesIO
 from pathlib import Path
 from typing import Any
+from urllib.request import urlopen
 
+import numpy as np
 import pandas as pd
 
 
@@ -83,3 +87,40 @@ def to_partitions(
             df_slice.to_parquet(out, index=False, compression="gzip")
         else:
             raise ValueError(f"file_type inválido: {file_type!r}")
+
+
+def clean_dataframe(dataframe: pd.DataFrame) -> pd.DataFrame:
+    """Remove null bytes e normaliza strings em colunas object de um DataFrame."""
+    for col in dataframe.columns.tolist():
+        if dataframe[col].dtype == object:
+            try:
+                dataframe[col] = (
+                    dataframe[col]
+                    .astype(str)
+                    .str.replace("\x00", "", regex=True)
+                    .replace("None", np.nan, regex=True)
+                )
+            except Exception as exc:
+                print(
+                    "Column: ",
+                    col,
+                    "\nData: ",
+                    dataframe[col].tolist(),
+                    "\n",
+                    exc,
+                )
+                raise
+    return dataframe
+
+
+def download_and_unzip_file(url: str, path: str) -> None:
+    """Baixa um arquivo ZIP da URL e extrai no caminho indicado."""
+    log(f"Baixando {url} → {path}")
+    try:
+        r = urlopen(url)
+        zf = zipfile.ZipFile(BytesIO(r.read()))
+        zf.extractall(path=path)
+        log(f"Extração concluída: {url} → {path}")
+    except Exception as e:
+        log(e, level="error")
+        raise


### PR DESCRIPTION
## O que esse PR corrige

Correções identificadas na revisão do backup `feat/prefect3-flows-migration-backup` vs `main`. Cinco bugs que ficaram para trás na migração P0 → P3.

---

## Mudanças

### `pipelines/utils/utils.py`
Restaura duas funções removidas na migração que crawlers dependem:
- `clean_dataframe` — usada por `br_bcb_estban`
- `download_and_unzip_file` — usada por todos os crawlers `br_cgu_*`

**Impacto:** desbloqueia 33 flows do Grupo A (bcb_estban × 2, bcb_sicor × 11, cgu × 20) que estavam pausados por `ImportError`.

### `pipelines/utils/schema_validator.py`
Migra `@root_validator(pre=False)` (Pydantic v1 compat) para `@model_validator(mode="after")` (Pydantic v2 nativo).

**Impacto:** corrige `ImportError` no `br_bcb_sicor` e qualquer crawler que importe `validate_schema`.

### `pipelines/utils/gcs.py` — `DBTArtifactUploader._init_gcs`
Substitui `storage.Client()` (usa ADC do pod = SA prod) por seleção explícita de credencial por `target`:
- `target=prod` → `BASEDOSDADOS_CREDENTIALS_PROD`
- demais targets → `BASEDOSDADOS_CREDENTIALS_STAGING`

**Causa do bug:** bucket `basedosdados-dev` é requester-pays; a SA prod (`dbt-rpc@basedosdados`) não tem `serviceusage.services.use` no projeto `basedosdados-dev` → 403 em todo upload de artefato dbt em dev/staging.

### `pipelines/utils/tasks.py` — `_upload_to_gcs`
Adiciona `billing_project_id = bucket_name` em `bd.Table` e `bd.Storage`.

**Causa do bug:** a lib `basedosdados` usa `basedosdados-staging` como billing project padrão; a SA do pod não tem `serviceusage.services.use` nesse projeto → 403 em `blob.exists()` durante uploads.

### `pipelines/crawler/ibge_inflacao/utils.py`
Substitui `.run(...)` por `.fn(...)` em dois call sites (`get_date_api` fallback e `next_date_update`).

**Causa do bug:** `.run()` era a API do Prefect 0 para chamar uma task fora de contexto de flow. No Prefect 3 o equivalente é `.fn()`. Causava `AttributeError: 'Task' object has no attribute 'run'` em runtime.

**Impacto:** corrige os 4 flows `br_ibge_ipca` pausados por esse erro.

---

## Flows desbloqueados após merge

| Dataset | Tabelas | Motivo do desbloqueio |
|---|---|---|
| `br_bcb_estban` | agencia, municipio | `clean_dataframe` restaurada |
| `br_bcb_sicor` | 11 tabelas | `schema_validator` Pydantic v2 + funções utils |
| `br_cgu_beneficios_cidadao` | bpc, garantia_safra, novo_bolsa_familia | `download_and_unzip_file` restaurada |
| `br_cgu_cartao_pagamento` | 3 tabelas | idem |
| `br_cgu_licitacao_contrato` | 7 tabelas | idem |
| `br_cgu_servidores_executivo_federal` | 7 tabelas | idem |
| `br_ibge_ipca` | 4 tabelas | `.run()` → `.fn()` |

> Após o merge, reativar os schedules manualmente no Prefect 3 para os flows acima.