### PR TITLE
Revert "[Fix] dbt_project.yml: caminho relativo para packages-install-path"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,10 @@ RUN uv export --locked --no-dev --no-hashes --no-emit-project -o /tmp/requiremen
     uv pip install --system --no-cache -r /tmp/requirements.txt
 
 # dbt deps — copia só os arquivos de configuração do dbt, não o código dos flows
+# DBT_PACKAGES_PATH garante que o dbt encontre os pacotes em /app/dbt_packages
+# em runtime (o flow roda a partir de um git clone, não de /app). Em dev local,
+# a variável não existe e o dbt_project.yml cai no default relativo 'dbt_packages'.
+ENV DBT_PACKAGES_PATH=/app/dbt_packages
 COPY packages.yml dbt_project.yml profiles.yml README.md ./
 RUN dbt deps
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -17,7 +17,7 @@ test-paths: [tests-dbt]
 macro-paths: [macros]
 snapshot-paths: [snapshots]
 target-path: target  # directory which will store compiled SQL files
-packages-install-path: /app/dbt_packages
+packages-install-path: "{{ env_var('DBT_PACKAGES_PATH', 'dbt_packages') }}"
 clean-targets:  # directories to be removed by `dbt clean`
   - target
   - dbt_modules

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -17,7 +17,7 @@ test-paths: [tests-dbt]
 macro-paths: [macros]
 snapshot-paths: [snapshots]
 target-path: target  # directory which will store compiled SQL files
-packages-install-path: dbt_packages
+packages-install-path: /app/dbt_packages
 clean-targets:  # directories to be removed by `dbt clean`
   - target
   - dbt_modules


### PR DESCRIPTION
Reverts basedosdados/pipelines#1606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the project’s package installation location to a fixed absolute path, improving consistency in environments where relative paths could cause issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->