### PR TITLE
fix: extract table-approve to standalone workflow with push to main trigger

### DIFF
--- a/.github/workflows/table-approve.yaml
+++ b/.github/workflows/table-approve.yaml
@@ -1,0 +1,90 @@
+---
+name: table-approve
+on:
+  push:
+    branches: [main]
+jobs:
+  table-approve:
+    name: table approve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR that triggered the push
+        id: get_pr
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const commits = await github.rest.repos.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha
+            });
+            const commitSha = commits.data[0].sha;
+            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: commitSha
+            });
+            if (prs.data.length === 0) {
+              core.setFailed("No pull request found for this commit.");
+            } else {
+              const pr = prs.data.at(-1);
+              console.log("PR Number", pr.number);
+              console.log(pr)
+              core.setOutput("pr_number", pr.number);
+            }
+      - name: Get PR labels
+        id: check_label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr_number = core.getInput("pr_number") || '${{ steps.get_pr.outputs.pr_number }}';
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number
+            });
+            const approved = labels.data.some(label => label.name === "table-approve");
+            console.log("table-approve label add:", approved);
+            core.setOutput("table-approve", approved);
+      - name: Get changed files in PR
+        if: steps.check_label.outputs.table-approve == 'true'
+        id: changed_files
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr_number = core.getInput("pr_number") || '${{ steps.get_pr.outputs.pr_number }}';
+            const files = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number
+            });
+            const fileNames = files.data
+              .filter(file => file.status !== 'removed')
+              .map(f => f.filename)
+              .join(',');
+            console.log("Changed files:", fileNames);
+            core.setOutput("files", fileNames);
+      - name: Checkout
+        if: steps.check_label.outputs.table-approve == 'true'
+        uses: actions/checkout@v6
+      - name: Install uv
+        if: steps.check_label.outputs.table-approve == 'true'
+        uses: astral-sh/setup-uv@v7
+      - name: Set up python
+        if: steps.check_label.outputs.table-approve == 'true'
+        run: uv python install
+      - name: Install requirements
+        if: steps.check_label.outputs.table-approve == 'true'
+        run: uv sync --locked --only-dev
+      - name: Run prefect flow to execute dbt model in prod
+        if: steps.check_label.outputs.table-approve == 'true'
+        run: |-
+          uv run .github/workflows/scripts/prefect_run_dbt.py \
+            --dbt-command run \
+            --sync-bucket \
+            --modified-files ${{ steps.changed_files.outputs.files }} \
+            --prefect-backend-token ${{ secrets.PREFECT_BACKEND_AUTH_TOML_API_KEY }}
+        env:
+          BASEDOSDADOS_CONFIG: ${{ secrets.BASEDOSDADOS_CONFIG }}
+          BASEDOSDADOS_CREDENTIALS_PROD: ${{ secrets.BASEDOSDADOS_CREDENTIALS_PROD }}
+          BASEDOSDADOS_CREDENTIALS_STAGING: ${{ secrets.BASEDOSDADOS_CREDENTIALS_STAGING }}


### PR DESCRIPTION
Closes #1584

## Problema

O commit `a0b8c92e` alterou o trigger de `cd (production)` de `push: branches:[main]` para `workflow_dispatch`. Como o job `table-approve` vivia dentro desse workflow com `needs: deploy-production`, ele parou de rodar automaticamente no merge para `main`.

## Solução

Extrai o job `table-approve` para um workflow próprio (`.github/workflows/table-approve.yaml`) com trigger `on: push: branches:[main]`.

O job não tem dependência real do `deploy-production` (Prefect 0) — ele só lê o PR mergeado, verifica a label `table-approve` e roda o dbt em prod se a label estiver presente. A dependência era apenas estrutural por estarem no mesmo workflow.

## O que mudou

- Novo arquivo: `.github/workflows/table-approve.yaml` — cópia exata do job `table-approve` de `cd.yaml`, sem o `needs: deploy-production`
- `cd.yaml` não foi alterado

## Test plan

- [ ] Mergear um PR com a label `table-approve` e verificar que o workflow `table-approve` dispara automaticamente
- [ ] Verificar que um PR sem a label `table-approve` não executa o step de dbt (os steps com `if: steps.check_label.outputs.table-approve == 'true'` são pulados)
