### PR TITLE
fix(ci): paginate listFiles in table-approve so large PRs materialize

### DIFF
--- a/.github/workflows/table-approve.yaml
+++ b/.github/workflows/table-approve.yaml
@@ -53,12 +53,17 @@ jobs:
         with:
           script: |
             const pr_number = core.getInput("pr_number") || '${{ steps.get_pr.outputs.pr_number }}';
-            const files = await github.rest.pulls.listFiles({
+            // Paginate: listFiles returns only 30 files per page by default,
+            // so PRs with more than 30 changed files (e.g. a dataset with many
+            // models) would silently drop the overflow — including the .sql
+            // models that prefect_run_dbt.py selects on — and materialize nothing.
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pr_number
+              pull_number: pr_number,
+              per_page: 100
             });
-            const fileNames = files.data
+            const fileNames = files
               .filter(file => file.status !== 'removed')
               .map(f => f.filename)
               .join(',');


### PR DESCRIPTION
## Paginate `listFiles` in `table-approve` so large PRs materialize

### The bug
`table-approve.yaml` computed the merged PR's changed files with a single call:

```js
const files = await github.rest.pulls.listFiles({ owner, repo, pull_number });
```

`pulls.listFiles` returns **30 files per page by default** and this call never paginates. Any PR that changes more than 30 files silently loses the overflow.

`prefect_run_dbt.py` then derives which tables to materialize from the `.sql` files in that list (`get_datasets_tables_from_modified_files` filters on `suffix == ".sql"`). When the dropped overflow contains the model files, the flow receives **zero models**, materializes **nothing**, and still reports success.

### How it surfaced
The IPEDS onboarding PR (`us_ed_ipeds`) changed **54 files** — 23 architecture CSVs, 23 dbt models, `schema.yml`, and scripts. Alphabetically the first 30 are `dbt_project.yml` + everything under `models/us_ed_ipeds/code/`, so `schema.yml` and all 23 `us_ed_ipeds__*.sql` (files 31–54) were dropped. The prod run built no tables; `basedosdados.us_ed_ipeds` was never created. Smaller onboardings (≤30 changed files) never hit this, which is why it went unnoticed.

### The fix
Paginate so every changed file is considered:

```js
const files = await github.paginate(github.rest.pulls.listFiles, {
  owner, repo, pull_number, per_page: 100,
});
```

(`github.paginate` returns the array directly, so `files.data` becomes `files`.)

### Follow-up
Datasets whose approval ran under the old code (e.g. `us_ed_ipeds`) need their prod materialization re-triggered once this is merged, since their models were skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pull requests with many changed files so all relevant file changes are included reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->