### PR TITLE
fix: propagate dbt task failure to flow state

### DIFF
--- a/pipelines/utils/execute_dbt_model/flows.py
+++ b/pipelines/utils/execute_dbt_model/flows.py
@@ -108,7 +108,9 @@ def run_dbt_model_flow(
             dataset_id=dataset_id,
             table_id=table_id,
             wait_for=[dbt_done],
-        )
+        ).result()
+    else:
+        dbt_done.result()
 
 
 run_dbt_model_flow.deploy_schedules = []


### PR DESCRIPTION
## Summary

- Sem `.result()` nos futures submetidos em `run_dbt_model_flow`, uma falha em `run_dbt_task` deixava o flow terminar como `Completed` em vez de `Failed`
- O `table-approve` reportava falso positivo de sucesso mesmo quando o dbt falhava
- Adiciona `.result()` no future do download (quando `download_csv_file=True`) e diretamente no future do dbt (quando `download_csv_file=False`), garantindo que exceções das tasks propagam para o flow

## Evidência

**Antes do fix — falso positivo:** task falhou mas flow retornou `Completed`
https://prefect3.basedosdados.org/runs/flow-run/d7669282-1881-4700-a9cf-7236a31e3289

**Depois do fix — comportamento correto:** task falhou e flow retornou `Failed`
https://prefect3.basedosdados.org/runs/flow-run/ffb2fa3b-6853-4710-bc2f-5c30f0df4144

## Test plan

- [ ] Após merge, acionar o `table-approve` e confirmar que falhas no dbt aparecem nos logs do GitHub Actions