### PR TITLE
fix: destrava crawler ibge_inflacao — parser resiliente + Update deferido

### DIFF
--- a/pipelines/crawler/ibge_inflacao/flows.py
+++ b/pipelines/crawler/ibge_inflacao/flows.py
@@ -12,7 +12,8 @@ from pipelines.crawler.ibge_inflacao.tasks import (
 )
 from pipelines.utils.metadata.domain import DateFormat, PartBdpro, YearMonth
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -43,7 +44,7 @@ def _run_ibge_inflacao(
 
     max_date = check_for_updates(dataset_id=dataset_id, table_id=table_id)
 
-    has_new_data = register_source_poll_task(
+    has_new_data = poll_source_for_update_task(
         dataset_id=dataset_id,
         table_id=table_id,
         source_max_date=max_date,
@@ -101,6 +102,14 @@ def _run_ibge_inflacao(
             ),
             env="prod",
             bq_project="basedosdados",
+        )
+
+        commit_source_update_task(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            source_max_date=max_date,
+            env="prod",
+            date_format="%Y-%m",
         )
 
 

--- a/pipelines/crawler/ibge_inflacao/utils.py
+++ b/pipelines/crawler/ibge_inflacao/utils.py
@@ -123,6 +123,9 @@ def json_categoria(table_id: str, dataset_id: str) -> defaultdict:
     dados_agrupados = defaultdict(dict)
 
     for indice_bloco in range(len(df)):
+        if not df[indice_bloco]:
+            continue
+
         total_resultados = len(df[indice_bloco][0]["resultados"])
         for indice_resultado in range(total_resultados):
             total_series = len(
@@ -235,6 +238,9 @@ def json_mes_brasil(table_id: str, dataset_id: str) -> defaultdict:
     dados_agrupados = defaultdict(dict)
 
     for indice_bloco in range(len(df)):
+        if not df[indice_bloco]:
+            continue
+
         total_resultados = len(df[indice_bloco][0]["resultados"])
         for indice_resultado in range(total_resultados):
             total_series = len(
@@ -363,6 +369,11 @@ def get_date_api(dataset_id: str, table_id: str) -> tuple[date, str]:
         df = json.load(f)
 
     try:
+        if not df or not df[0]:
+            raise ValueError(
+                f"[ibge_inflacao] Bloco vazio em get_date_api para {dataset_id}.{table_id} — mês provavelmente não publicado."
+            )
+
         chave_serie = next(
             iter(df[0][0]["resultados"][0]["series"][0]["serie"].keys())
         )

--- a/pipelines/datasets/br_ibge_ipca/flows.py
+++ b/pipelines/datasets/br_ibge_ipca/flows.py
@@ -1,5 +1,8 @@
 """
 Flows para br_ibge_ipca — Prefect 3.
+
+Redeploy disparado para propagar a correção dos parsers de ibge_inflacao
+(guards contra bloco vazio da API do IBGE) em utils.py.
 """
 
 from prefect import flow

--- a/pipelines/utils/metadata/register.py
+++ b/pipelines/utils/metadata/register.py
@@ -55,30 +55,35 @@ def register_source_poll(
     table_id: str,
     source_max_date: datetime.date | None = None,
 ) -> bool:
-    """'Olhei a fonte original hoje.'
+    """'Olhei a fonte original hoje' — versão eager (detecta e grava de uma vez).
 
-    Sempre registra um `RawDataSource.Poll` (data de hoje). Se `source_max_date`
-    é mais novo que o `RawDataSource.Update.latest` atual, grava também esse
-    Update e devolve True. `source_max_date=None` é a forma explícita de "só
-    polei, sem novidade".
+    Compõe `poll_source_for_update` (registra o `RawDataSource.Poll` de hoje e
+    detecta se a fonte tem dados mais novos que o `RawDataSource.Update.latest`
+    atual) com `commit_source_update` (grava esse Update). Se há novidade, grava
+    o Update e devolve True; caso contrário, devolve False sem gravar.
+    `source_max_date=None` é a forma explícita de "só polei, sem novidade".
+
+    Mantém o comportamento original de gravar o Update no mesmo passo do poll.
+    Flows que precisam adiar a gravação para depois da materialização devem
+    chamar `poll_source_for_update` e `commit_source_update` separadamente.
     """
-    client.upsert_raw_source_poll(
-        dataset_id, table_id, latest=datetime.datetime.today()
-    )  # Poll: sempre
 
-    if source_max_date is None:
-        return False
-
-    api_latest = client.get_raw_source_update_latest(dataset_id, table_id)
-    if not policy.should_update_raw_source(api_latest, source_max_date):
-        log("Não há novas atualizações na fonte original")
-        return False
-
-    client.upsert_raw_source_update(
-        dataset_id, table_id, latest=source_max_date
+    has_update = poll_source_for_update(
+        client=client,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        source_max_date=source_max_date,
     )
-    log("Data de atualização da fonte original modificada")
-    return True
+
+    if has_update:
+        commit_source_update(
+            client=client,
+            dataset_id=dataset_id,
+            table_id=table_id,
+            source_max_date=source_max_date,
+        )
+
+    return has_update
 
 
 def register_source_poll_by_size(
@@ -192,3 +197,95 @@ def register_table_materialization(
         )
     else:
         log("Pulando Table.Update: billing != bq_project", "warning")
+
+
+def poll_source_for_update(
+    client, dataset_id, table_id, source_max_date: datetime.date | None = None
+) -> bool:
+    """Detecta se a fonte original tem novidade, sem gravar o Update.
+
+    Sempre registra um ``RawDataSource.Poll`` (data de hoje) e devolve se a
+    fonte traz dados mais novos que o ``RawDataSource.Update.latest`` atual.
+    Ao contrário de :func:`register_source_poll`, **não grava** o Update — essa
+    escrita fica a cargo de :func:`commit_source_update`, chamada só após a
+    materialização. Assim, se o flow falha no meio, o Update não avança e a run
+    seguinte ainda detecta a novidade e retenta.
+
+    Parameters
+    ----------
+    client : MetadataClient
+        Cliente de escrita/leitura do backend de metadados.
+    dataset_id : str
+        ID do dataset no GCP/BigQuery (ex.: ``br_ibge_ipca``).
+    table_id : str
+        ID da tabela no GCP/BigQuery.
+    source_max_date : datetime.date or None, optional
+        Data máxima observada na fonte. ``None`` (padrão) é a forma explícita
+        de "só polei, sem novidade" — grava o Poll e devolve ``False``.
+
+    Returns
+    -------
+    bool
+        ``True`` se a fonte tem dados mais novos que o último Update
+        registrado; ``False`` caso contrário.
+
+    See Also
+    --------
+    commit_source_update : Grava o ``RawDataSource.Update`` ao fim do flow.
+    register_source_poll : Versão eager (detecta e grava numa só chamada).
+    """
+
+    client.upsert_raw_source_poll(
+        dataset_id, table_id, latest=datetime.datetime.today()
+    )
+
+    if source_max_date is None:
+        return False
+
+    api_latest = client.get_raw_source_update_latest(dataset_id, table_id)
+    if not policy.should_update_raw_source(api_latest, source_max_date):
+        log("Não há novas atualizações na fonte original")
+        return False
+
+    log("Há atualizações na fonte original")
+    return True
+
+
+def commit_source_update(
+    client,
+    dataset_id: str,
+    table_id: str,
+    source_max_date: datetime.date,
+) -> None:
+    """Grava o ``RawDataSource.Update`` da fonte original.
+
+    Registra ``source_max_date`` como o novo ``RawDataSource.Update.latest``.
+    É a contraparte de :func:`poll_source_for_update`: deve ser chamada **só ao
+    fim do flow**, depois de a materialização ter dado certo, de modo que o
+    Update só avance quando o dado de fato chegou ao destino. Separar a detecção
+    (poll) da gravação (este commit) é o que evita que uma falha no meio do flow
+    deixe o Update adiantado e trave as runs seguintes.
+
+    Parameters
+    ----------
+    client : MetadataClient
+        Cliente de escrita/leitura do backend de metadados.
+    dataset_id : str
+        ID do dataset no GCP/BigQuery (ex.: ``br_ibge_ipca``).
+    table_id : str
+        ID da tabela no GCP/BigQuery.
+    source_max_date : datetime.date
+        Data máxima observada na fonte, gravada como o novo
+        ``RawDataSource.Update.latest``.
+
+    See Also
+    --------
+    poll_source_for_update : Detecta a novidade sem gravar o Update.
+    register_source_poll : Versão eager (detecta e grava numa só chamada).
+    """
+
+    client.upsert_raw_source_update(
+        dataset_id, table_id, latest=source_max_date
+    )
+
+    log("Data de atualização da fonte original modificada")

--- a/pipelines/utils/metadata/tasks.py
+++ b/pipelines/utils/metadata/tasks.py
@@ -21,6 +21,8 @@ from pipelines.utils.metadata.client import MetadataClient
 from pipelines.utils.metadata.constants import constants as metadata_constants
 from pipelines.utils.metadata.domain import CoverageSpec
 from pipelines.utils.metadata.register import (
+    commit_source_update,
+    poll_source_for_update,
     register_source_poll,
     register_source_poll_by_size,
     register_table_materialization,
@@ -249,4 +251,93 @@ def register_table_materialization_task(
         coverage,
         env=env,
         bq_project=bq_project,
+    )
+
+
+@task(
+    retries=constants.TASK_MAX_RETRIES.value,
+    retry_delay_seconds=constants.TASK_RETRY_DELAY.value,
+)
+def poll_source_for_update_task(
+    dataset_id: str,
+    table_id: str,
+    source_max_date: datetime.date | str | None = None,
+    env: str = "dev",
+    date_format: str = "%Y-%m-%d",
+) -> bool:
+    """Detecta se a fonte original tem novidade hoje, sem gravar o Update.
+
+    Sempre grava um `Poll` na fonte (data de hoje) e devolve se `source_max_date`
+    indica dados mais novos do que o último `Update` registrado — mas, ao
+    contrário de `register_source_poll_task`, **não grava** o Update. A gravação
+    fica a cargo de `commit_source_update_task`, chamada ao fim do flow, após a
+    materialização. Use as duas em par quando a gravação do Update precisa ser
+    adiada para não travar runs futuras se o flow falhar no meio.
+
+    Args:
+        dataset_id: ID do dataset no GCP/BigQuery.
+        table_id: ID da tabela no GCP/BigQuery.
+        source_max_date: data máxima observada na fonte. Aceita `date`,
+            `datetime`, `pd.Timestamp` ou `str` no formato `date_format`. Passe
+            `None` (padrão) para registrar "só polei, sem novidade" — grava o
+            Poll e devolve False.
+        env: backend de destino — `"dev"` (padrão), `"staging"` ou `"prod"`.
+        date_format: formato usado para parsear `source_max_date` quando vier
+            como string. Padrão `"%Y-%m-%d"`; use `"%Y-%m"` ou `"%Y"` conforme a
+            granularidade da string.
+
+    Returns:
+        bool — True se a fonte trouxe novidade (Update ainda não gravado),
+        False caso contrário.
+    """
+
+    client = MetadataClient(env=env)
+    return poll_source_for_update(
+        client,
+        dataset_id,
+        table_id,
+        _coerce_to_date(source_max_date, date_format),
+    )
+
+
+@task(
+    retries=constants.TASK_MAX_RETRIES.value,
+    retry_delay_seconds=constants.TASK_RETRY_DELAY.value,
+)
+def commit_source_update_task(
+    dataset_id: str,
+    table_id: str,
+    source_max_date: datetime.date | str,
+    env: str = "dev",
+    date_format: str = "%Y-%m-%d",
+) -> None:
+    """Grava o `RawDataSource.Update` da fonte original.
+
+    Contraparte de `poll_source_for_update_task`: registra `source_max_date`
+    como o novo `Update.latest`. Deve ser chamada **só ao fim do flow**, depois
+    da materialização bem-sucedida, para que o Update só avance quando o dado de
+    fato chegou ao destino — evitando que uma falha no meio deixe o Update
+    adiantado e trave as runs seguintes.
+
+    Args:
+        dataset_id: ID do dataset no GCP/BigQuery.
+        table_id: ID da tabela no GCP/BigQuery.
+        source_max_date: data máxima observada na fonte, gravada como o novo
+            `Update.latest`. Aceita `date`, `datetime`, `pd.Timestamp` ou `str`
+            no formato `date_format`. Obrigatória — só se commita quando há data.
+        env: backend de destino — `"dev"` (padrão), `"staging"` ou `"prod"`.
+        date_format: formato usado para parsear `source_max_date` quando vier
+            como string. Padrão `"%Y-%m-%d"`; use `"%Y-%m"` ou `"%Y"` conforme a
+            granularidade da string.
+
+    Returns:
+        None.
+    """
+
+    client = MetadataClient(env=env)
+    commit_source_update(
+        client,
+        dataset_id,
+        table_id,
+        _coerce_to_date(source_max_date, date_format),
     )

--- a/pipelines/utils/tests/metadata/test_register_tasks.py
+++ b/pipelines/utils/tests/metadata/test_register_tasks.py
@@ -16,6 +16,8 @@ from pipelines.utils.metadata.domain import DateFormat, PartBdpro, YearMonth
 from pipelines.utils.metadata.policy import CoverageIds
 from pipelines.utils.metadata.tasks import (
     _coerce_to_date,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_source_poll_task,
     register_table_materialization_task,
 )
@@ -86,6 +88,51 @@ def test_source_poll_task_builds_client_with_env_and_delegates():
     mk.assert_called_once_with(env="prod")
     assert result is True
     assert fake.written_entities == ["poll", "raw_source_update"]
+
+
+def test_poll_source_for_update_task_writes_poll_only_not_update():
+    """Variante deferida: mesmo COM novidade, detecta sem gravar o Update.
+
+    Garante a separação que cura o problema (3): o `RawDataSource.Update` NÃO
+    pode ser escrito no poll — só `commit_source_update_task` o grava, ao fim do
+    flow. Se alguém recolar o `upsert_raw_source_update` aqui dentro, este teste
+    quebra.
+    """
+    fake = FakeMetadataClient(
+        raw_source_update_latest=datetime.date(2026, 1, 1)
+    )
+    with patch(
+        "pipelines.utils.metadata.tasks.MetadataClient", return_value=fake
+    ):
+        result = poll_source_for_update_task.fn(
+            "br_ibge_ipca",
+            "mes_brasil",
+            source_max_date="2026-04",
+            env="prod",
+            date_format="%Y-%m",
+        )
+    assert result is True
+    assert fake.written_entities == ["poll"]
+
+
+def test_commit_source_update_task_writes_raw_source_update():
+    """Contraparte do poll deferido: grava só o `RawDataSource.Update`."""
+    fake = FakeMetadataClient(
+        raw_source_update_latest=datetime.date(2026, 1, 1)
+    )
+    with patch(
+        "pipelines.utils.metadata.tasks.MetadataClient", return_value=fake
+    ) as mk:
+        result = commit_source_update_task.fn(
+            "br_ibge_ipca",
+            "mes_brasil",
+            source_max_date="2026-04",
+            env="prod",
+            date_format="%Y-%m",
+        )
+    mk.assert_called_once_with(env="prod")
+    assert result is None
+    assert fake.written_entities == ["raw_source_update"]
 
 
 def test_materialization_task_builds_client_and_bq_and_delegates():


### PR DESCRIPTION
## Contexto

As tabelas do crawler `ibge_inflacao` (`br_ibge_ipca`) pararam de atualizar.
A investigação apontou causas combinadas; este PR resolve duas.

## O que muda

### 1. Parser resiliente a bloco vazio (causa direta do crash)

Guards contra bloco vazio em `json_mes_brasil`, `json_categoria` e
`get_date_api` (`crawler/ibge_inflacao/utils.py`). Quando o IBGE devolve `[]`
para um mês ainda não publicado, o acesso `df[indice_bloco][0]` levantava
`IndexError` e derrubava o flow. Agora o bloco vazio é tratado.

### 2. Gravação do Update deferida (causa da trava permanente)

O `RawDataSource.Update` era gravado no **poll** (início do flow), antes da
materialização. Se o flow falhasse no meio, o Update ficava adiantado e as runs
seguintes desistiam ("Não há novas atualizações") sem retentar. A gravação foi
movida para **depois da materialização**:

- `register.py`: `poll_source_for_update` (só detecta) + `commit_source_update`
  (só grava). `register_source_poll` vira composição dos dois — **comportamento
  eager preservado para os ~22 flows que o usam**.
- `tasks.py`: wrappers `@task` `poll_source_for_update_task` e
  `commit_source_update_task`.
- `flows.py`: poll no início, `commit` no fim (depois de `dbt target=prod` +
  materialização). Com `materialize_after_dump=false`, o flow retorna antes do
  commit — testes em dev não tocam mais o Update de prod.

## Testes

- Unit verdes, incluindo 2 novos que travam a separação poll/commit
  (`poll_source_for_update_task` grava só `["poll"]`; `commit_source_update_task`
  grava só `["raw_source_update"]`).
- Validado em dev (pool `basedosdados-dev`): `force_run=true` +
  `materialize_after_dump=false`. Parser segurou, Update de prod intocado, BQ de
  dev até maio/2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or incomplete IBGE API responses so data processing no longer fails when expected blocks are missing.
  * Enhanced source update flow by separating “update detection” from “metadata commit,” reducing incorrect/partial metadata updates.
* **Tests**
  * Added unit tests validating that polling writes only poll metadata, while committing writes only the raw source update metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->