### PR TITLE
[Bugfix] br_anatel_banda_larga_fixa (microdados)

### DIFF
--- a/models/br_anatel_banda_larga_fixa/br_anatel_banda_larga_fixa__microdados.sql
+++ b/models/br_anatel_banda_larga_fixa/br_anatel_banda_larga_fixa__microdados.sql
@@ -6,7 +6,7 @@
         partition_by={
             "field": "ano",
             "data_type": "int64",
-            "range": {"start": 2007, "end": 2023, "interval": 1},
+            "range": {"start": 2007, "end": 2031, "interval": 1},
         },
         cluster_by=["id_municipio", "mes"],
         labels={"project_id": "basedosdados"},

--- a/pipelines/crawler/anatel/banda_larga_fixa/flows.py
+++ b/pipelines/crawler/anatel/banda_larga_fixa/flows.py
@@ -13,7 +13,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -42,17 +43,17 @@ def _run_anatel_banda_larga_fixa(
         ano=new_ano, table_id=table_id
     )
 
-    if not force_run:
-        is_outdated = register_source_poll_task(
-            dataset_id=dataset_id,
-            table_id=table_id,
-            source_max_date=data_source_max_date,
-            env="prod",
-            date_format="%Y-%m",
-        )
-        if not is_outdated:
-            print(f"Não há atualizações para a tabela {table_id}!")
-            return
+    has_new_data = poll_source_for_update_task(
+        dataset_id=dataset_id,
+        table_id=table_id,
+        source_max_date=data_source_max_date,
+        env="prod",
+        date_format="%Y-%m",
+    )
+
+    if not has_new_data and not force_run:
+        print(f"Não há atualizações para a tabela {table_id}!")
+        return
 
     filepath = join_tables_in_function(table_id=table_id, ano=new_ano)
 
@@ -101,4 +102,12 @@ def _run_anatel_banda_larga_fixa(
             ),
             env="prod",
             bq_project="basedosdados",
+        )
+
+        commit_source_update_task(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            source_max_date=data_source_max_date,
+            env="prod",
+            date_format="%Y-%m",
         )

--- a/pipelines/datasets/br_anatel_banda_larga_fixa/README.md
+++ b/pipelines/datasets/br_anatel_banda_larga_fixa/README.md
@@ -1,0 +1,150 @@
+# Documentação do Conjunto de Dados: br_anatel_banda_larga_fixa (Acessos — Banda Larga Fixa)
+
+Este documento centraliza o contexto da base de Acessos de Banda Larga Fixa da Anatel,
+consolidando a causa raiz do congelamento que travou a atualização das tabelas e as
+decisões de engenharia adotadas no fix. Serve de referência para futuros mantenedores.
+
+---
+
+## Sobre o Sistema
+
+Os dados são publicados **mensalmente** pela Anatel e cobrem os acessos ao serviço de
+Banda Larga Fixa (Serviço de Comunicação Multimídia — SCM). O microdado tem
+granularidade fina: uma linha por empresa × tecnologia × velocidade × produto, por
+município e mês. Além do microdado, o conjunto traz a densidade de acessos (por 100
+domicílios) nos níveis Brasil, UF e município.
+
+- Página do conjunto (dados.gov.br): <https://dados.gov.br/dados/conjuntos-dados/acessos---banda-larga-fixa>
+- API de catálogo (o crawler usa p/ achar o recurso ZIP): <https://dados.gov.br/api/publico/conjuntos-dados/acessos---banda-larga-fixa>
+- Arquivo ZIP dos dados (~1 GB): <https://www.anatel.gov.br/dadosabertos/paineis_de_dados/acessos/acessos_banda_larga_fixa.zip>
+- Área técnica responsável na Anatel: PRUV (`pruv@anatel.gov.br`)
+
+> O download real vem do ZIP da Anatel, resolvido via API de catálogo em
+> `banda_larga_fixa/utils.py:download_zip_file`. A landing page antiga
+> (`gov.br/anatel/.../banda-larga-fixa`) está **404** e não é usada pela pipeline.
+
+---
+
+## Causa raiz do congelamento (ponto crítico)
+
+O flow desistia sozinho **antes de materializar**, por causa do poll eager
+`register_source_poll_task` (`pipelines/crawler/anatel/banda_larga_fixa/flows.py`). Esse
+poll comparava duas grandezas incompatíveis:
+
+| lado da comparação                 | valor                 | o que é                                |
+| ---------------------------------- | --------------------- | -------------------------------------- |
+| `source_max` (calculado pelo flow) | `2026-04-01` (dia 01) | **cobertura** — último ano-mês do dado |
+| "última atualização na fonte"      | `2026-06-04` (dia 04) | **data de publicação** do arquivo      |
+
+A regra só atualiza se `source_max > api_latest`. Como a cobertura (abril, dia 01)
+**sempre atrasa** em relação à data de publicação (4 de junho), o resultado era sempre
+`False` → *"não há novas atualizações na fonte"* → o flow retornava sem materializar.
+Ficaria travado até a cobertura passar de julho/2026.
+
+O `2026-06-04` (dia 04) é um **resíduo envenenado**: este poll só grava datas de
+cobertura com dia 01, então o dia 04 veio de um fluxo antigo / cadastro manual que
+gravou a data de modificação do arquivo no campo que o poll lê. Além disso, o poll
+eager tinha um segundo defeito: gravava o `Update` no momento da checagem, mesmo que o
+flow morresse antes de materializar.
+
+**Fix aplicado.** Migração para o poll **deferido**, espelhando
+`pipelines/crawler/ibge_inflacao/flows.py`:
+
+- `poll_source_for_update_task` apenas **detecta** a novidade antes de materializar;
+- `commit_source_update_task` grava o `Update` **só depois** da materialização em prod.
+
+Como o `commit` grava a `source_max` (cobertura, dia 01) como novo `api_latest`, e o
+`upsert_raw_source_update` grava **sem trava monotônica**, esse commit **sobrescreve o
+`2026-06-04` envenenado** por uma data de cobertura. A partir daí o poll compara
+cobertura × cobertura (correto), e um crash no meio do flow não adianta mais o `Update`.
+
+---
+
+## Revisão histórica da fonte (verificação 2026-07-06)
+
+Baixando o ZIP e comparando a contagem de linhas por mês com o prod (script
+`task_davi/verifica_fonte_blf.py`), observou-se que a Anatel **revisa meses passados
+para cima** conforme chegam registros atrasados — e que a fonte já havia publicado
+**maio/2026** enquanto o prod estava preso em abril:
+
+| mês     | fonte  | BQ (prod) | diff          |
+| ------- | ------ | --------- | ------------- |
+| 2026-01 | 698274 | 696371    | +1903         |
+| 2026-02 | 698074 | 692951    | +5123         |
+| 2026-03 | 679799 | 671575    | +8224         |
+| 2026-04 | 684785 | 669968    | +14817        |
+| 2026-05 | 652876 | —         | novo na fonte |
+
+Os diffs positivos crescem com a recência do mês (assinatura de revisão histórica). Isso
+tem uma consequência prática importante: como o upload é `append` e o model dbt é
+`create or replace` a partir do staging, o `force_run` **re-materializa do staging
+revisado e realinha sozinho** — o backfill é idempotente por partição e, portanto,
+seguro de reexecutar.
+
+---
+
+## Tabelas e Particularidades
+
+### br_anatel_banda_larga_fixa__microdados
+
+Granularidade: uma linha por empresa × tecnologia × velocidade × produto por
+município e mês. Sem chave única simples (por isso não há teste de unicidade).
+
+**Range de partição.** A partição por `ano` estava com `end: 2023`, mas o dado já vai
+até 2026 — os anos 2024–2026 (os mais consultados) caíam na partição de overflow
+`__UNPARTITIONED__` e perdiam *partition pruning*. Corrigido para `end: 2031`
+(convenção BD: último ano + 5). Como o model é `create or replace`, o novo
+particionamento entra sozinho na próxima materialização completa.
+
+**`acessos` NULL em 2017–2020.** A coluna `acessos` é nula em ~61–66% das linhas de
+2017 a 2020 (e ~12% em 2007), com 0% nos demais anos. É **característica da fonte**, não
+regressão: o padrão é idêntico em dev e prod e casa com um salto de volume (~3,3× de
+2016 para 2017), sugerindo que a Anatel passou a emitir linhas decompostas sem o valor
+de acesso preenchido. **Investigação pendente** (não bloqueia o fix do congelamento):
+abrir os CSVs de 2017–2020 e comparar os headers com `RENAME_MICRODADOS`
+(`constants.py`) para decidir entre documentar (decomposição legítima) ou corrigir o
+parse.
+
+### Densidades: `densidade_brasil`, `densidade_uf`, `densidade_municipio`
+
+Densidade = acessos por 100 domicílios. Níveis geográficos consistentes em 1 (Brasil) /
+27 (UF) / 5570 (município) por mês. Durante o congelamento, as densidades `uf` e
+`municipio` ficaram **1 mês atrás** do microdados (paradas em março enquanto a fonte já
+tinha abril); o fix realinha na próxima materialização.
+
+---
+
+## Estrutura dos Flows
+
+Um flow por tabela em `pipelines/datasets/br_anatel_banda_larga_fixa/flows.py`, gerado
+por `_anatel_blf_flow(table_id, cron)` e agendado em horários distintos. Todos delegam
+a `_run_anatel_banda_larga_fixa` (`pipelines/crawler/anatel/banda_larga_fixa/flows.py`).
+
+### Parâmetros de execução
+
+| Parâmetro                | Default  | Observação                                                                |
+| ------------------------ | -------- | ------------------------------------------------------------------------- |
+| `ano`                    | `None`   | Ano a processar; `None` deriva o ano corrente do ZIP                      |
+| `target`                 | `"prod"` | Use `"dev"` para testes                                                   |
+| `materialize_after_dump` | `True`   | Quando `True`, escreve no bucket `basedosdados` (prod) e materializa prod |
+| `update_metadata`        | `True`   | Grava o Update de fonte (poll deferido) após materializar                 |
+| `force_run`              | `False`  | `True` ignora o poll e força o dump/materialização                        |
+
+> **Testes em dev sem tocar prod:** rode com `target="dev"`,
+> `materialize_after_dump=False`, `force_run=True`. Com os defaults
+> (`target="prod"`, `materialize_after_dump=True`), o flow grava no bucket de
+> **produção** mesmo rodando no worker de dev.
+
+---
+
+## Histórico de Correções
+
+- **Destravamento da atualização (PR #____):** substituição do poll eager
+  (`register_source_poll_task`) pelo par deferido (`poll_source_for_update_task` +
+  `commit_source_update_task`), que reescreve o `Update` envenenado (`2026-06-04`) por
+  uma data de cobertura e só grava após materializar. No mesmo PR, extensão do range de
+  partição do `microdados` (`end` 2023 → 2031). Recuperação do backlog (maio/2026 +
+  revisões dos meses anteriores) via `force_run` por tabela.
+
+> O `telefonia_movel` (`pipelines/crawler/anatel/telefonia_movel/flows.py`) tem o
+> **mesmo** poll eager — o mesmo fix se aplica lá, em correção à parte.

--- a/pipelines/datasets/br_anatel_banda_larga_fixa/README.md
+++ b/pipelines/datasets/br_anatel_banda_larga_fixa/README.md
@@ -108,17 +108,35 @@ parse.
 ### Densidades: `densidade_brasil`, `densidade_uf`, `densidade_municipio`
 
 Densidade = acessos por 100 domicílios. Níveis geográficos consistentes em 1 (Brasil) /
-27 (UF) / 5570 (município) por mês. Durante o congelamento, as densidades `uf` e
-`municipio` ficaram **1 mês atrás** do microdados (paradas em março enquanto a fonte já
-tinha abril); o fix realinha na próxima materialização.
+27 (UF) / 5570 (município) por mês.
+
+**A fonte apagou a densidade de 2023–2025.** O ZIP atual da Anatel publica 2023 e 2024
+com as linhas em branco em todos os níveis (Brasil, UF e município) e quase todo 2025
+vazio; retoma parcial em 2026. Prod ainda serve esses anos **completos**, materializado
+de uma versão anterior da fonte. Por isso as 3 tabelas de densidade estão **sem schedule**
+(`cron=None` em `flows.py`): um run automático re-materializaria do arquivo degradado e
+**regrediria o prod** (ex.: município 2025 cairia de 66.840 → 250 linhas). Elas só rodam
+via `force_run` manual. Reativar o cron somente após a decisão sobre a fonte (o apagão é
+transitório — recálculo de densidade? — ou permanente? confirmar com a PRUV). O
+`microdados` (acessos) **não** regrediu e mantém o schedule normal (`0 15 * * *`).
+
+**Crons originais das densidades** (timezone `America/Sao_Paulo`), para restaurar ao
+reativar o schedule:
+
+| tabela | cron original |
+| ------ | ------------- |
+| `densidade_municipio` | `0 16 * * *` (16h) |
+| `densidade_brasil` | `0 17 * * *` (17h) |
+| `densidade_uf` | `0 18 * * *` (18h) |
 
 ---
 
 ## Estrutura dos Flows
 
 Um flow por tabela em `pipelines/datasets/br_anatel_banda_larga_fixa/flows.py`, gerado
-por `_anatel_blf_flow(table_id, cron)` e agendado em horários distintos. Todos delegam
-a `_run_anatel_banda_larga_fixa` (`pipelines/crawler/anatel/banda_larga_fixa/flows.py`).
+por `_anatel_blf_flow(table_id, cron)`. O `microdados` tem cron diário; as 3 densidades
+vão com `cron=None` (sem schedule — ver seção Densidades). Todos delegam a
+`_run_anatel_banda_larga_fixa` (`pipelines/crawler/anatel/banda_larga_fixa/flows.py`).
 
 ### Parâmetros de execução
 

--- a/pipelines/datasets/br_anatel_banda_larga_fixa/flows.py
+++ b/pipelines/datasets/br_anatel_banda_larga_fixa/flows.py
@@ -12,7 +12,7 @@ from pipelines.crawler.anatel.banda_larga_fixa.flows import (
 )
 
 
-def _anatel_blf_flow(table_id: str, cron: str):
+def _anatel_blf_flow(table_id: str, cron: str | None):
     @flow(
         name=f"br_anatel_banda_larga_fixa__{table_id}",
         log_prints=True,
@@ -39,7 +39,9 @@ def _anatel_blf_flow(table_id: str, cron: str):
             force_run=force_run,
         )
 
-    _flow.deploy_schedules = [{"cron": cron, "timezone": "America/Sao_Paulo"}]
+    _flow.deploy_schedules = (
+        [{"cron": cron, "timezone": "America/Sao_Paulo"}] if cron else []
+    )
     return _flow
 
 
@@ -47,11 +49,11 @@ br_anatel_banda_larga_fixa__microdados = _anatel_blf_flow(
     table_id="microdados", cron="0 15 * * *"
 )
 br_anatel_banda_larga_fixa__densidade_municipio = _anatel_blf_flow(
-    table_id="densidade_municipio", cron="0 16 * * *"
+    table_id="densidade_municipio", cron=None
 )
 br_anatel_banda_larga_fixa__densidade_brasil = _anatel_blf_flow(
-    table_id="densidade_brasil", cron="0 17 * * *"
+    table_id="densidade_brasil", cron=None
 )
 br_anatel_banda_larga_fixa__densidade_uf = _anatel_blf_flow(
-    table_id="densidade_uf", cron="0 18 * * *"
+    table_id="densidade_uf", cron=None
 )

--- a/pipelines/datasets/br_anatel_banda_larga_fixa/flows.py
+++ b/pipelines/datasets/br_anatel_banda_larga_fixa/flows.py
@@ -1,5 +1,8 @@
 """
 Flows for br_anatel_banda_larga_fixa — Prefect 3.
+
+Contexto e decisões do fix de atualização (poll deferido): ver o README.md
+deste diretório.
 """
 
 from prefect import flow


### PR DESCRIPTION
## Nomeação do Pull Request

- [ ] **[Feature]**
- [ ] **[Data]**
- [x] **[Bugfix]**
- [ ] **[Refactor]**
- [ ] **[Docs]**
- [ ] **[Test]**
- [ ] **[Chore]**
- [x] **[Deactivate]**

## Descrição do PR

Destrava a atualização da tabela **`microdados`** do `br_anatel_banda_larga_fixa` (congelada há meses) e, no mesmo deploy, **desativa o schedule das 3 tabelas de densidade** para evitar regressão de dado em prod. Os *fixes de tratamento* das densidades ficam num PR separado.

- **Motivação/Contexto:** o flow desistia **antes de materializar** por causa do poll eager `register_source_poll_task`, que comparava grandezas incompatíveis — `source_max` = cobertura (último ano-mês do dado, dia 01, ~`2026-04-01`) contra `api_latest` = data de **publicação** do arquivo (`2026-06-04`, resíduo envenenado). Como a cobertura sempre atrasa a publicação, `source_max > api_latest` era sempre `False` → "não há novas atualizações" → não materializava. O poll eager ainda gravava o `Update` no momento da checagem, mesmo que o flow morresse antes de materializar.

## Detalhes Técnicos

- **Principais alterações na pipeline/scripts:**
  - Poll eager → **deferido** (`pipelines/crawler/anatel/banda_larga_fixa/flows.py`), espelhando `crawler/ibge_inflacao/flows.py`: `poll_source_for_update_task` só **detecta** a novidade antes de materializar; `commit_source_update_task` grava o `Update` **só depois** de materializar. Como grava a cobertura (dia 01) como novo `api_latest` sem trava monotônica, **sobrescreve o `2026-06-04` envenenado** → o poll passa a comparar cobertura × cobertura.
  - **Densidades sem schedule** (`pipelines/datasets/br_anatel_banda_larga_fixa/flows.py`): as 3 tabelas de densidade passam a ser criadas com `cron=None` → deployam sem schedule (só rodam via `force_run`). Os crons originais ficam documentados no README para restaurar. Ver Riscos.
  - Range de partição do `microdados` (`…__microdados.sql`): `end` 2023 → 2031 (anos 2024–2026 caíam no `__UNPARTITIONED__`).
- **Mudanças nos dados e no schema:** sem mudança de colunas/schema. O `microdados` volta a atualizar (destravado, chega a 2026-05). As densidades **não** são materializadas por este PR (schedule off; `force_run` manual apenas).
- **Impacto no desempenho:** *partition pruning* restaurado nos anos recentes do `microdados` (2024–2026), que eram os mais consultados.

## Teste e Validações

- [x] Testado localmente
- [x] Testado na Cloud

**Info:** flow do microdados rodado em dev (`target=dev`, `materialize_after_dump=False`, `force_run=true`): avançou de 2026-04 → **2026-05**, contagens de 2026 batendo com a fonte (jan–abr + maio), sem duplicação. `ruff` ok.

## Riscos e Mitigações

- **Risco:** o fix do poll está na função **compartilhada** `_run_anatel_banda_larga_fixa`, então destrava **todas** as tabelas. As densidades **não podem** materializar em prod agora: a fonte da Anatel **apagou a densidade de 2023–2025** (publica em branco), enquanto o prod tem o dado completo — um run automático regrediria o prod (ex.: município 2025 de 66.840 → 250 linhas). 
- **Mitigação (já neste PR):** as 3 densidades vão com `cron=None` → **não disparam sozinhas**; deployam paradas e só rodam via `force_run` manual. Crons originais documentados no README para reativar após a decisão sobre a fonte.
- **Ação no deploy:** rodar `force_run` **apenas do microdados**; **não** rodar as densidades.
- **Plano de rollback:** reverter o commit do poll deferido (o microdados recongelaria, sem risco de regressão); as densidades já estão inertes (sem schedule).

## Dependencias

- [x] Nenhuma dependência adicional. Os fixes de tratamento das densidades (`_parse_densidade`, `dtype=str`, `dropna`) vêm num **PR de follow-up** (não bloqueia este).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved data refresh handling so updates only run when new source data is available, with a manual override still supported.
  * Adjusted scheduling so some dataset updates no longer run automatically on a cron schedule.

* **Bug Fixes**
  * Extended the supported year range for the microdata partitioning, helping newer data load correctly.

* **Documentation**
  * Added a detailed dataset guide covering access, refresh behavior, and dataset-specific notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->