### PR TITLE
fix: adia gravação de histórico/Update da fonte para depois da materialização

### DIFF
--- a/pipelines/crawler/bcb/flows.py
+++ b/pipelines/crawler/bcb/flows.py
@@ -17,7 +17,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_by_size_task,
+    commit_source_size_update_task,
+    poll_source_size_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -81,14 +82,14 @@ def _run_bcb_sicor(
     )
 
     if not force_run:
-        is_outdated = register_source_poll_by_size_task(
+        has_new_data = poll_source_size_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             byte_length=table_size,
             env="prod",
             local_execution=local_redis_execution,
         )
-        if not is_outdated:
+        if not has_new_data:
             print(f"Não há atualizações para a tabela {table_id}!")
             return
 
@@ -143,4 +144,12 @@ def _run_bcb_sicor(
             coverage=_sicor_coverage(coverage_type, historical_database),
             env="prod",
             bq_project="basedosdados",
+        )
+
+        commit_source_size_update_task(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            byte_length=table_size,
+            env="prod",
+            local_execution=local_redis_execution,
         )

--- a/pipelines/crawler/cgu/flows.py
+++ b/pipelines/crawler/cgu/flows.py
@@ -16,7 +16,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -44,6 +45,7 @@ def _materialize_and_metadata(
     materialize_after_dump: bool,
     update_metadata: bool,
     coverage: CoverageSpec,
+    source_max_date=None,
 ) -> None:
     upload_to_gcs(
         data_path=filepath,
@@ -89,6 +91,15 @@ def _materialize_and_metadata(
             bq_project="basedosdados",
         )
 
+        if source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=source_max_date,
+                env="prod",
+                date_format="%Y-%m",
+            )
+
 
 def _run_cgu_cartao_pagamento(
     dataset_id: str,
@@ -109,14 +120,14 @@ def _run_cgu_cartao_pagamento(
     )
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             return
 
     filepath = partition_data(table_id=table_id, dataset_id=dataset_id)
@@ -128,6 +139,7 @@ def _run_cgu_cartao_pagamento(
         target=target,
         materialize_after_dump=materialize_after_dump,
         update_metadata=update_metadata,
+        source_max_date=data_source_max_date,
         coverage=_part_bdpro_year_month("ano_extrato", "mes_extrato"),
     )
 
@@ -158,14 +170,14 @@ def _run_cgu_servidores_publicos(
     )
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             return
 
     filepath = partition_data(table_id=table_id, dataset_id=dataset_id)
@@ -177,6 +189,7 @@ def _run_cgu_servidores_publicos(
         target=target,
         materialize_after_dump=materialize_after_dump,
         update_metadata=update_metadata,
+        source_max_date=data_source_max_date,
         coverage=_part_bdpro_year_month("ano", "mes"),
     )
 
@@ -200,14 +213,14 @@ def _run_cgu_licitacao_contrato(
     )
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             return
 
     filepath = partition_data(table_id=table_id, dataset_id=dataset_id)
@@ -219,6 +232,7 @@ def _run_cgu_licitacao_contrato(
         target=target,
         materialize_after_dump=materialize_after_dump,
         update_metadata=update_metadata,
+        source_max_date=data_source_max_date,
         coverage=_part_bdpro_year_month("ano", "mes"),
     )
 
@@ -242,14 +256,14 @@ def _run_cgu_beneficios_cidadao(
     )
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             return
 
     filepath = read_and_partition_beneficios_cidadao(table_id=table_id)
@@ -261,5 +275,6 @@ def _run_cgu_beneficios_cidadao(
         target=target,
         materialize_after_dump=materialize_after_dump,
         update_metadata=update_metadata,
+        source_max_date=data_source_max_date,
         coverage=_part_bdpro_year_month(**dict_for_table(table_id)),
     )

--- a/pipelines/crawler/cvm/flows.py
+++ b/pipelines/crawler/cvm/flows.py
@@ -14,7 +14,8 @@ from pipelines.utils.metadata.domain import (
     DateOnly,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -43,14 +44,14 @@ def _run_cvm_fi(
     print(f"Links e datas: {df}")
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=max_date,
             env="prod",
             date_format="%Y-%m-%d",
         )
-        if not is_outdated:
+        if not has_new_data:
             print(
                 "Sem atualizações na fonte — aguardando próxima execução agendada"
             )
@@ -112,3 +113,12 @@ def _run_cvm_fi(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=max_date,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )

--- a/pipelines/crawler/datasus/flows.py
+++ b/pipelines/crawler/datasus/flows.py
@@ -21,7 +21,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -53,14 +54,14 @@ def _run_cnes(
     source_max_date = get_datasus_source_max_date(ftp_files)
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=source_max_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             print("Fonte CNES sem novidade — encerrando")
             return
 
@@ -122,6 +123,15 @@ def _run_cnes(
             bq_project="basedosdados",
         )
 
+        if source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=source_max_date,
+                env="prod",
+                date_format="%Y-%m",
+            )
+
 
 def _run_dbf_to_parquet(
     dataset_id: str,
@@ -148,14 +158,14 @@ def _run_dbf_to_parquet(
     source_max_date = get_datasus_source_max_date(ftp_files)
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=source_max_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             print(f"Fonte {fonte_label} sem novidade — encerrando")
             return
 
@@ -218,6 +228,15 @@ def _run_dbf_to_parquet(
             bq_project="basedosdados",
         )
 
+        if source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=source_max_date,
+                env="prod",
+                date_format="%Y-%m",
+            )
+
 
 def _run_siasus(**kwargs) -> None:
     _run_dbf_to_parquet(source_format="csv", fonte_label="SIA", **kwargs)
@@ -245,14 +264,14 @@ def _run_sinan(
     )
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m-%d",
         )
-        if not is_outdated:
+        if not has_new_data:
             print("Sem atualizações na fonte SINAN — encerrando")
             return
 
@@ -311,3 +330,12 @@ def _run_sinan(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if data_source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=data_source_max_date,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )

--- a/pipelines/crawler/me_cnpj/flows.py
+++ b/pipelines/crawler/me_cnpj/flows.py
@@ -13,7 +13,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -50,14 +51,14 @@ def _run_me_cnpj(
     max_folder_date, max_last_modified_date = get_data_source_max_date()
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=max_folder_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             print(f"Não há atualizações para a tabela {tabelas}!")
             return
 
@@ -122,6 +123,15 @@ def _run_me_cnpj(
                 ),
                 env="prod",
                 bq_project="basedosdados",
+            )
+
+        if max_folder_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=max_folder_date,
+                env="prod",
+                date_format="%Y-%m",
             )
 
     # estabelecimentos: atualiza diretório de empresas + download p/ GCS

--- a/pipelines/crawler/rf/flows.py
+++ b/pipelines/crawler/rf/flows.py
@@ -14,7 +14,8 @@ from pipelines.utils.metadata.domain import (
     PartBdpro,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -42,7 +43,7 @@ def _run_rf(
     last_update_original_source = check_need_for_update(dataset_id=dataset_id)
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=last_update_original_source,
@@ -50,7 +51,7 @@ def _run_rf(
             date_format="%Y-%m-%d",
         )
 
-        if not is_outdated:
+        if not has_new_data:
             return
 
     crawl(dataset_id=dataset_id, input_dir="input")
@@ -110,3 +111,12 @@ def _run_rf(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if last_update_original_source is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=last_update_original_source,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )

--- a/pipelines/crawler/tse_eleicoes/flows.py
+++ b/pipelines/crawler/tse_eleicoes/flows.py
@@ -13,7 +13,8 @@ from pipelines.utils.metadata.domain import (
     YearOnly,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -40,14 +41,14 @@ def _run_tse_eleicoes(
     data_source_max_date = get_data_source_max_date(flow_class=flow)
 
     if not force_run:
-        outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m-%d",
         )
-        if not outdated:
+        if not has_new_data:
             return
 
     ready_data_path = preparing_data(flow_class=flow)
@@ -102,3 +103,12 @@ def _run_tse_eleicoes(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if data_source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=data_source_max_date,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )

--- a/pipelines/datasets/br_anp_precos_combustiveis/flows.py
+++ b/pipelines/datasets/br_anp_precos_combustiveis/flows.py
@@ -16,7 +16,8 @@ from pipelines.utils.metadata.domain import (
     PartBdpro,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -46,14 +47,14 @@ def br_anp_precos_combustiveis__microdados(
     data_source_max_date = get_data_source_anp_max_date()
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m-%d",
         )
-        if not is_outdated:
+        if not has_new_data:
             print(f"Não há atualizações para a tabela {table_id}!")
             return
 
@@ -107,6 +108,15 @@ def br_anp_precos_combustiveis__microdados(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if data_source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=data_source_max_date,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )
 
 
 br_anp_precos_combustiveis__microdados.deploy_schedules = [

--- a/pipelines/datasets/br_ans_beneficiario/flows.py
+++ b/pipelines/datasets/br_ans_beneficiario/flows.py
@@ -16,7 +16,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -46,19 +47,19 @@ def br_ans_beneficiario__informacao_consolidada(
     )
 
     links_and_dates = extract_links_and_dates(url=url)
+    file_last_date = get_file_max_date(df=links_and_dates)
 
     if force_run:
         files = files_to_download(df=links_and_dates, year=year)
     else:
-        file_last_date = get_file_max_date(df=links_and_dates)
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=file_last_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             print(f"Não há atualizações para a tabela {table_id}!")
             return
         files = files_to_download(df=links_and_dates, year=None)
@@ -120,6 +121,15 @@ def br_ans_beneficiario__informacao_consolidada(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if file_last_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=file_last_date,
+                env="prod",
+                date_format="%Y-%m",
+            )
 
 
 br_ans_beneficiario__informacao_consolidada.deploy_schedules = [

--- a/pipelines/datasets/br_bcb_agencia/flows.py
+++ b/pipelines/datasets/br_bcb_agencia/flows.py
@@ -17,7 +17,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
     task_get_api_most_recent_date,
 )
@@ -55,14 +56,14 @@ def br_bcb_agencia__agencia(
     _, data_source_max_date = get_latest_file(documents_metadata)
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             print(f"Não há atualizações para a tabela {table_id}!")
             return
 
@@ -132,6 +133,15 @@ def br_bcb_agencia__agencia(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if data_source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=data_source_max_date,
+                env="prod",
+                date_format="%Y-%m",
+            )
 
 
 br_bcb_agencia__agencia.deploy_schedules = [

--- a/pipelines/datasets/br_bcb_estban/flows.py
+++ b/pipelines/datasets/br_bcb_estban/flows.py
@@ -18,7 +18,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
     task_get_api_most_recent_date,
 )
@@ -51,14 +52,14 @@ def _run_bcb_estban(
     _, data_source_max_date = get_latest_file(documents_metadata)
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             print(f"Não há atualizações para a tabela {table_id}!")
             return
 
@@ -129,6 +130,15 @@ def _run_bcb_estban(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if data_source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=data_source_max_date,
+                env="prod",
+                date_format="%Y-%m",
+            )
 
 
 def _estban_flow(table_id: str, cron: str):

--- a/pipelines/datasets/br_bcb_taxa_selic/flows.py
+++ b/pipelines/datasets/br_bcb_taxa_selic/flows.py
@@ -14,7 +14,8 @@ from pipelines.utils.metadata.domain import (
     DateOnly,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -85,14 +86,14 @@ def br_bcb_taxa_selic__taxa_selic(
     file_info = treat_selic_data()
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=file_info["max_date"],
             env="prod",
             date_format="%Y-%m-%d",
         )
-        if not is_outdated:
+        if not has_new_data:
             return
 
     upload_to_gcs(
@@ -141,6 +142,15 @@ def br_bcb_taxa_selic__taxa_selic(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if file_info["max_date"] is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=file_info["max_date"],
+                env="prod",
+                date_format="%Y-%m-%d",
+            )
 
 
 br_bcb_taxa_selic__taxa_selic.deploy_schedules = [

--- a/pipelines/datasets/br_cgu_emendas_parlamentares/flows.py
+++ b/pipelines/datasets/br_cgu_emendas_parlamentares/flows.py
@@ -15,7 +15,8 @@ from pipelines.utils.metadata.domain import (
     YearOnly,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -45,14 +46,14 @@ def br_cgu_emendas_parlamentares__microdados(
     max_modified_time = get_last_modified_time()
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=max_modified_time,
             env="prod",
             date_format="%Y-%m-%d",
         )
-        if not is_outdated:
+        if not has_new_data:
             return
 
     output_path = convert_str_to_float()
@@ -106,6 +107,15 @@ def br_cgu_emendas_parlamentares__microdados(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if max_modified_time is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=max_modified_time,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )
 
 
 br_cgu_emendas_parlamentares__microdados.deploy_schedules = [

--- a/pipelines/datasets/br_denatran_frota/flows.py
+++ b/pipelines/datasets/br_denatran_frota/flows.py
@@ -20,7 +20,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -56,14 +57,14 @@ def _run_denatran(
     print(f"First available date: {source_first_available_date_str}")
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=source_first_available_date_str,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             print("No new data to be downloaded")
             return
 
@@ -131,6 +132,15 @@ def _run_denatran(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if source_first_available_date_str is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=source_first_available_date_str,
+                env="prod",
+                date_format="%Y-%m",
+            )
 
 
 @flow(

--- a/pipelines/datasets/br_ibge_pnadc/flows.py
+++ b/pipelines/datasets/br_ibge_pnadc/flows.py
@@ -15,7 +15,8 @@ from pipelines.utils.metadata.domain import (
     YearQuarter,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -46,14 +47,14 @@ def br_ibge_pnadc__microdados(
     data_source_max_date, url = get_data_source_date_and_url()
 
     if not force_run:
-        outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m-%d",
         )
-        if not outdated:
+        if not has_new_data:
             return
 
     input_dir, output_dir = build_table_paths(table_id=table_id)
@@ -106,6 +107,15 @@ def br_ibge_pnadc__microdados(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if data_source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=data_source_max_date,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )
 
 
 br_ibge_pnadc__microdados.deploy_schedules = [

--- a/pipelines/datasets/br_inmet_bdmep/flows.py
+++ b/pipelines/datasets/br_inmet_bdmep/flows.py
@@ -14,7 +14,8 @@ from pipelines.utils.metadata.domain import (
     PartBdpro,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -44,14 +45,14 @@ def br_inmet_bdmep__microdados(
     source_last_date = extract_last_date_from_source()
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=source_last_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             return
 
     output_filepath = get_base_inmet()
@@ -102,6 +103,15 @@ def br_inmet_bdmep__microdados(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if source_last_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=source_last_date,
+                env="prod",
+                date_format="%Y-%m",
+            )
 
 
 br_inmet_bdmep__microdados.deploy_schedules = [

--- a/pipelines/datasets/br_me_caged/flows.py
+++ b/pipelines/datasets/br_me_caged/flows.py
@@ -18,7 +18,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -45,14 +46,14 @@ def _run_me_caged(
     source_last_date = get_source_last_date()
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=source_last_date,
             env="prod",
             date_format="%Y-%m",
         )
-        if not is_outdated:
+        if not has_new_data:
             print(f"No updates for table {table_id}!")
             return
 
@@ -112,6 +113,15 @@ def _run_me_caged(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if source_last_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=source_last_date,
+                env="prod",
+                date_format="%Y-%m",
+            )
 
 
 def _caged_flow(table_id: str, cron: str):

--- a/pipelines/datasets/br_me_comex_stat/flows.py
+++ b/pipelines/datasets/br_me_comex_stat/flows.py
@@ -18,7 +18,8 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -49,14 +50,14 @@ def _comex_flow(table_id: str, table_name: str, table_type: str, cron: str):
         last_date = parse_last_date(link=comex_constants.DOWNLOAD_LINK.value)
 
         if not force_run:
-            is_outdated = register_source_poll_task(
+            has_new_data = poll_source_for_update_task(
                 dataset_id=dataset_id,
                 table_id=table_id,
                 source_max_date=last_date,
                 env="prod",
                 date_format="%Y-%m",
             )
-            if not is_outdated:
+            if not has_new_data:
                 return
 
         download_br_me_comex_stat(
@@ -116,6 +117,15 @@ def _comex_flow(table_id: str, table_name: str, table_type: str, cron: str):
                 env="prod",
                 bq_project="basedosdados",
             )
+
+            if last_date is not None:
+                commit_source_update_task(
+                    dataset_id=dataset_id,
+                    table_id=table_id,
+                    source_max_date=last_date,
+                    env="prod",
+                    date_format="%Y-%m",
+                )
 
     _flow.deploy_schedules = [{"cron": cron, "timezone": "America/Sao_Paulo"}]
     return _flow

--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -18,7 +18,8 @@ from pipelines.utils.metadata.domain import (
     PartBdpro,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -50,14 +51,14 @@ def br_rf_cafir__imoveis_rurais(
     arquivos, data_atualizacao = task_decide_files_to_download(df=df_metadata)
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_atualizacao,
             env="prod",
             date_format="%Y-%m-%d",
         )
-        if not is_outdated:
+        if not has_new_data:
             return
 
     file_path = task_download_files(
@@ -112,6 +113,15 @@ def br_rf_cafir__imoveis_rurais(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if data_atualizacao is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=data_atualizacao,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )
 
 
 br_rf_cafir__imoveis_rurais.deploy_schedules = [

--- a/pipelines/datasets/br_stf_corte_aberta/flows.py
+++ b/pipelines/datasets/br_stf_corte_aberta/flows.py
@@ -16,7 +16,8 @@ from pipelines.utils.metadata.domain import (
     PartBdpro,
 )
 from pipelines.utils.metadata.tasks import (
-    register_source_poll_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
     register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
@@ -46,14 +47,14 @@ def br_stf_corte_aberta__decisoes(
     data_source_max_date = get_data_source_stf_max_date()
 
     if not force_run:
-        is_outdated = register_source_poll_task(
+        has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=data_source_max_date,
             env="prod",
             date_format="%Y-%m-%d",
         )
-        if not is_outdated:
+        if not has_new_data:
             return
 
     df = download_and_transform()
@@ -106,6 +107,15 @@ def br_stf_corte_aberta__decisoes(
             env="prod",
             bq_project="basedosdados",
         )
+
+        if data_source_max_date is not None:
+            commit_source_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=data_source_max_date,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )
 
 
 br_stf_corte_aberta__decisoes.deploy_schedules = [

--- a/pipelines/utils/metadata/register.py
+++ b/pipelines/utils/metadata/register.py
@@ -104,12 +104,56 @@ def register_source_poll_by_size(
     - tamanho MAIOR  → novidade: grava Poll + Update(latest=hoje), devolve True.
     - tamanho IGUAL  → sem novidade: grava só Poll, devolve False.
     - tamanho MENOR  → `ValueError` (a fonte encolheu — possível quebra de schema).
-    """
-    today = datetime.datetime.today()
-    today_key = today.strftime("%Y-%m-%d")
 
+    Mantém o comportamento original de gravar o histórico de tamanho e o Update
+    no mesmo passo do poll. Flows que precisam adiar essas escritas para depois
+    da materialização devem chamar `poll_source_size_for_update` e
+    `commit_source_size_update` separadamente.
+    """
+    has_update = poll_source_size_for_update(
+        client=client,
+        redis=redis,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        byte_length=byte_length,
+    )
+
+    if has_update:
+        commit_source_size_update(
+            client=client,
+            redis=redis,
+            dataset_id=dataset_id,
+            table_id=table_id,
+            byte_length=byte_length,
+        )
+
+    return has_update
+
+
+def poll_source_size_for_update(
+    client, redis, dataset_id: str, table_id: str, byte_length: int
+) -> bool:
+    """Detecta novidade por TAMANHO, sem gravar histórico nem Update.
+
+    Contraparte por bytes de :func:`poll_source_for_update`. Sempre grava um
+    ``RawDataSource.Poll`` (data de hoje) e compara ``byte_length`` com o último
+    tamanho registrado no Redis, mas **não** grava o novo tamanho no histórico
+    nem o ``RawDataSource.Update`` — essas escritas ficam a cargo de
+    :func:`commit_source_size_update`, chamada só após a materialização. Assim,
+    se o flow falha no meio, nem o histórico de tamanho nem o Update avançam, e a
+    run seguinte ainda detecta a novidade e retenta.
+
+    - tamanho MAIOR (ou primeira vez) → novidade: grava só Poll, devolve True.
+    - tamanho IGUAL  → sem novidade: grava só Poll, devolve False.
+    - tamanho MENOR  → `ValueError` (a fonte encolheu — possível quebra de schema).
+
+    See Also
+    --------
+    commit_source_size_update : Grava histórico + Update ao fim do flow.
+    register_source_poll_by_size : Versão eager (detecta e grava numa só chamada).
+    """
     client.upsert_raw_source_poll(
-        dataset_id, table_id, latest=today
+        dataset_id, table_id, latest=datetime.datetime.today()
     )  # Poll: sempre
 
     dataset_data = redis.get(dataset_id) or {}
@@ -131,6 +175,31 @@ def register_source_poll_by_size(
                 f"original (coluna removida, recodificação, etc.)"
             )
 
+    log("Há atualizações na fonte original (tamanho maior)")
+    return True
+
+
+def commit_source_size_update(
+    client, redis, dataset_id: str, table_id: str, byte_length: int
+) -> None:
+    """Grava o histórico de tamanho (Redis) e o ``RawDataSource.Update``.
+
+    Contraparte por bytes de :func:`commit_source_update`. Registra
+    ``byte_length`` no histórico do Redis (mantendo os últimos 10 registros) e
+    grava ``RawDataSource.Update.latest`` com a data de hoje. Deve ser chamada
+    **só ao fim do flow**, depois de a materialização ter dado certo, de modo que
+    o histórico e o Update só avancem quando o dado de fato chegou ao destino.
+
+    See Also
+    --------
+    poll_source_size_for_update : Detecta a novidade sem gravar histórico/Update.
+    """
+    today = datetime.datetime.today()
+    today_key = today.strftime("%Y-%m-%d")
+
+    dataset_data = redis.get(dataset_id) or {}
+    table_data = dataset_data.get(table_id, {})
+
     table_data[today_key] = byte_length
 
     # mantém os últimos 10 registros
@@ -142,7 +211,6 @@ def register_source_poll_by_size(
 
     client.upsert_raw_source_update(dataset_id, table_id, latest=today)
     log("Fonte atualizada (tamanho maior) — Update gravado")
-    return True
 
 
 def register_table_materialization(

--- a/pipelines/utils/metadata/tasks.py
+++ b/pipelines/utils/metadata/tasks.py
@@ -21,8 +21,10 @@ from pipelines.utils.metadata.client import MetadataClient
 from pipelines.utils.metadata.constants import constants as metadata_constants
 from pipelines.utils.metadata.domain import CoverageSpec
 from pipelines.utils.metadata.register import (
+    commit_source_size_update,
     commit_source_update,
     poll_source_for_update,
+    poll_source_size_for_update,
     register_source_poll,
     register_source_poll_by_size,
     register_table_materialization,
@@ -340,4 +342,86 @@ def commit_source_update_task(
         dataset_id,
         table_id,
         _coerce_to_date(source_max_date, date_format),
+    )
+
+
+@task(
+    retries=constants.TASK_MAX_RETRIES.value,
+    retry_delay_seconds=constants.TASK_RETRY_DELAY.value,
+)
+def poll_source_size_for_update_task(
+    dataset_id: str,
+    table_id: str,
+    byte_length: int,
+    env: str = "dev",
+    local_execution: bool = False,
+) -> bool:
+    """Detecta novidade por TAMANHO hoje, sem gravar histórico nem Update.
+
+    Variante por bytes de `poll_source_for_update_task`. Sempre grava um `Poll`
+    na fonte (data de hoje) e compara `byte_length` com o último tamanho no
+    Redis — mas, ao contrário de `register_source_poll_by_size_task`, **não**
+    grava o novo tamanho no histórico nem o Update. A gravação fica a cargo de
+    `commit_source_size_update_task`, chamada ao fim do flow, após a
+    materialização. Use as duas em par para não travar runs futuras se o flow
+    falhar no meio.
+
+    - tamanho MAIOR (ou primeira vez) → grava só Poll, devolve True;
+    - tamanho IGUAL  → grava só Poll, devolve False;
+    - tamanho MENOR  → levanta `ValueError` (a fonte encolheu).
+
+    Args:
+        dataset_id: ID do dataset no GCP/BigQuery.
+        table_id: ID da tabela no GCP/BigQuery.
+        byte_length: tamanho atual da fonte em bytes.
+        env: backend de destino — `"dev"` (padrão), `"staging"` ou `"prod"`.
+        local_execution: se True, conecta no Redis via `localhost` (exige proxy
+            ativo para o pod do Redis); se False (padrão), usa o DNS do serviço
+            no cluster.
+
+    Returns:
+        bool — True se a fonte trouxe novidade (tamanho maior), False se igual.
+    """
+    client = MetadataClient(env=env)
+    redis = _get_redis_client(local_execution=local_execution)
+    return poll_source_size_for_update(
+        client, redis, dataset_id, table_id, byte_length
+    )
+
+
+@task(
+    retries=constants.TASK_MAX_RETRIES.value,
+    retry_delay_seconds=constants.TASK_RETRY_DELAY.value,
+)
+def commit_source_size_update_task(
+    dataset_id: str,
+    table_id: str,
+    byte_length: int,
+    env: str = "dev",
+    local_execution: bool = False,
+) -> None:
+    """Grava o histórico de tamanho (Redis) e o `RawDataSource.Update`.
+
+    Contraparte de `poll_source_size_for_update_task`: registra `byte_length` no
+    histórico do Redis (mantendo os últimos 10) e grava o `Update.latest` com a
+    data de hoje. Deve ser chamada **só ao fim do flow**, depois da
+    materialização bem-sucedida, para que histórico e Update só avancem quando o
+    dado de fato chegou ao destino — evitando que uma falha no meio deixe a
+    detecção adiantada e trave as runs seguintes.
+
+    Args:
+        dataset_id: ID do dataset no GCP/BigQuery.
+        table_id: ID da tabela no GCP/BigQuery.
+        byte_length: tamanho atual da fonte em bytes, gravado no histórico.
+        env: backend de destino — `"dev"` (padrão), `"staging"` ou `"prod"`.
+        local_execution: se True, conecta no Redis via `localhost`; se False
+            (padrão), usa o DNS do serviço no cluster.
+
+    Returns:
+        None.
+    """
+    client = MetadataClient(env=env)
+    redis = _get_redis_client(local_execution=local_execution)
+    commit_source_size_update(
+        client, redis, dataset_id, table_id, byte_length
     )

--- a/pipelines/utils/metadata/tasks.py
+++ b/pipelines/utils/metadata/tasks.py
@@ -422,6 +422,4 @@ def commit_source_size_update_task(
     """
     client = MetadataClient(env=env)
     redis = _get_redis_client(local_execution=local_execution)
-    commit_source_size_update(
-        client, redis, dataset_id, table_id, byte_length
-    )
+    commit_source_size_update(client, redis, dataset_id, table_id, byte_length)

--- a/pipelines/utils/tests/metadata/test_register.py
+++ b/pipelines/utils/tests/metadata/test_register.py
@@ -21,6 +21,8 @@ from pipelines.utils.metadata.domain import (
 )
 from pipelines.utils.metadata.policy import CoverageIds
 from pipelines.utils.metadata.register import (
+    commit_source_size_update,
+    poll_source_size_for_update,
     register_source_poll,
     register_source_poll_by_size,
     register_table_materialization,
@@ -214,4 +216,53 @@ def test_poll_by_size_keeps_last_10_records():
     history = {f"2020-01-{d:02d}": d for d in range(1, 11)}  # 10 registros
     redis = FakeRedis({"br_x": {"tab": dict(history)}})
     register_source_poll_by_size(client, redis, "br_x", "tab", 9999)
+    assert len(redis.store["br_x"]["tab"]) <= 10
+
+
+# ==================== poll/commit por tamanho — duas fases (deferido) (§fix R3)
+def test_poll_size_for_update_writes_poll_only_not_history_or_update():
+    """Fase 1 por tamanho: mesmo COM novidade (maior/primeira vez), grava só o
+    Poll — não toca o histórico no Redis nem o Update. Cura o problema (3) na
+    variante por bytes: se recolarem a escrita do histórico/Update aqui, quebra.
+    """
+    client = FakeMetadataClient()
+    redis = FakeRedis()
+    outdated = poll_source_size_for_update(client, redis, "br_x", "tab", 1000)
+    assert outdated is True
+    assert client.written_entities == ["poll"]  # sem Update
+    assert redis.store == {}  # histórico intacto
+
+
+def test_poll_size_for_update_equal_returns_false_poll_only():
+    client = FakeMetadataClient()
+    redis = FakeRedis({"br_x": {"tab": {"2020-01-01": 1000}}})
+    outdated = poll_source_size_for_update(client, redis, "br_x", "tab", 1000)
+    assert outdated is False
+    assert client.written_entities == ["poll"]
+
+
+def test_poll_size_for_update_smaller_raises_after_poll():
+    import pytest
+
+    client = FakeMetadataClient()
+    redis = FakeRedis({"br_x": {"tab": {"2020-01-01": 2000}}})
+    with pytest.raises(ValueError, match="MENOR"):
+        poll_source_size_for_update(client, redis, "br_x", "tab", 1000)
+    assert client.written_entities == ["poll"]
+
+
+def test_commit_size_update_writes_history_and_update():
+    """Fase 2 por tamanho: grava o novo tamanho no Redis e o Update — sem Poll."""
+    client = FakeMetadataClient()
+    redis = FakeRedis()
+    commit_source_size_update(client, redis, "br_x", "tab", 1000)
+    assert client.written_entities == ["raw_source_update"]
+    assert list(redis.store["br_x"]["tab"].values()) == [1000]
+
+
+def test_commit_size_update_keeps_last_10_records():
+    client = FakeMetadataClient()
+    history = {f"2020-01-{d:02d}": d for d in range(1, 11)}  # 10 registros
+    redis = FakeRedis({"br_x": {"tab": dict(history)}})
+    commit_source_size_update(client, redis, "br_x", "tab", 9999)
     assert len(redis.store["br_x"]["tab"]) <= 10

--- a/pipelines/utils/tests/metadata/test_register_tasks.py
+++ b/pipelines/utils/tests/metadata/test_register_tasks.py
@@ -234,6 +234,6 @@ def test_commit_size_update_task_writes_history_and_update():
     mk.assert_called_once_with(env="prod")
     assert result is None
     assert fake.written_entities == ["raw_source_update"]
-    assert list(redis.store["br_bcb_sicor"]["microdados_operacoes"].values()) == [
-        1000
-    ]
+    assert list(
+        redis.store["br_bcb_sicor"]["microdados_operacoes"].values()
+    ) == [1000]

--- a/pipelines/utils/tests/metadata/test_register_tasks.py
+++ b/pipelines/utils/tests/metadata/test_register_tasks.py
@@ -16,8 +16,10 @@ from pipelines.utils.metadata.domain import DateFormat, PartBdpro, YearMonth
 from pipelines.utils.metadata.policy import CoverageIds
 from pipelines.utils.metadata.tasks import (
     _coerce_to_date,
+    commit_source_size_update_task,
     commit_source_update_task,
     poll_source_for_update_task,
+    poll_source_size_for_update_task,
     register_source_poll_task,
     register_table_materialization_task,
 )
@@ -171,3 +173,67 @@ def test_materialization_task_builds_client_and_bq_and_delegates():
         )
     assert fake.written_entities == ["coverage", "coverage", "table_update"]
     assert len(fake_bq.rap_calls) == 1
+
+
+class _FakeRedis:
+    """Double in-memory de RedisPal para os testes das tasks por tamanho."""
+
+    def __init__(self, store=None):
+        self.store = store or {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value):
+        self.store[key] = value
+
+
+def test_poll_size_for_update_task_writes_poll_only_not_update():
+    """Variante por tamanho deferida: detecta sem gravar histórico nem Update."""
+    fake = FakeMetadataClient()
+    redis = _FakeRedis()
+    with (
+        patch(
+            "pipelines.utils.metadata.tasks.MetadataClient", return_value=fake
+        ),
+        patch(
+            "pipelines.utils.metadata.tasks._get_redis_client",
+            return_value=redis,
+        ),
+    ):
+        result = poll_source_size_for_update_task.fn(
+            "br_bcb_sicor",
+            "microdados_operacoes",
+            byte_length=1000,
+            env="prod",
+        )
+    assert result is True
+    assert fake.written_entities == ["poll"]
+    assert redis.store == {}  # histórico intacto
+
+
+def test_commit_size_update_task_writes_history_and_update():
+    """Contraparte por tamanho: grava histórico no Redis + Update."""
+    fake = FakeMetadataClient()
+    redis = _FakeRedis()
+    with (
+        patch(
+            "pipelines.utils.metadata.tasks.MetadataClient", return_value=fake
+        ) as mk,
+        patch(
+            "pipelines.utils.metadata.tasks._get_redis_client",
+            return_value=redis,
+        ),
+    ):
+        result = commit_source_size_update_task.fn(
+            "br_bcb_sicor",
+            "microdados_operacoes",
+            byte_length=1000,
+            env="prod",
+        )
+    mk.assert_called_once_with(env="prod")
+    assert result is None
+    assert fake.written_entities == ["raw_source_update"]
+    assert list(redis.store["br_bcb_sicor"]["microdados_operacoes"].values()) == [
+        1000
+    ]


### PR DESCRIPTION
## O que muda

Separa a detecção de novidade na fonte da gravação do histórico/`Update`, para que essas escritas só avancem **depois** da materialização dar certo. Antes, `register_source_poll` (por data) e `register_source_poll_by_size` (por tamanho) detectavam a novidade **e** gravavam o histórico + `RawDataSource.Update` no mesmo passo. Se o flow falhasse entre o poll e a materialização, o `Update`/histórico já tinha avançado e a run seguinte não retentava — o dado nunca chegava ao destino, mas a fonte constava como atualizada.

## Como

Cada poll vira um par de funções/tasks:

- **poll** — grava só o `Poll` (data de hoje) e devolve se há novidade, sem tocar no histórico nem no `Update`.
- **commit** — grava o histórico e o `RawDataSource.Update`, chamado **só ao fim do flow**, após a materialização.

Assim, se o flow falha no meio, nem o histórico nem o `Update` avançam e a run seguinte ainda detecta a novidade e retenta.

### `pipelines/utils/metadata/register.py` / `tasks.py`

- Novas funções por **tamanho**: `poll_source_size_for_update` + `commit_source_size_update` (e as tasks `poll_source_size_for_update_task` / `commit_source_size_update_task`).
- `register_source_poll_by_size` mantém o comportamento eager (detecta + grava numa só chamada) e agora é apenas um wrapper sobre o par acima — retrocompatível.
- Contrapartes por **data** (`poll_source_for_update` / `commit_source_update`) usadas nos flows.

### Flows

Migração dos flows para o padrão poll → materializar → commit: `register_source_poll_task` / `register_source_poll_by_size_task` passam a chamar `poll_*_task` antes e `commit_*_task` só após a materialização bem-sucedida (BCB, CGU, CVM, DATASUS, ME CNPJ, RF, TSE, e os datasets `br_anp_precos_combustiveis`, `br_ans_beneficiario`, `br_bcb_*`, `br_cgu_emendas_parlamentares`, `br_denatran_frota`, `br_ibge_pnadc`, `br_inmet_bdmep`, `br_me_caged`, `br_me_comex_stat`, `br_rf_cafir`, `br_stf_corte_aberta`).

## Testes

- `test_register.py` — cobre o novo par por tamanho e o wrapper eager.
- `test_register_tasks.py` — cobre as novas tasks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new two-step source update flow across multiple crawlers and datasets, helping runs stop early when no new data is available.
  * Source update status can now be committed after successful processing, improving consistency of update tracking.

* **Bug Fixes**
  * Improved “should run” checks to rely on fresh data availability instead of older update status handling.
  * Added size-based source tracking support, including сохранение recent history and better handling of unchanged or reduced source sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->