### PR TITLE
[Fix] dbt_project.yml: caminho relativo para packages-install-path

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -17,7 +17,7 @@ test-paths: [tests-dbt]
 macro-paths: [macros]
 snapshot-paths: [snapshots]
 target-path: target  # directory which will store compiled SQL files
-packages-install-path: /app/dbt_packages
+packages-install-path: dbt_packages
 clean-targets:  # directories to be removed by `dbt clean`
   - target
   - dbt_modules


### PR DESCRIPTION
Closes #1605

## Problema

`packages-install-path: /app/dbt_packages` usa um caminho absoluto que só existe dentro do container Docker (`WORKDIR /app`). Rodando `dbt deps` localmente, o dbt tenta criar `/app/dbt_packages` — que não existe — e bloqueia qualquer desenvolvedor que tente materializar modelos sem Docker.

## Solução

Troca para `packages-install-path: dbt_packages` (caminho relativo).

- **Docker**: `WORKDIR /app` + caminho relativo → `/app/dbt_packages` — comportamento idêntico ao anterior
- **Local**: resolve para `./dbt_packages` na raiz do repo

## Testes

**Local:**
- `dbt deps` instalou `dbt_utils` em `./dbt_packages` na raiz do repo ✅
- `dbt test --select br_bd_diretorios_brasil__etnia_indigena --target dev` — **PASS** ✅

**Docker (build local):**
- `docker build` concluiu sem erros ✅
- `ls /app/dbt_packages/` dentro do container retornou `dbt_utils` — instalado no lugar correto ✅

**Dev (imagem `gcr.io/basedosdados-dev/pipelines:dev` buildada a partir deste branch):**
- Flow `BD template: Executa DBT model` com `dataset_id=br_bd_diretorios_brasil`, `table_id=etnia_indigena`, `target=dev` — **Completed** ✅
- Run: https://prefect3.basedosdados.org/runs/flow-run/c3e4ceca-1073-404b-8bd4-be789ed6731a