### PR TITLE
fix: set memory limit 8Gi and stagger weekly schedules for br_anatel_telefonia_movel

### DIFF
--- a/.github/scripts/deploy_flows.py
+++ b/.github/scripts/deploy_flows.py
@@ -81,6 +81,8 @@ def deploy_flow(
             for s in schedules
         ]
 
+    job_variables = getattr(flow, "job_variables", None)
+
     print(f"  Registrando {flow_name} → {entrypoint}")
 
     try:
@@ -95,6 +97,7 @@ def deploy_flow(
             work_pool_name=pool_name,
             tags=["automated-deploy"],
             schedules=schedules,
+            job_variables=job_variables,
             build=False,
         )
         status = (

--- a/pipelines/datasets/br_anatel_telefonia_movel/flows.py
+++ b/pipelines/datasets/br_anatel_telefonia_movel/flows.py
@@ -36,18 +36,19 @@ def _anatel_tm_flow(table_id: str, cron: str):
         )
 
     _flow.deploy_schedules = [{"cron": cron, "timezone": "America/Sao_Paulo"}]
+    _flow.job_variables = {"memory_limit": "8Gi", "memory_request": "2Gi"}
     return _flow
 
 
 br_anatel_telefonia_movel__microdados = _anatel_tm_flow(
-    table_id="microdados", cron="30 16 * * *"
+    table_id="microdados", cron="30 16 * * 1"
 )
 br_anatel_telefonia_movel__densidade_municipio = _anatel_tm_flow(
-    table_id="densidade_municipio", cron="30 17 * * *"
+    table_id="densidade_municipio", cron="30 16 * * 2"
 )
 br_anatel_telefonia_movel__densidade_uf = _anatel_tm_flow(
-    table_id="densidade_uf", cron="30 18 * * *"
+    table_id="densidade_uf", cron="30 16 * * 3"
 )
 br_anatel_telefonia_movel__densidade_brasil = _anatel_tm_flow(
-    table_id="densidade_brasil", cron="30 19 * * *"
+    table_id="densidade_brasil", cron="30 16 * * 4"
 )


### PR DESCRIPTION
## Problema

Os 4 flows `br_anatel_telefonia_movel` estavam OOMKilled com o limit padrão de 4Gi do work pool. O download do zip da Anatel (`acessos_telefonia_movel.zip`) exige mais memória para extração e processamento.

Além disso, os schedules eram diários e espaçados apenas 1h — se qualquer flow atrasasse, havia risco de concorrência e pressão de memória no nó.

## Mudanças

### `pipelines/datasets/br_anatel_telefonia_movel/flows.py`
- Adiciona `job_variables = {memory_limit: "8Gi", memory_request: "2Gi"}` nos 4 flows via factory `_anatel_tm_flow`
- Distribui os schedules por dias da semana (seg–qui) para garantir que nunca rodem no mesmo dia

| Flow | Schedule antigo | Schedule novo |
|---|---|---|
| `microdados` | todo dia 16:30 | segunda 16:30 |
| `densidade_municipio` | todo dia 17:30 | terça 16:30 |
| `densidade_uf` | todo dia 18:30 | quarta 16:30 |
| `densidade_brasil` | todo dia 19:30 | quinta 16:30 |

### `.github/scripts/deploy_flows.py`
- Lê `flow.job_variables` (similar ao `flow.deploy_schedules` já existente) e passa para `.deploy()`
- Outros flows sem `job_variables` não são afetados (passa `None`, comportamento idêntico ao anterior)

## Contexto

O work pool `basedosdados` foi atualizado para suportar override de recursos por deployment via variáveis Jinja (`{{ memory_limit }}`, `{{ memory_request }}`, `{{ cpu_limit }}`, `{{ cpu_request }}`), com defaults de 4Gi/1Gi/2/500m. Flows que não declaram `job_variables` continuam com os mesmos valores de antes.

## Test plan

- [ ] Verificar que o deploy CI aplica os `job_variables` nos 4 deployments
- [ ] Confirmar que os outros flows não foram afetados (deployments sem `job_variables` continuam com 4Gi)
- [ ] Após merge, despausar os 4 flows e validar que rodam sem OOMKill
