### PR TITLE
fix: add latin-1 encoding to br_cgu_pessoal_executivo_federal__terceirizados

### DIFF
--- a/pipelines/crawler/cgu_pessoal_executivo_federal/tasks.py
+++ b/pipelines/crawler/cgu_pessoal_executivo_federal/tasks.py
@@ -72,7 +72,11 @@ def clean_save_table(root: str, url_list: list):
         # handle cases with and without header
         if "id_terc" in csv.text[:20]:
             df_url = pd.read_csv(
-                file_bytes, sep=";", low_memory=False, dtype=str
+                file_bytes,
+                sep=";",
+                low_memory=False,
+                dtype=str,
+                encoding="latin-1",
             )
         else:
             df_url = pd.read_csv(
@@ -82,6 +86,7 @@ def clean_save_table(root: str, url_list: list):
                 names=cols,
                 header=None,
                 dtype=str,
+                encoding="latin-1",
             )
         df = pd.concat([df, df_url], ignore_index=True)
         del df_url

--- a/pipelines/datasets/br_cgu_pessoal_executivo_federal/flows.py
+++ b/pipelines/datasets/br_cgu_pessoal_executivo_federal/flows.py
@@ -1,6 +1,4 @@
-"""
-Flows para br_cgu_pessoal_executivo_federal — Prefect 3.
-"""
+"""Flows para br_cgu_pessoal_executivo_federal — Prefect 3."""
 
 from prefect import flow
 


### PR DESCRIPTION
## Problema

O flow `br_cgu_pessoal_executivo_federal__terceirizados` falha com:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xba in position 252227: invalid start byte
```

Os CSVs do Portal da Transparência da CGU são codificados em latin-1 (ISO-8859-1), não UTF-8.

## Fix

Adicionado `encoding="latin-1"` nos dois `pd.read_csv` em `crawler/cgu_pessoal_executivo_federal/tasks.py` — um para arquivos com header e outro sem.

## Test plan

- [ ] Após merge, despausar o flow e disparar um run de teste
