### PR TITLE
feat(world_un_wpp): onboard UN World Population Prospects (2024 revision)

### DIFF
--- a/.claude/rules/metadata-schema.md
+++ b/.claude/rules/metadata-schema.md
@@ -105,9 +105,17 @@ Only set these fields — do NOT re-set fields already handled by `upload_column
 | `column_name` | Column name |
 | `table_id` | Table ID |
 | `is_partition` | `True` for partition columns |
-| `is_primary_key` | `True` for primary key columns |
+| `is_primary_key` | `True` **only in directory tables** (`br_bd_diretorios_*`). Leave `False` everywhere else — see rule below. |
 | `description_en` | Translated from Portuguese |
 | `description_es` | Translated from Portuguese |
+
+### Primary keys: directory tables only
+
+`is_primary_key = True` is reserved for the key column(s) of **directory tables** (datasets under `br_bd_diretorios_*`). In every non-directory table (i.e. ordinary data tables), **no column may have `is_primary_key = True`** — not even the columns that form the logical key (`ano`, `sigla_uf`, `id_municipio`, `country_iso3_code`, `age`, etc.).
+
+In a data table, a column's relationship to a key is expressed **only** through its `directoryPrimaryKey` link (the directory column it references), set via the `directory_column` field in the architecture sheet / `upload_columns_from_sheet`. Columns with no directory (e.g. `age`, `age_group` when no age directory exists) simply carry neither `is_primary_key` nor a directory link.
+
+Uniqueness of the logical key is still enforced separately in dbt (`dbt_utils.unique_combination_of_columns`); that is independent of the backend `is_primary_key` flag.
 
 ## `create_update_cloud_table` fields
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -427,6 +427,9 @@ models:
     world_sofascore_competicoes_futebol:
       +materialized: table
       +schema: world_sofascore_competicoes_futebol
+    world_un_wpp:
+      +materialized: table
+      +schema: world_un_wpp
     world_wb_mides:
       +materialized: table
       +schema: world_wb_mides

--- a/models/world_un_wpp/code/clean.py
+++ b/models/world_un_wpp/code/clean.py
@@ -1,0 +1,262 @@
+"""Cleaning code for world_un_wpp (UN World Population Prospects 2024, Medium variant).
+
+Tables:
+    1. demographic_indicators   — country x year, 54 indicators
+    2. population_age_group_sex — country x year x 5-year age group
+    3. population_single_age_sex — country x year x single age (0-100)
+
+Global rules:
+    - Countries only: LocTypeID == 4 (equivalently non-empty ISO3_code; asserted).
+    - Values kept in raw units (thousands). No unit conversion.
+    - Output: snappy Parquet, hive-partitioned by year:
+      output/<table_slug>/year=<YYYY>/data.parquet
+      (partition column `year` is encoded in the path, not stored in the file).
+"""
+
+import gc
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+ROOT = Path(__file__).resolve().parents[1]
+INPUT = ROOT / "input"
+OUTPUT = ROOT / "output"
+
+FILE_INDICATORS = INPUT / "WPP2024_Demographic_Indicators_Medium.csv.gz"
+FILE_AGE_GROUP = (
+    INPUT / "WPP2024_Population1JanuaryByAge5GroupSex_Medium.csv.gz"
+)
+FILES_SINGLE_AGE = [
+    INPUT / "WPP2024_PopulationBySingleAgeSex_Medium_1950-2023.csv.gz",
+    INPUT / "WPP2024_PopulationBySingleAgeSex_Medium_2024-2100.csv.gz",
+]
+
+EXPECTED_N_COUNTRIES = 237
+
+INDICATOR_RENAMES = {
+    "TPopulation1Jan": "total_population_1_january",
+    "TPopulation1July": "total_population_1_july",
+    "TPopulationMale1July": "total_population_male_1_july",
+    "TPopulationFemale1July": "total_population_female_1_july",
+    "PopDensity": "population_density",
+    "PopSexRatio": "population_sex_ratio",
+    "MedianAgePop": "median_age",
+    "NatChange": "natural_change",
+    "NatChangeRT": "rate_natural_change",
+    "PopChange": "population_change",
+    "PopGrowthRate": "population_growth_rate",
+    "DoublingTime": "population_doubling_time",
+    "Births": "births",
+    "Births1519": "births_women_age_15_19",
+    "CBR": "crude_birth_rate",
+    "TFR": "total_fertility_rate",
+    "NRR": "net_reproduction_rate",
+    "MAC": "mean_age_childbearing",
+    "SRB": "sex_ratio_at_birth",
+    "Deaths": "total_deaths",
+    "DeathsMale": "total_deaths_male",
+    "DeathsFemale": "total_deaths_female",
+    "CDR": "crude_death_rate",
+    "LEx": "life_expectancy_at_birth",
+    "LExMale": "life_expectancy_at_birth_male",
+    "LExFemale": "life_expectancy_at_birth_female",
+    "LE15": "life_expectancy_at_15",
+    "LE15Male": "life_expectancy_at_15_male",
+    "LE15Female": "life_expectancy_at_15_female",
+    "LE65": "life_expectancy_at_65",
+    "LE65Male": "life_expectancy_at_65_male",
+    "LE65Female": "life_expectancy_at_65_female",
+    "LE80": "life_expectancy_at_80",
+    "LE80Male": "life_expectancy_at_80_male",
+    "LE80Female": "life_expectancy_at_80_female",
+    "InfantDeaths": "infant_deaths",
+    "IMR": "infant_mortality_rate",
+    "LBsurvivingAge1": "live_births_surviving_age_1",
+    "Under5Deaths": "under_5_deaths",
+    "Q5": "under_5_mortality_rate",
+    "Q0040": "mortality_before_age_40",
+    "Q0040Male": "mortality_before_age_40_male",
+    "Q0040Female": "mortality_before_age_40_female",
+    "Q0060": "mortality_before_age_60",
+    "Q0060Male": "mortality_before_age_60_male",
+    "Q0060Female": "mortality_before_age_60_female",
+    "Q1550": "mortality_between_age_15_50",
+    "Q1550Male": "mortality_between_age_15_50_male",
+    "Q1550Female": "mortality_between_age_15_50_female",
+    "Q1560": "mortality_between_age_15_60",
+    "Q1560Male": "mortality_between_age_15_60_male",
+    "Q1560Female": "mortality_between_age_15_60_female",
+    "NetMigrations": "net_migrations",
+    "CNMR": "net_migration_rate",
+}
+
+
+def filter_countries(df: pd.DataFrame) -> pd.DataFrame:
+    """Keep countries only (LocTypeID == 4) and assert agreement with ISO3_code."""
+    loc_type = pd.to_numeric(df["LocTypeID"], errors="coerce")
+    iso3 = df["ISO3_code"].astype("string").str.strip()
+    mask_type = (loc_type == 4).to_numpy(dtype=bool)
+    mask_iso3 = (
+        (iso3.notna() & (iso3 != "")).fillna(False).to_numpy(dtype=bool)
+    )
+    assert (mask_type == mask_iso3).all(), (
+        f"LocTypeID==4 ({mask_type.sum()}) and non-empty ISO3_code "
+        f"({mask_iso3.sum()}) filters disagree"
+    )
+    out = df.loc[mask_type].copy()
+    n_countries = out["ISO3_code"].nunique()
+    assert n_countries == EXPECTED_N_COUNTRIES, (
+        f"expected {EXPECTED_N_COUNTRIES} countries, got {n_countries}"
+    )
+    return out
+
+
+def write_partitions(
+    df: pd.DataFrame, table_slug: str, schema: pa.Schema
+) -> None:
+    """Write one snappy parquet file per year: output/<slug>/year=<YYYY>/data.parquet.
+
+    `year` is encoded in the path only; the file schema excludes it.
+    """
+    file_schema = pa.schema([f for f in schema if f.name != "year"])
+    file_cols = [f.name for f in file_schema]
+    for year, group in df.groupby("year", sort=True):
+        part_dir = OUTPUT / table_slug / f"year={int(year)}"
+        part_dir.mkdir(parents=True, exist_ok=True)
+        table = pa.Table.from_pandas(
+            group[file_cols], schema=file_schema, preserve_index=False
+        )
+        pq.write_table(table, part_dir / "data.parquet", compression="snappy")
+
+
+def clean_demographic_indicators() -> None:
+    print("=== demographic_indicators ===")
+    df = pd.read_csv(FILE_INDICATORS, encoding="utf-8-sig", low_memory=False)
+    df = filter_countries(df)
+    df = df.rename(columns={"Time": "year", "ISO3_code": "country_iso3_code"})
+    df = df.rename(columns=INDICATOR_RENAMES)
+
+    cols = ["year", "country_iso3_code", *INDICATOR_RENAMES.values()]
+    df = df[cols]
+
+    df["year"] = pd.to_numeric(df["year"], errors="coerce").astype("Int64")
+    df["country_iso3_code"] = df["country_iso3_code"].astype(str).str.strip()
+    for col in INDICATOR_RENAMES.values():
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    schema = pa.schema(
+        [("year", pa.int64()), ("country_iso3_code", pa.string())]
+        + [(col, pa.float64()) for col in INDICATOR_RENAMES.values()]
+    )
+    print(f"rows: {len(df):,} | years: {df['year'].min()}-{df['year'].max()}")
+    write_partitions(df, "demographic_indicators", schema)
+    del df
+    gc.collect()
+
+
+POP_SCHEMA_AGE_GROUP = pa.schema(
+    [
+        ("year", pa.int64()),
+        ("country_iso3_code", pa.string()),
+        ("age_group", pa.string()),
+        ("population_male", pa.float64()),
+        ("population_female", pa.float64()),
+        ("population_total", pa.float64()),
+    ]
+)
+
+POP_SCHEMA_SINGLE_AGE = pa.schema(
+    [
+        ("year", pa.int64()),
+        ("country_iso3_code", pa.string()),
+        ("age", pa.int64()),
+        ("population_male", pa.float64()),
+        ("population_female", pa.float64()),
+        ("population_total", pa.float64()),
+    ]
+)
+
+POP_USECOLS = [
+    "ISO3_code",
+    "LocTypeID",
+    "Time",
+    "AgeGrp",
+    "AgeGrpStart",
+    "PopMale",
+    "PopFemale",
+    "PopTotal",
+]
+
+
+def _read_population_file(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(
+        path, encoding="utf-8-sig", usecols=POP_USECOLS, low_memory=False
+    )
+    df = filter_countries(df)
+    df = df.rename(
+        columns={
+            "Time": "year",
+            "ISO3_code": "country_iso3_code",
+            "PopMale": "population_male",
+            "PopFemale": "population_female",
+            "PopTotal": "population_total",
+        }
+    )
+    df["year"] = pd.to_numeric(df["year"], errors="coerce").astype("Int64")
+    df["country_iso3_code"] = df["country_iso3_code"].astype(str).str.strip()
+    for col in ["population_male", "population_female", "population_total"]:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df
+
+
+def clean_population_age_group_sex() -> None:
+    print("=== population_age_group_sex ===")
+    df = _read_population_file(FILE_AGE_GROUP)
+    df["age_group"] = df["AgeGrp"].astype(str).str.strip()
+    df = df[[f.name for f in POP_SCHEMA_AGE_GROUP]]
+    print(f"rows: {len(df):,} | years: {df['year'].min()}-{df['year'].max()}")
+    write_partitions(df, "population_age_group_sex", POP_SCHEMA_AGE_GROUP)
+    del df
+    gc.collect()
+
+
+def clean_population_single_age_sex() -> None:
+    print("=== population_single_age_sex ===")
+    # Files cover disjoint year ranges (1950-2023, 2024-2100); process sequentially.
+    for path in FILES_SINGLE_AGE:
+        print(f"processing {path.name} ...")
+        df = _read_population_file(path)
+        df["age"] = pd.to_numeric(df["AgeGrpStart"], errors="coerce").astype(
+            "Int64"
+        )
+        df = df[[f.name for f in POP_SCHEMA_SINGLE_AGE]]
+        print(
+            f"  rows: {len(df):,} | years: {df['year'].min()}-{df['year'].max()}"
+        )
+        write_partitions(
+            df, "population_single_age_sex", POP_SCHEMA_SINGLE_AGE
+        )
+        del df
+        gc.collect()
+
+
+def main() -> None:
+    for slug in [
+        "demographic_indicators",
+        "population_age_group_sex",
+        "population_single_age_sex",
+    ]:
+        target = OUTPUT / slug
+        if target.exists():
+            shutil.rmtree(target)
+    clean_demographic_indicators()
+    clean_population_age_group_sex()
+    clean_population_single_age_sex()
+    print("done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/world_un_wpp/code/download.py
+++ b/models/world_un_wpp/code/download.py
@@ -1,0 +1,62 @@
+"""Download raw data for world_un_wpp (UN World Population Prospects, 2024 revision).
+
+Source: https://population.un.org/wpp/downloads (JavaScript SPA — do not scrape).
+Files are fetched via direct asset URLs. Files are kept gzipped; never decompress
+or modify files in input/ after saving.
+
+Note: a mid-year (1 July) population-by-5-year-age-group file does not exist
+on the portal (checked 2026-07-09); the 1 January file is used instead. The
+single-age files are 1 July estimates.
+"""
+
+import time
+from pathlib import Path
+
+import requests
+
+BASE_URL = (
+    "https://population.un.org/wpp/assets/Excel%20Files/"
+    "1_Indicator%20(Standard)/CSV_FILES/"
+)
+
+FILES = [
+    "WPP2024_Demographic_Indicators_Medium.csv.gz",
+    "WPP2024_Population1JanuaryByAge5GroupSex_Medium.csv.gz",
+    "WPP2024_PopulationBySingleAgeSex_Medium_1950-2023.csv.gz",
+    "WPP2024_PopulationBySingleAgeSex_Medium_2024-2100.csv.gz",
+]
+
+INPUT_DIR = Path(__file__).resolve().parents[1] / "input"
+INPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def download_file(url: str, dest: Path, retries: int = 3) -> None:
+    for attempt in range(retries):
+        try:
+            r = requests.get(url, timeout=120, stream=True)
+            r.raise_for_status()
+            with open(dest, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            print(
+                f"Downloaded: {dest} ({dest.stat().st_size / 1e6:.1f} MB) <- {url}"
+            )
+            return
+        except requests.RequestException as e:
+            if attempt < retries - 1:
+                time.sleep(2**attempt)
+            else:
+                raise RuntimeError(f"Failed to download {url}: {e}") from e
+
+
+def main() -> None:
+    for filename in FILES:
+        dest = INPUT_DIR / filename
+        if dest.exists() and dest.stat().st_size > 0:
+            print(f"Skip (exists): {dest}")
+            continue
+        download_file(BASE_URL + filename, dest)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/world_un_wpp/code/upload.py
+++ b/models/world_un_wpp/code/upload.py
@@ -1,0 +1,96 @@
+"""Upload cleaned world_un_wpp Parquet tables to BigQuery (dev)."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import basedosdados as bd
+import google.cloud.storage as gcs
+from google.cloud import bigquery
+
+BILLING_PROJECT = "basedosdados-dev"
+DATASET_ID = "world_un_wpp"
+OUTPUT_DIR = Path(__file__).resolve().parents[1] / "output"
+
+EXPECTED_ROWS = {
+    "demographic_indicators": 36_024,
+    "population_age_group_sex": 756_504,
+    "population_single_age_sex": 3_614_487,
+}
+
+# Monkey-patch for requester-pays bucket
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+
+def delete_staging_prefix(table_id: str) -> int:
+    """Delete stale GCS staging objects for the table."""
+    client = gcs.Client(project=BILLING_PROJECT)
+    bucket = client.bucket("basedosdados-dev")
+    n = 0
+    for prefix in (f"staging/{DATASET_ID}/{table_id}/",):
+        blobs = list(client.list_blobs(bucket, prefix=prefix))
+        for blob in blobs:
+            blob.delete()
+            n += 1
+    return n
+
+
+def upload_table(table_id: str) -> None:
+    path = OUTPUT_DIR / table_id
+    if not path.is_dir():
+        raise FileNotFoundError(f"Output path missing: {path}")
+
+    print(f"--- {table_id} ---", flush=True)
+    tb = bd.Table(table_id=table_id, dataset_id=DATASET_ID)
+
+    deleted = delete_staging_prefix(table_id)
+    print(f"Deleted {deleted} stale staging objects", flush=True)
+
+    tb.create(
+        path=str(path),
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+    )
+    print("create+upload: OK", flush=True)
+
+    # Verify row count in BigQuery staging table
+    bq = bigquery.Client(project=BILLING_PROJECT)
+    query = (
+        f"select count(*) as n from "
+        f"`{BILLING_PROJECT}.{DATASET_ID}_staging.{table_id}`"
+    )
+    n = next(iter(bq.query(query).result()))["n"]
+    expected = EXPECTED_ROWS[table_id]
+    status = "OK" if n == expected else "MISMATCH"
+    print(f"rows: {n:,} (expected {expected:,}) — {status}", flush=True)
+    if n != expected:
+        raise RuntimeError(
+            f"{table_id}: row count mismatch ({n} vs {expected})"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--table", default=None, help="Upload only this table")
+    args = parser.parse_args()
+
+    tables = [args.table] if args.table else list(EXPECTED_ROWS)
+    for table_id in tables:
+        try:
+            upload_table(table_id)
+        except Exception as e:
+            print(f"FAILED: {table_id}: {e}", flush=True)
+            sys.exit(1)
+    print("ALL DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/world_un_wpp/schema.yml
+++ b/models/world_un_wpp/schema.yml
@@ -1,0 +1,308 @@
+---
+version: 2
+models:
+  - name: world_un_wpp__demographic_indicators
+    description: >
+      Annual demographic indicators by country from the United Nations World
+      Population Prospects, 2024 revision. Covers population stocks, fertility,
+      mortality, life expectancy, and migration for countries and areas only
+      (no aggregates). Values for 1950-2023 are estimates; values for 2024-2100
+      (population stocks through 2101) are Medium-variant projections. Counts
+      (population, births, deaths, migrations) are expressed in thousands;
+      crude rates are per 1,000 population. Rows for year 2101 carry only the
+      1 January total population stock; all other indicators are null in that
+      year. Population doubling time is null when the growth rate is zero or
+      negative.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [year, country_iso3_code]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: >
+          Year of reference. 1950-2023 are estimates; 2024 onwards are
+          Medium-variant projections
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: country_iso3_code
+        description: >
+          Country or area ISO 3166-1 alpha-3 code
+        tests:
+          - not_null
+          - custom_relationships:
+              to: ref('br_bd_diretorios_mundo__pais')
+              field: sigla_iso3
+              ignore_values: [XKX]
+      - name: total_population_1_january
+        description: >
+          Total population on 1 January, both sexes combined, in thousands
+      - name: total_population_1_july
+        description: >
+          Total population on 1 July (mid-year), both sexes combined, in
+          thousands
+      - name: total_population_male_1_july
+        description: >
+          Male population on 1 July (mid-year), in thousands
+      - name: total_population_female_1_july
+        description: >
+          Female population on 1 July (mid-year), in thousands
+      - name: population_density
+        description: >
+          Population density on 1 July, persons per square kilometer
+      - name: population_sex_ratio
+        description: >
+          Population sex ratio on 1 July, males per 100 females
+      - name: median_age
+        description: >
+          Median age of the population on 1 July, in years
+      - name: natural_change
+        description: >
+          Natural change of the population (births minus deaths), in thousands
+      - name: rate_natural_change
+        description: >
+          Rate of natural change of the population, per 1,000 population
+      - name: population_change
+        description: >
+          Total population change (natural change plus net migration), in
+          thousands
+      - name: population_growth_rate
+        description: >
+          Population growth rate, in percentage
+      - name: population_doubling_time
+        description: >
+          Population annual doubling time, in years. Null when the growth rate
+          is zero or negative
+      - name: births
+        description: >
+          Number of live births, both sexes combined, in thousands
+      - name: births_women_age_15_19
+        description: >
+          Number of live births to women aged 15 to 19 years, in thousands
+      - name: crude_birth_rate
+        description: >
+          Crude birth rate, births per 1,000 population
+      - name: total_fertility_rate
+        description: >
+          Total fertility rate, live births per woman
+      - name: net_reproduction_rate
+        description: >
+          Net reproduction rate, surviving daughters per woman
+      - name: mean_age_childbearing
+        description: >
+          Mean age of childbearing, in years
+      - name: sex_ratio_at_birth
+        description: >
+          Sex ratio at birth, male births per female birth
+      - name: total_deaths
+        description: >
+          Total number of deaths, both sexes combined, in thousands
+      - name: total_deaths_male
+        description: >
+          Number of male deaths, in thousands
+      - name: total_deaths_female
+        description: >
+          Number of female deaths, in thousands
+      - name: crude_death_rate
+        description: >
+          Crude death rate, deaths per 1,000 population
+      - name: life_expectancy_at_birth
+        description: >
+          Life expectancy at birth, both sexes combined, in years
+      - name: life_expectancy_at_birth_male
+        description: >
+          Male life expectancy at birth, in years
+      - name: life_expectancy_at_birth_female
+        description: >
+          Female life expectancy at birth, in years
+      - name: life_expectancy_at_15
+        description: >
+          Life expectancy at age 15, both sexes combined, in years
+      - name: life_expectancy_at_15_male
+        description: >
+          Male life expectancy at age 15, in years
+      - name: life_expectancy_at_15_female
+        description: >
+          Female life expectancy at age 15, in years
+      - name: life_expectancy_at_65
+        description: >
+          Life expectancy at age 65, both sexes combined, in years
+      - name: life_expectancy_at_65_male
+        description: >
+          Male life expectancy at age 65, in years
+      - name: life_expectancy_at_65_female
+        description: >
+          Female life expectancy at age 65, in years
+      - name: life_expectancy_at_80
+        description: >
+          Life expectancy at age 80, both sexes combined, in years
+      - name: life_expectancy_at_80_male
+        description: >
+          Male life expectancy at age 80, in years
+      - name: life_expectancy_at_80_female
+        description: >
+          Female life expectancy at age 80, in years
+      - name: infant_deaths
+        description: >
+          Number of infant deaths (under age 1), both sexes combined, in
+          thousands
+      - name: infant_mortality_rate
+        description: >
+          Infant mortality rate, infant deaths per 1,000 live births
+      - name: live_births_surviving_age_1
+        description: >
+          Number of live births surviving to age 1, both sexes combined, in
+          thousands
+      - name: under_5_deaths
+        description: >
+          Number of deaths under age 5, both sexes combined, in thousands
+      - name: under_5_mortality_rate
+        description: >
+          Under-5 mortality rate, deaths under age 5 per 1,000 live births
+      - name: mortality_before_age_40
+        description: >
+          Mortality before age 40, both sexes combined, deaths under age 40
+          per 1,000 live births
+      - name: mortality_before_age_40_male
+        description: >
+          Male mortality before age 40, deaths under age 40 per 1,000 male
+          live births
+      - name: mortality_before_age_40_female
+        description: >
+          Female mortality before age 40, deaths under age 40 per 1,000 female
+          live births
+      - name: mortality_before_age_60
+        description: >
+          Mortality before age 60, both sexes combined, deaths under age 60
+          per 1,000 live births
+      - name: mortality_before_age_60_male
+        description: >
+          Male mortality before age 60, deaths under age 60 per 1,000 male
+          live births
+      - name: mortality_before_age_60_female
+        description: >
+          Female mortality before age 60, deaths under age 60 per 1,000 female
+          live births
+      - name: mortality_between_age_15_50
+        description: >
+          Mortality between age 15 and 50, both sexes combined, deaths under
+          age 50 per 1,000 alive at age 15
+      - name: mortality_between_age_15_50_male
+        description: >
+          Male mortality between age 15 and 50, deaths under age 50 per 1,000
+          males alive at age 15
+      - name: mortality_between_age_15_50_female
+        description: >
+          Female mortality between age 15 and 50, deaths under age 50 per
+          1,000 females alive at age 15
+      - name: mortality_between_age_15_60
+        description: >
+          Mortality between age 15 and 60, both sexes combined, deaths under
+          age 60 per 1,000 alive at age 15
+      - name: mortality_between_age_15_60_male
+        description: >
+          Male mortality between age 15 and 60, deaths under age 60 per 1,000
+          males alive at age 15
+      - name: mortality_between_age_15_60_female
+        description: >
+          Female mortality between age 15 and 60, deaths under age 60 per
+          1,000 females alive at age 15
+      - name: net_migrations
+        description: >
+          Net number of migrants (immigrants minus emigrants), in thousands
+      - name: net_migration_rate
+        description: >
+          Net migration rate, per 1,000 population
+  - name: world_un_wpp__population_age_group_sex
+    description: >
+      Population by country, year, five-year age group, and sex from the
+      United Nations World Population Prospects, 2024 revision. Population is
+      the stock on 1 January, in thousands, for countries and areas only (no
+      aggregates). Values for 1950-2023 are estimates; values for 2024-2101
+      are Medium-variant projections.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [year, country_iso3_code, age_group]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: >
+          Year of reference. 1950-2023 are estimates; 2024 onwards are
+          Medium-variant projections
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: country_iso3_code
+        description: >
+          Country or area ISO 3166-1 alpha-3 code
+        tests:
+          - not_null
+          - custom_relationships:
+              to: ref('br_bd_diretorios_mundo__pais')
+              field: sigla_iso3
+              ignore_values: [XKX]
+      - name: age_group
+        description: >
+          Five-year age group, from 0-4 to 100+ (21 groups)
+        tests: [not_null]
+      - name: population_male
+        description: >
+          Male population on 1 January, in thousands
+      - name: population_female
+        description: >
+          Female population on 1 January, in thousands
+      - name: population_total
+        description: >
+          Total population on 1 January, both sexes combined, in thousands
+  - name: world_un_wpp__population_single_age_sex
+    description: >
+      Population by country, year, single age, and sex from the United Nations
+      World Population Prospects, 2024 revision. Population is the stock on
+      1 July (mid-year), in thousands, for countries and areas only (no
+      aggregates). Values for 1950-2023 are estimates; values for 2024-2100
+      are Medium-variant projections.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [year, country_iso3_code, age]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: >
+          Year of reference. 1950-2023 are estimates; 2024 onwards are
+          Medium-variant projections
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: country_iso3_code
+        description: >
+          Country or area ISO 3166-1 alpha-3 code
+        tests:
+          - not_null
+          - custom_relationships:
+              to: ref('br_bd_diretorios_mundo__pais')
+              field: sigla_iso3
+              ignore_values: [XKX]
+      - name: age
+        description: >
+          Single age in completed years, from 0 to 100. Age 100 is the
+          open-ended group 100 and over
+        tests: [not_null]
+      - name: population_male
+        description: >
+          Male population on 1 July (mid-year), in thousands
+      - name: population_female
+        description: >
+          Female population on 1 July (mid-year), in thousands
+      - name: population_total
+        description: >-
+          Total population on 1 July (mid-year), both sexes combined, in
+          thousands

--- a/models/world_un_wpp/world_un_wpp__demographic_indicators.sql
+++ b/models/world_un_wpp/world_un_wpp__demographic_indicators.sql
@@ -1,0 +1,82 @@
+{{
+    config(
+        schema="world_un_wpp",
+        alias="demographic_indicators",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1950, "end": 2106, "interval": 1},
+        },
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(country_iso3_code as string) country_iso3_code,
+    safe_cast(total_population_1_january as float64) total_population_1_january,
+    safe_cast(total_population_1_july as float64) total_population_1_july,
+    safe_cast(total_population_male_1_july as float64) total_population_male_1_july,
+    safe_cast(total_population_female_1_july as float64) total_population_female_1_july,
+    safe_cast(population_density as float64) population_density,
+    safe_cast(population_sex_ratio as float64) population_sex_ratio,
+    safe_cast(median_age as float64) median_age,
+    safe_cast(natural_change as float64) natural_change,
+    safe_cast(rate_natural_change as float64) rate_natural_change,
+    safe_cast(population_change as float64) population_change,
+    safe_cast(population_growth_rate as float64) population_growth_rate,
+    safe_cast(population_doubling_time as float64) population_doubling_time,
+    safe_cast(births as float64) births,
+    safe_cast(births_women_age_15_19 as float64) births_women_age_15_19,
+    safe_cast(crude_birth_rate as float64) crude_birth_rate,
+    safe_cast(total_fertility_rate as float64) total_fertility_rate,
+    safe_cast(net_reproduction_rate as float64) net_reproduction_rate,
+    safe_cast(mean_age_childbearing as float64) mean_age_childbearing,
+    safe_cast(sex_ratio_at_birth as float64) sex_ratio_at_birth,
+    safe_cast(total_deaths as float64) total_deaths,
+    safe_cast(total_deaths_male as float64) total_deaths_male,
+    safe_cast(total_deaths_female as float64) total_deaths_female,
+    safe_cast(crude_death_rate as float64) crude_death_rate,
+    safe_cast(life_expectancy_at_birth as float64) life_expectancy_at_birth,
+    safe_cast(life_expectancy_at_birth_male as float64) life_expectancy_at_birth_male,
+    safe_cast(
+        life_expectancy_at_birth_female as float64
+    ) life_expectancy_at_birth_female,
+    safe_cast(life_expectancy_at_15 as float64) life_expectancy_at_15,
+    safe_cast(life_expectancy_at_15_male as float64) life_expectancy_at_15_male,
+    safe_cast(life_expectancy_at_15_female as float64) life_expectancy_at_15_female,
+    safe_cast(life_expectancy_at_65 as float64) life_expectancy_at_65,
+    safe_cast(life_expectancy_at_65_male as float64) life_expectancy_at_65_male,
+    safe_cast(life_expectancy_at_65_female as float64) life_expectancy_at_65_female,
+    safe_cast(life_expectancy_at_80 as float64) life_expectancy_at_80,
+    safe_cast(life_expectancy_at_80_male as float64) life_expectancy_at_80_male,
+    safe_cast(life_expectancy_at_80_female as float64) life_expectancy_at_80_female,
+    safe_cast(infant_deaths as float64) infant_deaths,
+    safe_cast(infant_mortality_rate as float64) infant_mortality_rate,
+    safe_cast(live_births_surviving_age_1 as float64) live_births_surviving_age_1,
+    safe_cast(under_5_deaths as float64) under_5_deaths,
+    safe_cast(under_5_mortality_rate as float64) under_5_mortality_rate,
+    safe_cast(mortality_before_age_40 as float64) mortality_before_age_40,
+    safe_cast(mortality_before_age_40_male as float64) mortality_before_age_40_male,
+    safe_cast(mortality_before_age_40_female as float64) mortality_before_age_40_female,
+    safe_cast(mortality_before_age_60 as float64) mortality_before_age_60,
+    safe_cast(mortality_before_age_60_male as float64) mortality_before_age_60_male,
+    safe_cast(mortality_before_age_60_female as float64) mortality_before_age_60_female,
+    safe_cast(mortality_between_age_15_50 as float64) mortality_between_age_15_50,
+    safe_cast(
+        mortality_between_age_15_50_male as float64
+    ) mortality_between_age_15_50_male,
+    safe_cast(
+        mortality_between_age_15_50_female as float64
+    ) mortality_between_age_15_50_female,
+    safe_cast(mortality_between_age_15_60 as float64) mortality_between_age_15_60,
+    safe_cast(
+        mortality_between_age_15_60_male as float64
+    ) mortality_between_age_15_60_male,
+    safe_cast(
+        mortality_between_age_15_60_female as float64
+    ) mortality_between_age_15_60_female,
+    safe_cast(net_migrations as float64) net_migrations,
+    safe_cast(net_migration_rate as float64) net_migration_rate
+from {{ set_datalake_project("world_un_wpp_staging.demographic_indicators") }} as t

--- a/models/world_un_wpp/world_un_wpp__population_age_group_sex.sql
+++ b/models/world_un_wpp/world_un_wpp__population_age_group_sex.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        schema="world_un_wpp",
+        alias="population_age_group_sex",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1950, "end": 2106, "interval": 1},
+        },
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(country_iso3_code as string) country_iso3_code,
+    safe_cast(age_group as string) age_group,
+    safe_cast(population_male as float64) population_male,
+    safe_cast(population_female as float64) population_female,
+    safe_cast(population_total as float64) population_total
+from {{ set_datalake_project("world_un_wpp_staging.population_age_group_sex") }} as t

--- a/models/world_un_wpp/world_un_wpp__population_single_age_sex.sql
+++ b/models/world_un_wpp/world_un_wpp__population_single_age_sex.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        schema="world_un_wpp",
+        alias="population_single_age_sex",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1950, "end": 2105, "interval": 1},
+        },
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(country_iso3_code as string) country_iso3_code,
+    safe_cast(age as int64) age,
+    safe_cast(population_male as float64) population_male,
+    safe_cast(population_female as float64) population_female,
+    safe_cast(population_total as float64) population_total
+from {{ set_datalake_project("world_un_wpp_staging.population_single_age_sex") }} as t


### PR DESCRIPTION
## Summary
Onboards the UN World Population Prospects (WPP), 2024 revision — official estimates (1950–2023) and Medium-variant projections (2024–2100) of population and demographic indicators for 237 countries/areas, from the UN Population Division (population.un.org/wpp). Countries only (`LocTypeID = 4`). Column names and structure follow the raw UN files, in English.

## Tables (dataset `world_un_wpp`)
- `demographic_indicators` — country × year, 54 indicators (population stocks, fertility, mortality, life expectancy, migration). 36,024 rows, 1950–2101.
- `population_age_group_sex` — country × year × 5-year age group, 1 January stock, in thousands. 756,504 rows.
- `population_single_age_sex` — country × year × single age (0–100+), 1 July mid-year, in thousands. 3,614,487 rows.

## Data
- Source: official `.csv.gz` files (Demographic Indicators Medium; Population by 5-year age group; Population by single age & sex 1950–2023 + 2024–2100). License CC BY 3.0 IGO.
- Cleaned to Parquet partitioned by `year`, uploaded to BigQuery dev (`basedosdados-dev.world_un_wpp_staging`), row counts verified.
- Country key `country_iso3_code` → `br_bd_diretorios_mundo.pais:sigla_iso3` (`custom_relationships`, `ignore_values [XKX]` — Kosovo absent from the directory).

## dbt
- 3 models + `schema.yml`; `uv run dbt run/test --select world_un_wpp` → 3 models, 20/20 tests pass.

## Metadata
- Registered on staging (dev backend was down) and promoted to prod; dataset/table/column descriptions in PT/EN/ES.

## Notes
- Values kept in thousands (counts) / per 1,000 (rates), as in the raw UN files — no unit conversion.
- Deferred to later rounds: fertility by age, deaths by age/sex, life tables, non-Medium variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new population dataset package with three ready-to-use tables: demographic indicators, population by age group, and population by single age.
  * Introduced streamlined download, cleaning, and BigQuery upload workflows to keep data refreshes consistent.
  * Added table documentation plus data validation tests (including key uniqueness and coverage thresholds) for the new models.
* **Bug Fixes**
  * Standardized types and year-based partitioning across the new tables to improve query consistency and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->