### PR TITLE
feat(br_bd_diretorios_us): add US directories dataset (14 tables)

### DIFF
--- a/.dbtignore
+++ b/.dbtignore
@@ -1,3 +1,4 @@
 **.py
 **.ipynb
 **.r
+models/br_bd_diretorios_us/data/**

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -82,6 +82,9 @@ models:
     br_bd_diretorios_mundo:
       +materialized: table
       +schema: br_bd_diretorios_mundo
+    br_bd_diretorios_us:
+      +materialized: table
+      +schema: br_bd_diretorios_us
     br_bd_indicadores:
       +materialized: table
       +schema: br_bd_indicadores

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__cbsa_2023.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__cbsa_2023.sql
@@ -1,0 +1,14 @@
+{{
+    config(
+        alias="cbsa_2023",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_cbsa as string) id_cbsa,
+    safe_cast(name as string) name,
+    safe_cast(type as string) type,
+    safe_cast(id_csa as string) id_csa,
+    safe_cast(name_csa as string) name_csa
+from {{ set_datalake_project("br_bd_diretorios_us_staging.cbsa_2023") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__census_tract_2020.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__census_tract_2020.sql
@@ -1,0 +1,15 @@
+{{
+    config(
+        alias="census_tract_2020",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_census_tract as string) id_census_tract,
+    safe_cast(id_county as string) id_county,
+    safe_cast(id_state as string) id_state,
+    safe_cast(area_land_km2 as float64) area_land_km2,
+    safe_cast(area_water_km2 as float64) area_water_km2,
+    safe.st_geogfromtext(centroid) centroid
+from {{ set_datalake_project("br_bd_diretorios_us_staging.census_tract_2020") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__congress_member.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__congress_member.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        alias="congress_member",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_bioguide as string) id_bioguide,
+    safe_cast(name_first as string) name_first,
+    safe_cast(name_middle as string) name_middle,
+    safe_cast(name_last as string) name_last,
+    safe_cast(name_suffix as string) name_suffix,
+    safe_cast(name_official_full as string) name_official_full,
+    safe_cast(birthday as date) birthday,
+    safe_cast(gender as string) gender,
+    safe_cast(id_govtrack as string) id_govtrack,
+    safe_cast(id_icpsr as string) id_icpsr,
+    safe_cast(id_lis as string) id_lis,
+    safe_cast(id_thomas as string) id_thomas,
+    safe_cast(id_opensecrets as string) id_opensecrets,
+    safe_cast(id_votesmart as string) id_votesmart,
+    safe_cast(id_cspan as string) id_cspan,
+    safe_cast(id_fec as string) id_fec,
+    safe_cast(id_wikidata as string) id_wikidata,
+    safe_cast(wikipedia as string) wikipedia,
+    safe_cast(ballotpedia as string) ballotpedia
+from {{ set_datalake_project("br_bd_diretorios_us_staging.congress_member") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__congressional_district_119.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__congressional_district_119.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        alias="congressional_district_119",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_congressional_district as string) id_congressional_district,
+    safe_cast(id_state as string) id_state,
+    safe_cast(abbreviation_state as string) abbreviation_state,
+    safe_cast(district as string) district,
+    safe_cast(type as string) type
+from
+    {{ set_datalake_project("br_bd_diretorios_us_staging.congressional_district_119") }}
+    as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__county.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__county.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        alias="county",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_county as string) id_county,
+    safe_cast(name as string) name,
+    safe_cast(type as string) type,
+    safe_cast(id_state as string) id_state,
+    safe_cast(abbreviation_state as string) abbreviation_state,
+    safe_cast(name_state as string) name_state,
+    safe_cast(id_gnis as string) id_gnis,
+    safe_cast(id_cbsa as string) id_cbsa,
+    safe_cast(name_cbsa as string) name_cbsa,
+    safe_cast(id_csa as string) id_csa,
+    safe_cast(name_csa as string) name_csa,
+    safe_cast(central_outlying as string) central_outlying,
+    safe_cast(area_land_km2 as float64) area_land_km2,
+    safe_cast(area_water_km2 as float64) area_water_km2,
+    safe.st_geogfromtext(centroid) centroid
+from {{ set_datalake_project("br_bd_diretorios_us_staging.county") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__higher_education_institution.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__higher_education_institution.sql
@@ -1,0 +1,26 @@
+{{
+    config(
+        alias="higher_education_institution",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_institution as string) id_institution,
+    safe_cast(id_opeid as string) id_opeid,
+    safe_cast(name as string) name,
+    safe_cast(id_state as string) id_state,
+    safe_cast(abbreviation_state as string) abbreviation_state,
+    safe_cast(id_county as string) id_county,
+    safe_cast(city as string) city,
+    safe_cast(zip as string) zip,
+    safe_cast(sector as string) sector,
+    safe_cast(control as string) control,
+    safe_cast(level as string) level,
+    safe_cast(operational_status as string) operational_status
+from
+    {{
+        set_datalake_project(
+            "br_bd_diretorios_us_staging.higher_education_institution"
+        )
+    }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__naics_2022.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__naics_2022.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        alias="naics_2022",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_naics as string) id_naics,
+    safe_cast(name as string) name,
+    safe_cast(level as int64) level,
+    safe_cast(id_sector as string) id_sector,
+    safe_cast(name_sector as string) name_sector,
+    safe_cast(id_subsector as string) id_subsector,
+    safe_cast(name_subsector as string) name_subsector,
+    safe_cast(id_industry_group as string) id_industry_group,
+    safe_cast(name_industry_group as string) name_industry_group,
+    safe_cast(id_naics_industry as string) id_naics_industry,
+    safe_cast(name_naics_industry as string) name_naics_industry
+from {{ set_datalake_project("br_bd_diretorios_us_staging.naics_2022") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__place.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__place.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        alias="place",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_place as string) id_place,
+    safe_cast(name as string) name,
+    safe_cast(type as string) type,
+    safe_cast(class_code as string) class_code,
+    safe_cast(id_gnis as string) id_gnis,
+    safe_cast(id_state as string) id_state,
+    safe_cast(abbreviation_state as string) abbreviation_state,
+    safe_cast(area_land_km2 as float64) area_land_km2,
+    safe_cast(area_water_km2 as float64) area_water_km2,
+    safe.st_geogfromtext(centroid) centroid
+from {{ set_datalake_project("br_bd_diretorios_us_staging.place") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__puma_2020.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__puma_2020.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        alias="puma_2020",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_puma as string) id_puma,
+    safe_cast(name as string) name,
+    safe_cast(id_state as string) id_state,
+    safe_cast(abbreviation_state as string) abbreviation_state,
+    safe_cast(area_land_km2 as float64) area_land_km2,
+    safe_cast(area_water_km2 as float64) area_water_km2,
+    safe.st_geogfromtext(centroid) centroid
+from {{ set_datalake_project("br_bd_diretorios_us_staging.puma_2020") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__school.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__school.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        alias="school",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_school as string) id_school,
+    safe_cast(name as string) name,
+    safe_cast(id_school_district as string) id_school_district,
+    safe_cast(id_state as string) id_state,
+    safe_cast(abbreviation_state as string) abbreviation_state,
+    safe_cast(id_county as string) id_county,
+    safe_cast(type as string) type,
+    safe_cast(level as string) level,
+    safe_cast(charter as string) charter,
+    safe_cast(operational_status as string) operational_status
+from {{ set_datalake_project("br_bd_diretorios_us_staging.school") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__school_district.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__school_district.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        alias="school_district",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_school_district as string) id_school_district,
+    safe_cast(name as string) name,
+    safe_cast(type as string) type,
+    safe_cast(level as string) level,
+    safe_cast(id_state as string) id_state,
+    safe_cast(abbreviation_state as string) abbreviation_state,
+    safe_cast(id_county as string) id_county,
+    safe_cast(operational_status as string) operational_status
+from {{ set_datalake_project("br_bd_diretorios_us_staging.school_district") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__soc_2018.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__soc_2018.sql
@@ -1,0 +1,18 @@
+{{
+    config(
+        alias="soc_2018",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_soc as string) id_soc,
+    safe_cast(name as string) name,
+    safe_cast(level as string) level,
+    safe_cast(id_major_group as string) id_major_group,
+    safe_cast(name_major_group as string) name_major_group,
+    safe_cast(id_minor_group as string) id_minor_group,
+    safe_cast(name_minor_group as string) name_minor_group,
+    safe_cast(id_broad_occupation as string) id_broad_occupation,
+    safe_cast(name_broad_occupation as string) name_broad_occupation
+from {{ set_datalake_project("br_bd_diretorios_us_staging.soc_2018") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__state.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__state.sql
@@ -1,0 +1,18 @@
+{{
+    config(
+        alias="state",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_state as string) id_state,
+    safe_cast(abbreviation as string) abbreviation,
+    safe_cast(name as string) name,
+    safe_cast(id_gnis as string) id_gnis,
+    safe_cast(id_region as string) id_region,
+    safe_cast(name_region as string) name_region,
+    safe_cast(id_division as string) id_division,
+    safe_cast(name_division as string) name_division,
+    safe_cast(type as string) type
+from {{ set_datalake_project("br_bd_diretorios_us_staging.state") }} as t

--- a/models/br_bd_diretorios_us/br_bd_diretorios_us__zcta_2020.sql
+++ b/models/br_bd_diretorios_us/br_bd_diretorios_us__zcta_2020.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        alias="zcta_2020",
+        schema="br_bd_diretorios_us",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_zcta as string) id_zcta,
+    safe_cast(area_land_km2 as float64) area_land_km2,
+    safe_cast(area_water_km2 as float64) area_water_km2,
+    safe.st_geogfromtext(centroid) centroid
+from {{ set_datalake_project("br_bd_diretorios_us_staging.zcta_2020") }} as t

--- a/models/br_bd_diretorios_us/code/clean.py
+++ b/models/br_bd_diretorios_us/code/clean.py
@@ -1,0 +1,897 @@
+import datetime
+import time
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+BASE = Path(__file__).resolve().parents[1] / "data"
+INPUT = BASE / "input"
+OUTPUT = BASE / "output"
+
+REGION_NAMES = {"1": "Northeast", "2": "Midwest", "3": "South", "4": "West"}
+DIVISION_NAMES = {
+    "1": "New England",
+    "2": "Middle Atlantic",
+    "3": "East North Central",
+    "4": "West North Central",
+    "5": "South Atlantic",
+    "6": "East South Central",
+    "7": "West South Central",
+    "8": "Mountain",
+    "9": "Pacific",
+}
+STATE_DIVISION = {
+    "CT": "1",
+    "ME": "1",
+    "MA": "1",
+    "NH": "1",
+    "RI": "1",
+    "VT": "1",
+    "NJ": "2",
+    "NY": "2",
+    "PA": "2",
+    "IL": "3",
+    "IN": "3",
+    "MI": "3",
+    "OH": "3",
+    "WI": "3",
+    "IA": "4",
+    "KS": "4",
+    "MN": "4",
+    "MO": "4",
+    "NE": "4",
+    "ND": "4",
+    "SD": "4",
+    "DE": "5",
+    "DC": "5",
+    "FL": "5",
+    "GA": "5",
+    "MD": "5",
+    "NC": "5",
+    "SC": "5",
+    "VA": "5",
+    "WV": "5",
+    "AL": "6",
+    "KY": "6",
+    "MS": "6",
+    "TN": "6",
+    "AR": "7",
+    "LA": "7",
+    "OK": "7",
+    "TX": "7",
+    "AZ": "8",
+    "CO": "8",
+    "ID": "8",
+    "MT": "8",
+    "NV": "8",
+    "NM": "8",
+    "UT": "8",
+    "WY": "8",
+    "AK": "9",
+    "CA": "9",
+    "HI": "9",
+    "OR": "9",
+    "WA": "9",
+}
+DIVISION_REGION = {
+    "1": "1",
+    "2": "1",
+    "3": "2",
+    "4": "2",
+    "5": "3",
+    "6": "3",
+    "7": "3",
+    "8": "4",
+    "9": "4",
+}
+TERRITORY_FIPS = {"60", "66", "69", "72", "74", "78"}
+
+
+def nullify(df):
+    for col in df.columns:
+        if df[col].dtype == object:
+            df[col] = df[col].map(
+                lambda x: x.strip() if isinstance(x, str) else x
+            )
+            df[col] = df[col].map(
+                lambda x: (
+                    None
+                    if x is None or pd.isna(x) or x in ("", "nan", "None")
+                    else x
+                )
+            )
+    return df
+
+
+def write_table(df, slug, fields):
+    df = nullify(df.copy())
+    names = [f[0] for f in fields]
+    df = df[names]
+    for name, typ in fields:
+        if typ == pa.float64():
+            df[name] = pd.to_numeric(df[name], errors="coerce")
+        elif typ == pa.int64():
+            df[name] = pd.to_numeric(df[name], errors="coerce").astype("Int64")
+    schema = pa.schema(fields)
+    table = pa.Table.from_pandas(df, schema=schema, preserve_index=False)
+    out = OUTPUT / slug
+    out.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, out / "data.parquet", compression="snappy")
+    return df
+
+
+def read_gazetteer(filename):
+    df = pd.read_csv(
+        INPUT / "gazetteer" / filename,
+        sep="|",
+        dtype=str,
+        encoding="utf-8-sig",
+    )
+    df.columns = [c.strip() for c in df.columns]
+    for col in df.columns:
+        df[col] = df[col].str.strip()
+    return df
+
+
+def area_km2(series):
+    return pd.to_numeric(series, errors="coerce") / 1e6
+
+
+def centroid_wkt(lat, lon):
+    lat = lat.str.strip().str.lstrip("+")
+    lon = lon.str.strip().str.lstrip("+")
+    return "POINT(" + lon + " " + lat + ")"
+
+
+def clean_state():
+    df = pd.read_csv(
+        INPUT / "state" / "state.txt", sep="|", dtype=str, encoding="utf-8-sig"
+    )
+    df = df.rename(
+        columns={
+            "STATE": "id_state",
+            "STUSAB": "abbreviation",
+            "STATE_NAME": "name",
+            "STATENS": "id_gnis",
+        }
+    )
+    df["type"] = df["id_state"].map(
+        lambda x: (
+            "district"
+            if x == "11"
+            else "territory"
+            if x in TERRITORY_FIPS
+            else "state"
+        )
+    )
+    df["id_division"] = df["abbreviation"].map(STATE_DIVISION)
+    df["id_region"] = df["id_division"].map(DIVISION_REGION)
+    df["name_region"] = df["id_region"].map(REGION_NAMES)
+    df["name_division"] = df["id_division"].map(DIVISION_NAMES)
+    fields = [
+        ("id_state", pa.string()),
+        ("abbreviation", pa.string()),
+        ("name", pa.string()),
+        ("id_gnis", pa.string()),
+        ("id_region", pa.string()),
+        ("name_region", pa.string()),
+        ("id_division", pa.string()),
+        ("name_division", pa.string()),
+        ("type", pa.string()),
+    ]
+    return write_table(df, "state", fields)
+
+
+def county_type(name):
+    if name == "District of Columbia":
+        return "district"
+    if name.endswith(" Parish"):
+        return "parish"
+    if name.endswith("Borough"):
+        return "borough"
+    if name.endswith("Census Area"):
+        return "census area"
+    if name.endswith("Municipality"):
+        return "municipality"
+    if name.endswith("Municipio"):
+        return "municipio"
+    if name.endswith("Planning Region"):
+        return "planning region"
+    if name.endswith(" city") or name == "Carson City":
+        return "city"
+    if name.endswith(" District"):
+        return "district"
+    if name.endswith(" Island") or name.endswith(" Islands"):
+        return "island"
+    return "county"
+
+
+def read_cbsa_delineation():
+    df = pd.read_excel(INPUT / "cbsa" / "list1_2023.xlsx", header=2, dtype=str)
+    df.columns = [c.strip() for c in df.columns]
+    df = df[df["CBSA Code"].notna()].copy()
+    for col in df.columns:
+        df[col] = df[col].map(lambda x: x.strip() if isinstance(x, str) else x)
+        df[col] = df[col].str.replace(r"\.0$", "", regex=True)
+    return df
+
+
+def clean_county(state_df):
+    gaz = read_gazetteer("2025_Gaz_counties_national.txt")
+    df = pd.DataFrame()
+    df["id_county"] = gaz["GEOID"]
+    df["name"] = gaz["NAME"]
+    df["type"] = gaz["NAME"].map(county_type)
+    df["id_state"] = gaz["GEOID"].str[:2]
+    df["abbreviation_state"] = gaz["USPS"]
+    df["id_gnis"] = gaz["ANSICODE"]
+    state_names = state_df.set_index("id_state")["name"]
+    df["name_state"] = df["id_state"].map(state_names)
+    omb = read_cbsa_delineation()
+    omb["id_county"] = omb["FIPS State Code"].str.zfill(2) + omb[
+        "FIPS County Code"
+    ].str.zfill(3)
+    omb = omb.drop_duplicates(subset="id_county")
+    omb["central_outlying"] = omb["Central/Outlying County"].str.lower()
+    omb = omb.rename(
+        columns={
+            "CBSA Code": "id_cbsa",
+            "CBSA Title": "name_cbsa",
+            "CSA Code": "id_csa",
+            "CSA Title": "name_csa",
+        }
+    )
+    df = df.merge(
+        omb[
+            [
+                "id_county",
+                "id_cbsa",
+                "name_cbsa",
+                "id_csa",
+                "name_csa",
+                "central_outlying",
+            ]
+        ],
+        on="id_county",
+        how="left",
+    )
+    df["area_land_km2"] = area_km2(gaz["ALAND"]).to_numpy()
+    df["area_water_km2"] = area_km2(gaz["AWATER"]).to_numpy()
+    df["centroid"] = centroid_wkt(gaz["INTPTLAT"], gaz["INTPTLONG"]).to_numpy()
+    fields = [
+        ("id_county", pa.string()),
+        ("name", pa.string()),
+        ("type", pa.string()),
+        ("id_state", pa.string()),
+        ("abbreviation_state", pa.string()),
+        ("name_state", pa.string()),
+        ("id_gnis", pa.string()),
+        ("id_cbsa", pa.string()),
+        ("name_cbsa", pa.string()),
+        ("id_csa", pa.string()),
+        ("name_csa", pa.string()),
+        ("central_outlying", pa.string()),
+        ("area_land_km2", pa.float64()),
+        ("area_water_km2", pa.float64()),
+        ("centroid", pa.string()),
+    ]
+    return write_table(df, "county", fields)
+
+
+def clean_place():
+    gaz = read_gazetteer("2025_Gaz_place_national.txt")
+    df = pd.DataFrame()
+    df["id_place"] = gaz["GEOID"]
+    df["name"] = gaz["NAME"]
+    df["class_code"] = gaz["LSAD"]
+    df["type"] = gaz["LSAD"].map(
+        lambda x: (
+            "census designated place" if x == "57" else "incorporated place"
+        )
+    )
+    df["id_gnis"] = gaz["ANSICODE"]
+    df["id_state"] = gaz["GEOID"].str[:2]
+    df["abbreviation_state"] = gaz["USPS"]
+    df["area_land_km2"] = area_km2(gaz["ALAND"])
+    df["area_water_km2"] = area_km2(gaz["AWATER"])
+    df["centroid"] = centroid_wkt(gaz["INTPTLAT"], gaz["INTPTLONG"])
+    fields = [
+        ("id_place", pa.string()),
+        ("name", pa.string()),
+        ("type", pa.string()),
+        ("class_code", pa.string()),
+        ("id_gnis", pa.string()),
+        ("id_state", pa.string()),
+        ("abbreviation_state", pa.string()),
+        ("area_land_km2", pa.float64()),
+        ("area_water_km2", pa.float64()),
+        ("centroid", pa.string()),
+    ]
+    return write_table(df, "place", fields)
+
+
+def clean_census_tract_2020():
+    gaz = read_gazetteer("2025_Gaz_tracts_national.txt")
+    df = pd.DataFrame()
+    df["id_census_tract"] = gaz["GEOID"]
+    df["id_county"] = gaz["GEOID"].str[:5]
+    df["id_state"] = gaz["GEOID"].str[:2]
+    df["area_land_km2"] = area_km2(gaz["ALAND"])
+    df["area_water_km2"] = area_km2(gaz["AWATER"])
+    df["centroid"] = centroid_wkt(gaz["INTPTLAT"], gaz["INTPTLONG"])
+    fields = [
+        ("id_census_tract", pa.string()),
+        ("id_county", pa.string()),
+        ("id_state", pa.string()),
+        ("area_land_km2", pa.float64()),
+        ("area_water_km2", pa.float64()),
+        ("centroid", pa.string()),
+    ]
+    return write_table(df, "census_tract_2020", fields)
+
+
+def clean_zcta_2020():
+    gaz = read_gazetteer("2025_Gaz_zcta_national.txt")
+    df = pd.DataFrame()
+    df["id_zcta"] = gaz["GEOID"]
+    df["area_land_km2"] = area_km2(gaz["ALAND"])
+    df["area_water_km2"] = area_km2(gaz["AWATER"])
+    df["centroid"] = centroid_wkt(gaz["INTPTLAT"], gaz["INTPTLONG"])
+    fields = [
+        ("id_zcta", pa.string()),
+        ("area_land_km2", pa.float64()),
+        ("area_water_km2", pa.float64()),
+        ("centroid", pa.string()),
+    ]
+    return write_table(df, "zcta_2020", fields)
+
+
+def clean_cbsa_2023():
+    omb = read_cbsa_delineation()
+    df = omb.drop_duplicates(subset="CBSA Code").copy()
+    out = pd.DataFrame()
+    out["id_cbsa"] = df["CBSA Code"]
+    out["name"] = df["CBSA Title"]
+    out["type"] = df["Metropolitan/Micropolitan Statistical Area"].map(
+        lambda x: (
+            "metropolitan"
+            if isinstance(x, str) and x.startswith("Metro")
+            else "micropolitan"
+        )
+    )
+    out["id_csa"] = df["CSA Code"]
+    out["name_csa"] = df["CSA Title"]
+    fields = [
+        ("id_cbsa", pa.string()),
+        ("name", pa.string()),
+        ("type", pa.string()),
+        ("id_csa", pa.string()),
+        ("name_csa", pa.string()),
+    ]
+    return write_table(out, "cbsa_2023", fields)
+
+
+def cd_type(id_state):
+    if id_state == "72":
+        return "resident_commissioner"
+    if id_state in ("11", "60", "66", "69", "78"):
+        return "delegate"
+    return "voting"
+
+
+def clean_congressional_district_119():
+    gaz = read_gazetteer("2025_Gaz_119CDs_national.txt")
+    df = pd.DataFrame()
+    df["id_congressional_district"] = gaz["GEOID"]
+    df["id_state"] = gaz["GEOID"].str[:2]
+    df["abbreviation_state"] = gaz["USPS"]
+    df["district"] = gaz["GEOID"].str[2:]
+    df["type"] = df["id_state"].map(cd_type)
+    df.loc[df["district"] == "ZZ", "type"] = "not defined"
+    fields = [
+        ("id_congressional_district", pa.string()),
+        ("id_state", pa.string()),
+        ("abbreviation_state", pa.string()),
+        ("district", pa.string()),
+        ("type", pa.string()),
+    ]
+    return write_table(df, "congressional_district_119", fields)
+
+
+def clean_puma_2020(state_df):
+    import tempfile
+    import zipfile
+
+    from dbfread import DBF
+
+    puma_dir = INPUT / "tiger_puma"
+    for attempt in range(4):
+        sources = (
+            sorted(puma_dir.glob("tl_*_puma20.dbf"))
+            if puma_dir.exists()
+            else []
+        )
+        zips = (
+            sorted(puma_dir.glob("tl_*_puma20.zip"))
+            if puma_dir.exists()
+            else []
+        )
+        if len(sources) >= 50 or len(zips) >= 50:
+            break
+        if attempt < 3:
+            print(
+                f"puma_2020: found {len(sources)} dbf / {len(zips)} zip files, waiting 120s (attempt {attempt + 1}/3)"
+            )
+            time.sleep(120)
+    else:
+        raise FileNotFoundError(
+            f"tiger_puma incomplete: {len(sources)} dbf / {len(zips)} zip files found, expected >= 50"
+        )
+    tmpdir = tempfile.mkdtemp(prefix="tiger_puma_")
+    if len(sources) < 50:
+        sources = []
+        for zpath in zips:
+            with zipfile.ZipFile(zpath) as zf:
+                dbf_names = [n for n in zf.namelist() if n.endswith(".dbf")]
+                for n in dbf_names:
+                    sources.append(Path(zf.extract(n, tmpdir)))
+        sources = sorted(sources)
+    records = []
+    for path in sources:
+        for rec in DBF(path, encoding="utf-8"):
+            records.append(
+                {
+                    "id_puma": str(rec["GEOID20"]).strip(),
+                    "name": str(rec["NAMELSAD20"]).strip(),
+                    "id_state": str(rec["STATEFP20"]).strip(),
+                    "aland": rec["ALAND20"],
+                    "awater": rec["AWATER20"],
+                    "lat": str(rec["INTPTLAT20"]).strip().lstrip("+"),
+                    "lon": str(rec["INTPTLON20"]).strip().lstrip("+"),
+                }
+            )
+    df = pd.DataFrame(records)
+    abbrev = state_df.set_index("id_state")["abbreviation"]
+    df["abbreviation_state"] = df["id_state"].map(abbrev)
+    df["area_land_km2"] = pd.to_numeric(df["aland"], errors="coerce") / 1e6
+    df["area_water_km2"] = pd.to_numeric(df["awater"], errors="coerce") / 1e6
+    df["centroid"] = "POINT(" + df["lon"] + " " + df["lat"] + ")"
+    fields = [
+        ("id_puma", pa.string()),
+        ("name", pa.string()),
+        ("id_state", pa.string()),
+        ("abbreviation_state", pa.string()),
+        ("area_land_km2", pa.float64()),
+        ("area_water_km2", pa.float64()),
+        ("centroid", pa.string()),
+    ]
+    return write_table(df, "puma_2020", fields)
+
+
+def clean_school_district():
+    raw = pd.read_csv(
+        INPUT / "ccd" / "ccd_lea_029_2324_w_1a_073124.csv",
+        dtype=str,
+        encoding="utf-8-sig",
+        low_memory=False,
+    )
+    df = pd.DataFrame()
+    df["id_school_district"] = raw["LEAID"].str.strip().str.zfill(7)
+    df["name"] = raw["LEA_NAME"]
+    df["type"] = raw["LEA_TYPE_TEXT"]
+    df["level"] = raw["LEVEL"] if "LEVEL" in raw.columns else None
+    df["id_state"] = raw["FIPST"].str.strip().str.zfill(2)
+    df["abbreviation_state"] = raw["ST"]
+    df["id_county"] = (
+        raw["CNTY"].str.strip().str.zfill(5) if "CNTY" in raw.columns else None
+    )
+    df["operational_status"] = raw["SY_STATUS_TEXT"]
+    fields = [
+        ("id_school_district", pa.string()),
+        ("name", pa.string()),
+        ("type", pa.string()),
+        ("level", pa.string()),
+        ("id_state", pa.string()),
+        ("abbreviation_state", pa.string()),
+        ("id_county", pa.string()),
+        ("operational_status", pa.string()),
+    ]
+    return write_table(df, "school_district", fields)
+
+
+def clean_school():
+    raw = pd.read_csv(
+        INPUT / "ccd" / "ccd_sch_029_2324_w_1a_073124.csv",
+        dtype=str,
+        encoding="utf-8-sig",
+        low_memory=False,
+    )
+    df = pd.DataFrame()
+    df["id_school"] = raw["NCESSCH"].str.strip().str.zfill(12)
+    df["name"] = raw["SCH_NAME"]
+    df["id_school_district"] = raw["LEAID"].str.strip().str.zfill(7)
+    df["id_state"] = raw["FIPST"].str.strip().str.zfill(2)
+    df["abbreviation_state"] = raw["ST"]
+    df["id_county"] = (
+        raw["CNTY"].str.strip().str.zfill(5) if "CNTY" in raw.columns else None
+    )
+    df["type"] = raw["SCH_TYPE_TEXT"]
+    df["level"] = raw["LEVEL"]
+    df["charter"] = raw["CHARTER_TEXT"]
+    df["operational_status"] = raw["SY_STATUS_TEXT"]
+    fields = [
+        ("id_school", pa.string()),
+        ("name", pa.string()),
+        ("id_school_district", pa.string()),
+        ("id_state", pa.string()),
+        ("abbreviation_state", pa.string()),
+        ("id_county", pa.string()),
+        ("type", pa.string()),
+        ("level", pa.string()),
+        ("charter", pa.string()),
+        ("operational_status", pa.string()),
+    ]
+    return write_table(df, "school", fields)
+
+
+SECTOR_MAP = {
+    0: "administrative unit",
+    1: "public 4-year or above",
+    2: "private not-for-profit 4-year or above",
+    3: "private for-profit 4-year or above",
+    4: "public 2-year",
+    5: "private not-for-profit 2-year",
+    6: "private for-profit 2-year",
+    7: "public less-than-2-year",
+    8: "private not-for-profit less-than-2-year",
+    9: "private for-profit less-than-2-year",
+    99: None,
+}
+CONTROL_MAP = {
+    1: "public",
+    2: "private not-for-profit",
+    3: "private for-profit",
+    -3: None,
+}
+ICLEVEL_MAP = {
+    1: "4-year or above",
+    2: "2-year",
+    3: "less-than-2-year",
+    -3: None,
+}
+CYACTIVE_MAP = {1: "active", 2: "inactive", 3: "closed"}
+
+
+def map_code(series, mapping):
+    codes = pd.to_numeric(series, errors="coerce")
+    return codes.map(lambda x: mapping.get(int(x)) if pd.notna(x) else None)
+
+
+def clean_higher_education_institution():
+    raw = pd.read_csv(
+        INPUT / "ipeds" / "HD2024.csv",
+        dtype=str,
+        encoding="latin-1",
+        low_memory=False,
+    )
+    raw.columns = [c.lstrip("﻿\xef\xbb\xbf") for c in raw.columns]
+    print(
+        "higher_education_institution CYACTIVE values:",
+        sorted(raw["CYACTIVE"].str.strip().unique()),
+    )
+    df = pd.DataFrame()
+    df["id_institution"] = raw["UNITID"].str.strip()
+    opeid = raw["OPEID"].str.strip()
+    df["id_opeid"] = opeid.map(lambda x: None if x in ("-2", "") else x)
+    df["name"] = raw["INSTNM"]
+    df["id_state"] = raw["FIPS"].str.strip().str.zfill(2)
+    df["abbreviation_state"] = raw["STABBR"]
+    county = pd.to_numeric(raw["COUNTYCD"], errors="coerce")
+    df["id_county"] = county.map(
+        lambda x: str(int(x)).zfill(5) if pd.notna(x) and x > 0 else None
+    )
+    df["city"] = raw["CITY"]
+    df["zip"] = raw["ZIP"].str.strip().str[:5]
+    df["sector"] = map_code(raw["SECTOR"], SECTOR_MAP)
+    df["control"] = map_code(raw["CONTROL"], CONTROL_MAP)
+    df["level"] = map_code(raw["ICLEVEL"], ICLEVEL_MAP)
+    df["operational_status"] = map_code(raw["CYACTIVE"], CYACTIVE_MAP)
+    fields = [
+        ("id_institution", pa.string()),
+        ("id_opeid", pa.string()),
+        ("name", pa.string()),
+        ("id_state", pa.string()),
+        ("abbreviation_state", pa.string()),
+        ("id_county", pa.string()),
+        ("city", pa.string()),
+        ("zip", pa.string()),
+        ("sector", pa.string()),
+        ("control", pa.string()),
+        ("level", pa.string()),
+        ("operational_status", pa.string()),
+    ]
+    return write_table(df, "higher_education_institution", fields)
+
+
+def legislator_record(person):
+    ids = person.get("id", {})
+    name = person.get("name", {})
+    bio = person.get("bio", {})
+
+    def s(value):
+        return None if value is None else str(value)
+
+    fec = ids.get("fec")
+    birthday = bio.get("birthday")
+    return {
+        "id_bioguide": s(ids.get("bioguide")),
+        "name_first": s(name.get("first")),
+        "name_middle": s(name.get("middle")),
+        "name_last": s(name.get("last")),
+        "name_suffix": s(name.get("suffix")),
+        "name_official_full": s(name.get("official_full")),
+        "birthday": datetime.date.fromisoformat(birthday)
+        if birthday
+        else None,
+        "gender": s(bio.get("gender")),
+        "id_govtrack": s(ids.get("govtrack")),
+        "id_icpsr": s(ids.get("icpsr")),
+        "id_lis": s(ids.get("lis")),
+        "id_thomas": s(ids.get("thomas")),
+        "id_opensecrets": s(ids.get("opensecrets")),
+        "id_votesmart": s(ids.get("votesmart")),
+        "id_cspan": s(ids.get("cspan")),
+        "id_fec": ",".join(fec) if fec else None,
+        "id_wikidata": s(ids.get("wikidata")),
+        "wikipedia": s(ids.get("wikipedia")),
+        "ballotpedia": s(ids.get("ballotpedia")),
+    }
+
+
+def clean_congress_member():
+    with open(
+        INPUT / "congress_legislators" / "legislators-current.yaml"
+    ) as f:
+        current = yaml.safe_load(f)
+    with open(
+        INPUT / "congress_legislators" / "legislators-historical.yaml"
+    ) as f:
+        historical = yaml.safe_load(f)
+    df = pd.DataFrame([legislator_record(p) for p in current + historical])
+    df = df.drop_duplicates(subset="id_bioguide", keep="first")
+    fields = [
+        ("id_bioguide", pa.string()),
+        ("name_first", pa.string()),
+        ("name_middle", pa.string()),
+        ("name_last", pa.string()),
+        ("name_suffix", pa.string()),
+        ("name_official_full", pa.string()),
+        ("birthday", pa.date32()),
+        ("gender", pa.string()),
+        ("id_govtrack", pa.string()),
+        ("id_icpsr", pa.string()),
+        ("id_lis", pa.string()),
+        ("id_thomas", pa.string()),
+        ("id_opensecrets", pa.string()),
+        ("id_votesmart", pa.string()),
+        ("id_cspan", pa.string()),
+        ("id_fec", pa.string()),
+        ("id_wikidata", pa.string()),
+        ("wikipedia", pa.string()),
+        ("ballotpedia", pa.string()),
+    ]
+    return write_table(df, "congress_member", fields)
+
+
+def clean_naics_2022():
+    raw = pd.read_excel(
+        INPUT / "naics" / "2-6_digit_2022_Codes.xlsx", sheet_name=0, dtype=str
+    )
+    codes = raw.iloc[:, 1].astype(str).str.strip()
+    titles = raw.iloc[:, 2].astype(str).str.strip().str.rstrip("T").str.strip()
+    df = pd.DataFrame({"id_naics": codes, "name": titles})
+    df = df[
+        df["id_naics"].notna()
+        & (df["id_naics"] != "nan")
+        & (df["id_naics"] != "")
+    ]
+    df["level"] = df["id_naics"].map(lambda c: 2 if "-" in c else len(c))
+    sector_map = {}
+    for _, row in df[df["level"] == 2].iterrows():
+        code = row["id_naics"]
+        if "-" in code:
+            lo, hi = code.split("-")
+            for two in range(int(lo), int(hi) + 1):
+                sector_map[str(two)] = (code, row["name"])
+        else:
+            sector_map[code] = (code, row["name"])
+    name_by_code = df.set_index("id_naics")["name"].to_dict()
+
+    def parents(row):
+        code, level = row["id_naics"], row["level"]
+        out = {
+            "id_sector": None,
+            "name_sector": None,
+            "id_subsector": None,
+            "name_subsector": None,
+            "id_industry_group": None,
+            "name_industry_group": None,
+            "id_naics_industry": None,
+            "name_naics_industry": None,
+        }
+        if level > 2:
+            sector = sector_map.get(code[:2])
+            if sector:
+                out["id_sector"], out["name_sector"] = sector
+        if level > 3:
+            out["id_subsector"] = code[:3]
+            out["name_subsector"] = name_by_code.get(code[:3])
+        if level > 4:
+            out["id_industry_group"] = code[:4]
+            out["name_industry_group"] = name_by_code.get(code[:4])
+        if level > 5:
+            out["id_naics_industry"] = code[:5]
+            out["name_naics_industry"] = name_by_code.get(code[:5])
+        return pd.Series(out)
+
+    df = pd.concat(
+        [
+            df.reset_index(drop=True),
+            df.apply(parents, axis=1).reset_index(drop=True),
+        ],
+        axis=1,
+    )
+    fields = [
+        ("id_naics", pa.string()),
+        ("name", pa.string()),
+        ("level", pa.int64()),
+        ("id_sector", pa.string()),
+        ("name_sector", pa.string()),
+        ("id_subsector", pa.string()),
+        ("name_subsector", pa.string()),
+        ("id_industry_group", pa.string()),
+        ("name_industry_group", pa.string()),
+        ("id_naics_industry", pa.string()),
+        ("name_naics_industry", pa.string()),
+    ]
+    return write_table(df, "naics_2022", fields)
+
+
+def clean_soc_2018():
+    raw = pd.read_excel(
+        INPUT / "soc" / "soc_structure_2018.xlsx",
+        sheet_name=0,
+        header=None,
+        dtype=str,
+    )
+    header_idx = raw.index[
+        raw.iloc[:, 0].astype(str).str.strip() == "Major Group"
+    ][0]
+    data = raw.iloc[header_idx + 1 :].copy()
+    level_cols = {0: "major", 1: "minor", 2: "broad", 3: "detailed"}
+    rows = []
+    for _, r in data.iterrows():
+        title = str(r.iloc[4]).strip() if pd.notna(r.iloc[4]) else None
+        for col_idx, level in level_cols.items():
+            val = r.iloc[col_idx]
+            if pd.notna(val) and str(val).strip():
+                rows.append(
+                    {"id_soc": str(val).strip(), "name": title, "level": level}
+                )
+                break
+    names = {r["id_soc"]: r["name"] for r in rows}
+    current = {"major": None, "minor": None, "broad": None}
+    for row in rows:
+        level, code = row["level"], row["id_soc"]
+        if level == "major":
+            current = {"major": code, "minor": None, "broad": None}
+        elif level == "minor":
+            current["minor"], current["broad"] = code, None
+        elif level == "broad":
+            current["broad"] = code
+        row["id_major_group"] = current["major"] if level != "major" else None
+        row["id_minor_group"] = (
+            current["minor"] if level in ("broad", "detailed") else None
+        )
+        row["id_broad_occupation"] = (
+            current["broad"] if level == "detailed" else None
+        )
+        for parent, col in [
+            ("id_major_group", "name_major_group"),
+            ("id_minor_group", "name_minor_group"),
+            ("id_broad_occupation", "name_broad_occupation"),
+        ]:
+            row[col] = names.get(row[parent]) if row[parent] else None
+        if row["id_major_group"]:
+            assert code[:2] == row["id_major_group"][:2], (
+                f"soc hierarchy mismatch: {code}"
+            )
+        if row["id_broad_occupation"]:
+            assert code[:5] == row["id_broad_occupation"][:5], (
+                f"soc hierarchy mismatch: {code}"
+            )
+    df = pd.DataFrame(rows)
+    fields = [
+        ("id_soc", pa.string()),
+        ("name", pa.string()),
+        ("level", pa.string()),
+        ("id_major_group", pa.string()),
+        ("name_major_group", pa.string()),
+        ("id_minor_group", pa.string()),
+        ("name_minor_group", pa.string()),
+        ("id_broad_occupation", pa.string()),
+        ("name_broad_occupation", pa.string()),
+    ]
+    return write_table(df, "soc_2018", fields)
+
+
+PRIMARY_KEYS = {
+    "state": "id_state",
+    "county": "id_county",
+    "place": "id_place",
+    "census_tract_2020": "id_census_tract",
+    "zcta_2020": "id_zcta",
+    "cbsa_2023": "id_cbsa",
+    "congressional_district_119": "id_congressional_district",
+    "puma_2020": "id_puma",
+    "school_district": "id_school_district",
+    "school": "id_school",
+    "higher_education_institution": "id_institution",
+    "congress_member": "id_bioguide",
+    "naics_2022": "id_naics",
+    "soc_2018": "id_soc",
+}
+
+
+def main():
+    pd.set_option("display.width", 250)
+    pd.set_option("display.max_columns", 50)
+    pd.set_option("display.max_colwidth", 28)
+    results = {}
+    runners = [
+        ("state", clean_state),
+        ("county", lambda: clean_county(results["state"])),
+        ("place", clean_place),
+        ("census_tract_2020", clean_census_tract_2020),
+        ("zcta_2020", clean_zcta_2020),
+        ("cbsa_2023", clean_cbsa_2023),
+        ("congressional_district_119", clean_congressional_district_119),
+        ("school_district", clean_school_district),
+        ("school", clean_school),
+        ("higher_education_institution", clean_higher_education_institution),
+        ("congress_member", clean_congress_member),
+        ("naics_2022", clean_naics_2022),
+        ("soc_2018", clean_soc_2018),
+        ("puma_2020", lambda: clean_puma_2020(results["state"])),
+    ]
+    failures = {}
+    for slug, fn in runners:
+        try:
+            results[slug] = fn()
+            print(f"done: {slug} ({len(results[slug])} rows)")
+        except Exception as exc:
+            failures[slug] = f"{type(exc).__name__}: {exc}"
+            print(f"FAILED: {slug} — {failures[slug]}")
+
+    print("\n===== SUMMARY =====")
+    for slug in PRIMARY_KEYS:
+        if slug in failures:
+            print(f"\n--- {slug}: FAILED — {failures[slug]}")
+            continue
+        df = results[slug]
+        pk = PRIMARY_KEYS[slug]
+        unique = df[pk].is_unique
+        nulls = int(df[pk].isna().sum())
+        print(
+            f"\n--- {slug}: rows={len(df)} cols={len(df.columns)} pk={pk} unique={'OK' if unique else 'FAIL'} pk_nulls={nulls}"
+        )
+        print(df.head(2).to_string(index=False))
+        assert unique, f"{slug}: duplicate {pk}"
+        assert nulls == 0, f"{slug}: null {pk}"
+
+
+if __name__ == "__main__":
+    main()

--- a/models/br_bd_diretorios_us/code/clean.py
+++ b/models/br_bd_diretorios_us/code/clean.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 import time
 from pathlib import Path
 
@@ -88,6 +89,16 @@ DIVISION_REGION = {
     "9": "4",
 }
 TERRITORY_FIPS = {"60", "66", "69", "72", "74", "78"}
+FREELY_ASSOCIATED_STATES = [
+    {
+        "id_state": "64",
+        "abbreviation": "FM",
+        "name": "Federated States of Micronesia",
+    },
+    {"id_state": "68", "abbreviation": "MH", "name": "Marshall Islands"},
+    {"id_state": "70", "abbreviation": "PW", "name": "Palau"},
+]
+ISLAND_AREA_FIPS = {"60", "66", "69", "74", "78"}
 
 
 def nullify(df):
@@ -171,6 +182,9 @@ def clean_state():
     df["id_region"] = df["id_division"].map(DIVISION_REGION)
     df["name_region"] = df["id_region"].map(REGION_NAMES)
     df["name_division"] = df["id_division"].map(DIVISION_NAMES)
+    fas = pd.DataFrame(FREELY_ASSOCIATED_STATES)
+    fas["type"] = "freely associated state"
+    df = pd.concat([df, fas], ignore_index=True)
     fields = [
         ("id_state", pa.string()),
         ("abbreviation", pa.string()),
@@ -207,6 +221,39 @@ def county_type(name):
     if name.endswith(" Island") or name.endswith(" Islands"):
         return "island"
     return "county"
+
+
+def island_area_county_type(name):
+    last = name.split()[-1].lower()
+    return {
+        "district": "district",
+        "island": "island",
+        "islands": "island",
+        "municipality": "municipality",
+        "atoll": "atoll",
+        "guam": "island",
+    }.get(last, last)
+
+
+def island_area_counties(existing_ids, state_names):
+    raw = pd.read_csv(
+        INPUT / "county" / "national_county2020.txt",
+        sep="|",
+        dtype=str,
+        encoding="utf-8-sig",
+    )
+    raw = raw[raw["STATEFP"].isin(ISLAND_AREA_FIPS)].copy()
+    raw["id_county"] = raw["STATEFP"] + raw["COUNTYFP"]
+    raw = raw[~raw["id_county"].isin(existing_ids)]
+    df = pd.DataFrame()
+    df["id_county"] = raw["id_county"]
+    df["name"] = raw["COUNTYNAME"]
+    df["type"] = raw["COUNTYNAME"].map(island_area_county_type)
+    df["id_state"] = raw["STATEFP"]
+    df["abbreviation_state"] = raw["STATE"]
+    df["name_state"] = df["id_state"].map(state_names)
+    df["id_gnis"] = raw["COUNTYNS"]
+    return df
 
 
 def read_cbsa_delineation():
@@ -261,6 +308,9 @@ def clean_county(state_df):
     df["area_land_km2"] = area_km2(gaz["ALAND"]).to_numpy()
     df["area_water_km2"] = area_km2(gaz["AWATER"]).to_numpy()
     df["centroid"] = centroid_wkt(gaz["INTPTLAT"], gaz["INTPTLONG"]).to_numpy()
+    island = island_area_counties(set(df["id_county"]), state_names)
+    print(f"county: appending {len(island)} island-area county equivalents")
+    df = pd.concat([df, island], ignore_index=True)
     fields = [
         ("id_county", pa.string()),
         ("name", pa.string()),
@@ -471,7 +521,16 @@ def clean_puma_2020(state_df):
     return write_table(df, "puma_2020", fields)
 
 
-def clean_school_district():
+def null_invalid_fipst(id_state, state_df, table):
+    valid = set(state_df["id_state"])
+    invalid = ~id_state.isin(valid)
+    if invalid.any():
+        dist = id_state[invalid].value_counts().to_dict()
+        print(f"{table}: nulled id_state for FIPST not in state table: {dist}")
+    return id_state.where(~invalid, None)
+
+
+def clean_school_district(state_df):
     raw = pd.read_csv(
         INPUT / "ccd" / "ccd_lea_029_2324_w_1a_073124.csv",
         dtype=str,
@@ -483,7 +542,9 @@ def clean_school_district():
     df["name"] = raw["LEA_NAME"]
     df["type"] = raw["LEA_TYPE_TEXT"]
     df["level"] = raw["LEVEL"] if "LEVEL" in raw.columns else None
-    df["id_state"] = raw["FIPST"].str.strip().str.zfill(2)
+    df["id_state"] = null_invalid_fipst(
+        raw["FIPST"].str.strip().str.zfill(2), state_df, "school_district"
+    )
     df["abbreviation_state"] = raw["ST"]
     df["id_county"] = (
         raw["CNTY"].str.strip().str.zfill(5) if "CNTY" in raw.columns else None
@@ -502,7 +563,7 @@ def clean_school_district():
     return write_table(df, "school_district", fields)
 
 
-def clean_school():
+def clean_school(state_df):
     raw = pd.read_csv(
         INPUT / "ccd" / "ccd_sch_029_2324_w_1a_073124.csv",
         dtype=str,
@@ -513,7 +574,9 @@ def clean_school():
     df["id_school"] = raw["NCESSCH"].str.strip().str.zfill(12)
     df["name"] = raw["SCH_NAME"]
     df["id_school_district"] = raw["LEAID"].str.strip().str.zfill(7)
-    df["id_state"] = raw["FIPST"].str.strip().str.zfill(2)
+    df["id_state"] = null_invalid_fipst(
+        raw["FIPST"].str.strip().str.zfill(2), state_df, "school"
+    )
     df["abbreviation_state"] = raw["ST"]
     df["id_county"] = (
         raw["CNTY"].str.strip().str.zfill(5) if "CNTY" in raw.columns else None
@@ -859,16 +922,21 @@ def main():
         ("zcta_2020", clean_zcta_2020),
         ("cbsa_2023", clean_cbsa_2023),
         ("congressional_district_119", clean_congressional_district_119),
-        ("school_district", clean_school_district),
-        ("school", clean_school),
+        ("school_district", lambda: clean_school_district(results["state"])),
+        ("school", lambda: clean_school(results["state"])),
         ("higher_education_institution", clean_higher_education_institution),
         ("congress_member", clean_congress_member),
         ("naics_2022", clean_naics_2022),
         ("soc_2018", clean_soc_2018),
         ("puma_2020", lambda: clean_puma_2020(results["state"])),
     ]
+    selected = set(sys.argv[1:]) or {slug for slug, _ in runners}
+    if selected & {"county", "school_district", "school", "puma_2020"}:
+        selected.add("state")
     failures = {}
     for slug, fn in runners:
+        if slug not in selected:
+            continue
         try:
             results[slug] = fn()
             print(f"done: {slug} ({len(results[slug])} rows)")
@@ -878,6 +946,8 @@ def main():
 
     print("\n===== SUMMARY =====")
     for slug in PRIMARY_KEYS:
+        if slug not in selected:
+            continue
         if slug in failures:
             print(f"\n--- {slug}: FAILED — {failures[slug]}")
             continue

--- a/models/br_bd_diretorios_us/code/upload.py
+++ b/models/br_bd_diretorios_us/code/upload.py
@@ -1,0 +1,98 @@
+"""Upload cleaned parquet tables of br_bd_diretorios_us to BigQuery dev.
+
+Uploads each table to gs://basedosdados-dev staging and creates
+basedosdados-dev.br_bd_diretorios_us_staging.<table_slug>, then verifies
+row counts against expected values. Stops at the first failure.
+"""
+
+import sys
+from pathlib import Path
+
+import basedosdados as bd
+import google.cloud.storage as gcs
+
+BILLING_PROJECT = "basedosdados-dev"
+DATASET_ID = "br_bd_diretorios_us"
+ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_DIR = ROOT / "data" / "output"
+
+# Monkey-patch for requester-pays bucket
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+# (table_slug, expected_row_count) — upload in this order
+TABLES = [
+    ("state", 60),
+    ("county", 3236),
+    ("place", 32350),
+    ("census_tract_2020", 85396),
+    ("zcta_2020", 33791),
+    ("cbsa_2023", 937),
+    ("congressional_district_119", 440),
+    ("puma_2020", 2487),
+    ("school_district", 19637),
+    ("school", 102274),
+    ("higher_education_institution", 6072),
+    ("congress_member", 12767),
+    ("naics_2022", 2125),
+    ("soc_2018", 1447),
+]
+
+
+def upload_table(table_slug: str, expected_rows: int) -> int:
+    path = OUTPUT_DIR / table_slug / "data.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"Missing parquet file: {path}")
+
+    # Delete stale GCS staging prefix before upload
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=table_slug)
+    st.delete_table(mode="staging", not_found_ok=True)
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=table_slug)
+    tb.create(
+        path=path,
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    # Verify row count in BigQuery staging table
+    query = (
+        f"select count(*) as n from "
+        f"`{BILLING_PROJECT}.{DATASET_ID}_staging.{table_slug}`"
+    )
+    df = bd.read_sql(query, billing_project_id=BILLING_PROJECT, from_file=True)
+    n = int(df["n"].iloc[0])
+    match = "MATCH" if n == expected_rows else "MISMATCH"
+    print(
+        f"[{table_slug}] uploaded — rows={n} expected={expected_rows} {match}"
+    )
+    if n != expected_rows:
+        raise ValueError(
+            f"Row count mismatch for {table_slug}: got {n}, expected {expected_rows}"
+        )
+    return n
+
+
+def main() -> None:
+    only = sys.argv[1:] or None
+    for table_slug, expected in TABLES:
+        if only and table_slug not in only:
+            continue
+        try:
+            upload_table(table_slug, expected)
+        except Exception as e:
+            print(f"[{table_slug}] FAILED — {e}")
+            sys.exit(1)
+    print("All uploads complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/br_bd_diretorios_us/schema.yml
+++ b/models/br_bd_diretorios_us/schema.yml
@@ -1,0 +1,469 @@
+---
+version: 2
+models:
+  - name: br_bd_diretorios_us__state
+    description: >
+      Diretório de estados, territórios e estados livremente associados dos
+      Estados Unidos, com códigos FIPS, siglas, códigos GNIS e classificação
+      por região e divisão do Census Bureau.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_state]
+    columns:
+      - name: id_state
+        description: Código FIPS do estado (2 dígitos)
+        tests: [not_null]
+      - name: abbreviation
+        description: Sigla do estado (USPS)
+      - name: name
+        description: Nome do estado
+      - name: id_gnis
+        description: Código GNIS do estado
+      - name: id_region
+        description: Código da região do Census Bureau
+      - name: name_region
+        description: Nome da região do Census Bureau
+      - name: id_division
+        description: Código da divisão do Census Bureau
+      - name: name_division
+        description: Nome da divisão do Census Bureau
+      - name: type
+        description: >
+          Tipo de unidade (estado, distrito federal, território, estado
+          livremente associado)
+  - name: br_bd_diretorios_us__county
+    description: >
+      Diretório de condados e equivalentes dos Estados Unidos, incluindo
+      equivalentes das áreas insulares, com códigos FIPS e GNIS, vínculo com
+      CBSA e CSA, áreas de terra e água e centroide.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_county]
+    columns:
+      - name: id_county
+        description: Código FIPS do condado (5 dígitos)
+        tests: [not_null]
+      - name: name
+        description: Nome do condado
+      - name: type
+        description: Tipo de unidade (condado, paróquia, borough, etc.)
+      - name: id_state
+        description: Código FIPS do estado (2 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: id_state
+      - name: abbreviation_state
+        description: Sigla do estado (USPS)
+      - name: name_state
+        description: Nome do estado
+      - name: id_gnis
+        description: Código GNIS do condado
+      - name: id_cbsa
+        description: Código da Core-Based Statistical Area (CBSA)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__cbsa_2023')
+              field: id_cbsa
+      - name: name_cbsa
+        description: Nome da Core-Based Statistical Area (CBSA)
+      - name: id_csa
+        description: Código da Combined Statistical Area (CSA)
+      - name: name_csa
+        description: Nome da Combined Statistical Area (CSA)
+      - name: central_outlying
+        description: Classificação do condado na CBSA (central ou periférico)
+      - name: area_land_km2
+        description: Área de terra em km²
+      - name: area_water_km2
+        description: Área de água em km²
+      - name: centroid
+        description: Centroide do condado
+  - name: br_bd_diretorios_us__place
+    description: >
+      Diretório de places (cidades, vilas e áreas designadas pelo censo) dos
+      Estados Unidos, com códigos FIPS e GNIS, áreas de terra e água e centroide.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_place]
+    columns:
+      - name: id_place
+        description: Código FIPS do place (7 dígitos, estado + place)
+        tests: [not_null]
+      - name: name
+        description: Nome do place
+      - name: type
+        description: Tipo de place (city, town, village, CDP, etc.)
+      - name: class_code
+        description: Código de classe FIPS do place
+      - name: id_gnis
+        description: Código GNIS do place
+      - name: id_state
+        description: Código FIPS do estado (2 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: id_state
+      - name: abbreviation_state
+        description: Sigla do estado (USPS)
+      - name: area_land_km2
+        description: Área de terra em km²
+      - name: area_water_km2
+        description: Área de água em km²
+      - name: centroid
+        description: Centroide do place
+  - name: br_bd_diretorios_us__census_tract_2020
+    description: >
+      Diretório de census tracts do Censo 2020 dos Estados Unidos, com vínculo
+      a condado e estado, áreas de terra e água e centroide.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_census_tract]
+    columns:
+      - name: id_census_tract
+        description: Código do census tract (11 dígitos, estado + condado + tract)
+        tests: [not_null]
+      - name: id_county
+        description: Código FIPS do condado (5 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__county')
+              field: id_county
+      - name: id_state
+        description: Código FIPS do estado (2 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: id_state
+      - name: area_land_km2
+        description: Área de terra em km²
+      - name: area_water_km2
+        description: Área de água em km²
+      - name: centroid
+        description: Centroide do census tract
+  - name: br_bd_diretorios_us__zcta_2020
+    description: >
+      Diretório de ZIP Code Tabulation Areas (ZCTA) do Censo 2020 dos Estados
+      Unidos, com áreas de terra e água e centroide.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_zcta]
+    columns:
+      - name: id_zcta
+        description: Código da ZIP Code Tabulation Area (5 dígitos)
+        tests: [not_null]
+      - name: area_land_km2
+        description: Área de terra em km²
+      - name: area_water_km2
+        description: Área de água em km²
+      - name: centroid
+        description: Centroide da ZCTA
+  - name: br_bd_diretorios_us__cbsa_2023
+    description: >
+      Diretório de Core-Based Statistical Areas (CBSA) dos Estados Unidos,
+      delineação de 2023, com tipo (metropolitana ou micropolitana) e vínculo
+      com Combined Statistical Areas (CSA).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_cbsa]
+    columns:
+      - name: id_cbsa
+        description: Código da Core-Based Statistical Area (CBSA)
+        tests: [not_null]
+      - name: name
+        description: Nome da CBSA
+      - name: type
+        description: Tipo da CBSA (metropolitana ou micropolitana)
+      - name: id_csa
+        description: Código da Combined Statistical Area (CSA)
+      - name: name_csa
+        description: Nome da Combined Statistical Area (CSA)
+  - name: br_bd_diretorios_us__congressional_district_119
+    description: >
+      Diretório de distritos congressionais do 119º Congresso dos Estados
+      Unidos, com vínculo ao estado. Inclui 3 registros com distrito 'ZZ'
+      (áreas não definidas).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_congressional_district]
+    columns:
+      - name: id_congressional_district
+        description: Código do distrito congressional (4 dígitos, estado + distrito)
+        tests: [not_null]
+      - name: id_state
+        description: Código FIPS do estado (2 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: id_state
+      - name: abbreviation_state
+        description: Sigla do estado (USPS)
+      - name: district
+        description: Número do distrito dentro do estado
+      - name: type
+        description: Tipo do distrito (com representação, delegado, etc.)
+  - name: br_bd_diretorios_us__puma_2020
+    description: >
+      Diretório de Public Use Microdata Areas (PUMA) do Censo 2020 dos Estados
+      Unidos, com vínculo ao estado, áreas de terra e água e centroide.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_puma]
+    columns:
+      - name: id_puma
+        description: Código da PUMA (7 dígitos, estado + PUMA)
+        tests: [not_null]
+      - name: name
+        description: Nome da PUMA
+      - name: id_state
+        description: Código FIPS do estado (2 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: id_state
+      - name: abbreviation_state
+        description: Sigla do estado (USPS)
+      - name: area_land_km2
+        description: Área de terra em km²
+      - name: area_water_km2
+        description: Área de água em km²
+      - name: centroid
+        description: Centroide da PUMA
+  - name: br_bd_diretorios_us__school_district
+    description: >
+      Diretório de distritos escolares dos Estados Unidos (NCES Common Core of
+      Data), com tipo, nível de ensino, vínculo ao estado e status operacional.
+      A coluna id_county está 100% nula, pois o diretório CCD de origem não
+      informa o condado.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_school_district]
+    columns:
+      - name: id_school_district
+        description: Código NCES do distrito escolar (7 dígitos)
+        tests: [not_null]
+      - name: name
+        description: Nome do distrito escolar
+      - name: type
+        description: Tipo de agência escolar
+      - name: level
+        description: Nível de ensino atendido pelo distrito
+      - name: id_state
+        description: Código FIPS do estado (2 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: id_state
+      - name: abbreviation_state
+        description: Sigla do estado (USPS)
+      - name: id_county
+        description: >
+          Código FIPS do condado (5 dígitos). Atualmente 100% nulo — o
+          diretório CCD de origem não informa o condado.
+      - name: operational_status
+        description: Status operacional do distrito escolar
+  - name: br_bd_diretorios_us__school
+    description: >
+      Diretório de escolas públicas dos Estados Unidos (NCES Common Core of
+      Data), com vínculo ao distrito escolar e ao estado, tipo, nível,
+      indicador de charter e status operacional. A coluna id_county está 100%
+      nula, pois o diretório CCD de origem não informa o condado.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_school]
+    columns:
+      - name: id_school
+        description: Código NCES da escola (12 dígitos)
+        tests: [not_null]
+      - name: name
+        description: Nome da escola
+      - name: id_school_district
+        description: Código NCES do distrito escolar (7 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__school_district')
+              field: id_school_district
+      - name: id_state
+        description: Código FIPS do estado (2 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: id_state
+      - name: abbreviation_state
+        description: Sigla do estado (USPS)
+      - name: id_county
+        description: >
+          Código FIPS do condado (5 dígitos). Atualmente 100% nulo — o
+          diretório CCD de origem não informa o condado.
+      - name: type
+        description: Tipo de escola
+      - name: level
+        description: Nível de ensino da escola
+      - name: charter
+        description: Indicador se a escola é charter
+      - name: operational_status
+        description: Status operacional da escola
+  - name: br_bd_diretorios_us__higher_education_institution
+    description: >
+      Diretório de instituições de ensino superior dos Estados Unidos (IPEDS),
+      com códigos UNITID e OPEID, localização, setor, controle, nível e status
+      operacional.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_institution]
+    columns:
+      - name: id_institution
+        description: Código UNITID da instituição (IPEDS)
+        tests: [not_null]
+      - name: id_opeid
+        description: Código OPEID da instituição (Office of Postsecondary Education)
+      - name: name
+        description: Nome da instituição
+      - name: id_state
+        description: Código FIPS do estado (2 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: id_state
+      - name: abbreviation_state
+        description: Sigla do estado (USPS)
+      - name: id_county
+        description: Código FIPS do condado (5 dígitos)
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__county')
+              field: id_county
+      - name: city
+        description: Cidade da instituição
+      - name: zip
+        description: Código postal (ZIP) da instituição
+      - name: sector
+        description: Setor da instituição (combinação de controle e nível)
+      - name: control
+        description: Controle da instituição (pública, privada sem/com fins lucrativos)
+      - name: level
+        description: Nível da instituição (4 anos, 2 anos, menos de 2 anos)
+      - name: operational_status
+        description: Status operacional da instituição
+  - name: br_bd_diretorios_us__congress_member
+    description: >
+      Diretório de membros do Congresso dos Estados Unidos (projeto
+      unitedstates/congress-legislators), ligando o código Bioguide a
+      identificadores externos (GovTrack, ICPSR, FEC, Wikidata, etc.).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_bioguide]
+    columns:
+      - name: id_bioguide
+        description: Código Bioguide do membro do Congresso
+        tests: [not_null]
+      - name: name_first
+        description: Primeiro nome
+      - name: name_middle
+        description: Nome do meio
+      - name: name_last
+        description: Sobrenome
+      - name: name_suffix
+        description: Sufixo do nome (Jr., III, etc.)
+      - name: name_official_full
+        description: Nome oficial completo
+      - name: birthday
+        description: Data de nascimento
+      - name: gender
+        description: Gênero
+      - name: id_govtrack
+        description: ID GovTrack
+      - name: id_icpsr
+        description: ID ICPSR
+      - name: id_lis
+        description: ID LIS (Legislative Information System do Senado)
+      - name: id_thomas
+        description: ID THOMAS (Biblioteca do Congresso)
+      - name: id_opensecrets
+        description: ID OpenSecrets
+      - name: id_votesmart
+        description: ID Vote Smart
+      - name: id_cspan
+        description: ID C-SPAN
+      - name: id_fec
+        description: IDs na Federal Election Commission (FEC)
+      - name: id_wikidata
+        description: ID Wikidata
+      - name: wikipedia
+        description: Título da página na Wikipedia
+      - name: ballotpedia
+        description: Título da página na Ballotpedia
+  - name: br_bd_diretorios_us__naics_2022
+    description: >
+      Diretório da classificação industrial NAICS 2022 (North American Industry
+      Classification System), com hierarquia de setor, subsetor, grupo
+      industrial e indústria NAICS.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_naics]
+    columns:
+      - name: id_naics
+        description: Código NAICS (2 a 6 dígitos)
+        tests: [not_null]
+      - name: name
+        description: Nome da categoria NAICS
+      - name: level
+        description: Nível hierárquico do código (2 a 6)
+      - name: id_sector
+        description: Código do setor (2 dígitos)
+      - name: name_sector
+        description: Nome do setor
+      - name: id_subsector
+        description: Código do subsetor (3 dígitos)
+      - name: name_subsector
+        description: Nome do subsetor
+      - name: id_industry_group
+        description: Código do grupo industrial (4 dígitos)
+      - name: name_industry_group
+        description: Nome do grupo industrial
+      - name: id_naics_industry
+        description: Código da indústria NAICS (5 dígitos)
+      - name: name_naics_industry
+        description: Nome da indústria NAICS
+  - name: br_bd_diretorios_us__soc_2018
+    description: >
+      Diretório da classificação ocupacional SOC 2018 (Standard Occupational
+      Classification), com hierarquia de grupo principal, grupo menor e
+      ocupação ampla.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          tags: [diretorio]
+          combination_of_columns: [id_soc]
+    columns:
+      - name: id_soc
+        description: Código SOC (formato XX-XXXX)
+        tests: [not_null]
+      - name: name
+        description: Nome da ocupação ou grupo
+      - name: level
+        description: Nível hierárquico do código
+      - name: id_major_group
+        description: Código do grupo principal
+      - name: name_major_group
+        description: Nome do grupo principal
+      - name: id_minor_group
+        description: Código do grupo menor
+      - name: name_minor_group
+        description: Nome do grupo menor
+      - name: id_broad_occupation
+        description: Código da ocupação ampla
+      - name: name_broad_occupation
+        description: Nome da ocupação ampla


### PR DESCRIPTION
## br_bd_diretorios_us — US directories dataset

Adds `br_bd_diretorios_us`, the US analogue of `br_bd_diretorios_brasil`: 14 directory tables that serve as foreign-key targets for future US datasets.

### Tables (14)
`state`, `county`, `place`, `census_tract_2020`, `zcta_2020`, `cbsa_2023`, `congressional_district_119`, `puma_2020`, `school_district`, `school`, `higher_education_institution`, `congress_member`, `naics_2022`, `soc_2018`.

All IDs are zero-padded strings; geographic IDs follow Census GEOID construction. English column names, PT/EN/ES descriptions.

### Sources
US Census Bureau (Gazetteer, ANSI/FIPS, TIGER PUMA), OMB metro delineations, NCES Common Core of Data, IPEDS, `unitedstates/congress-legislators` (CC0), Census NAICS 2022, BLS SOC 2018.

### What's included
- Cleaning code: `models/br_bd_diretorios_us/code/clean.py` → partitioned-free Parquet
- dbt models + `schema.yml` (14 models, `[diretorio]`-tagged uniqueness + within-dataset relationship tests)
- Upload script

### Data decisions
- `state` includes DC, territories, and freely associated states (FIPS 64/68/70, used by IPEDS)
- `county` includes island-area equivalents; excludes CT legacy counties (2022 planning regions)
- NCES pseudo-state `59` (Bureau of Indian Education) rows keep `BI` abbreviation with null `id_state`
- CCD directory files carry no county column, so `school`/`school_district` `id_county` is null (backfill via NCES EDGE geocodes later)

### Test plan
```
uv run dbt run --select br_bd_diretorios_us
uv run dbt test --select br_bd_diretorios_us
```
14/14 models pass, 40/40 tests green. Metadata registered in staging and prod.
