### PR TITLE
[Data] br_inep_indicadores_educacionais

### DIFF
--- a/models/br_inep_indicadores_educacionais/br_inep_indicadores_educacionais__brasil.sql
+++ b/models/br_inep_indicadores_educacionais/br_inep_indicadores_educacionais__brasil.sql
@@ -7,7 +7,7 @@
         partition_by={
             "field": "ano",
             "data_type": "int64",
-            "range": {"start": 2006, "end": 2024, "interval": 1},
+            "range": {"start": 2006, "end": 2025, "interval": 1},
         },
     )
 }}

--- a/models/br_inep_indicadores_educacionais/br_inep_indicadores_educacionais__brasil.sql
+++ b/models/br_inep_indicadores_educacionais/br_inep_indicadores_educacionais__brasil.sql
@@ -7,7 +7,7 @@
         partition_by={
             "field": "ano",
             "data_type": "int64",
-            "range": {"start": 2006, "end": 2025, "interval": 1},
+            "range": {"start": 2006, "end": 2030, "interval": 1},
         },
     )
 }}


### PR DESCRIPTION
## Descrição do PR:

- Os dados da tabela brasil apresentavam inconsistências entre os ambientes de produção (`basedosdados.br_inep_indicadores_educacionais.brasil`) e dev (`basedosdados-dev.br_inep_indicadores_educacionais_staging.brasil`). Os anos de 2023, 2024 e 2025 estavam com valores incorretos ou nulos em staging. Foi feita a correção desses dados.

  - [x]  Testado localmente
  - [x]  Testado na Cloud


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended the available year coverage for educational indicators data through **2025**, ensuring newer records can continue to load without interruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->