### PR TITLE
feat: deploy Prefect 3 flows com paused=True e sync via backend

### DIFF
--- a/.github/scripts/deploy_flows.py
+++ b/.github/scripts/deploy_flows.py
@@ -99,6 +99,7 @@ def deploy_flow(
             schedules=schedules,
             job_variables=job_variables,
             build=False,
+            paused=True,  # schedules activated by backend sync (prod) or manually (dev)
         )
         status = (
             "(sem schedule)"

--- a/.github/workflows/cd-prefect3.yaml
+++ b/.github/workflows/cd-prefect3.yaml
@@ -24,3 +24,11 @@ jobs:
             --pool basedosdados \
             --branch ${{ github.ref_name }} \
             --all
+      - name: Sync deployments with backend
+        env:
+          PREFECT3_AUTH_TOKEN: ${{ secrets.PREFECT3_AUTH_TOKEN }}
+        run: |-
+          curl -sf -X POST https://backend.basedosdados.org/admin-tools/sync-deployments/ \
+            -H "Authorization: Bearer $PREFECT3_AUTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            || echo "⚠️ Backend sync failed — activate flows manually via Django admin"


### PR DESCRIPTION
## Resumo

Parte da nova arquitetura de gestão de schedules (ver issue #1630).

- **`deploy_flows.py`** — adiciona `paused=True` no `.deploy()`; todos os flows chegam pausados após o deploy. O backend sync decide o que ativar em prod; em dev é feito manualmente
- **`cd-prefect3.yaml`** — adiciona step pós-deploy que chama `POST /admin-tools/sync-deployments/` no backend para re-enforçar o estado correto dos flows

Depende do PR basedosdados/backend#1035.

## Plano de testes

- [x] Verificar que o step de sync não quebra o CD quando o backend está indisponível (`|| echo` garante isso)
- [x] Confirmar que flows em dev ainda podem ser rodados manualmente mesmo com `paused=True`
- [x] Validar que o sync ativa os flows corretos após um deploy em produção

## Referências

- Issue: #1620
- Backend PR: basedosdados/backend#1029
