### PR TITLE
chore(us_ed_ipeds): re-materialize IPEDS in prod (table-approve re-trigger)

### DIFF
--- a/models/us_ed_ipeds/us_ed_ipeds__adm.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__adm.sql
@@ -124,4 +124,6 @@ select
     safe_cast(act_writing_25th as float64) act_writing_25th,
     safe_cast(xactwr75 as string) xactwr75,
     safe_cast(act_writing_75th as float64) act_writing_75th
-from {{ set_datalake_project("us_ed_ipeds_staging.adm") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.adm") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__al.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__al.sql
@@ -85,4 +85,6 @@ select
     safe_cast(lexptot as float64) lexptot,
     safe_cast(lswmsom as float64) lswmsom,
     safe_cast(lsuppvrs as float64) lsuppvrs
-from {{ set_datalake_project("us_ed_ipeds_staging.al") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.al") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__c_a.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__c_a.sql
@@ -158,4 +158,6 @@ select
     safe_cast(crace23 as float64) crace23,
     safe_cast(xcrace24 as string) xcrace24,
     safe_cast(crace24 as float64) crace24
-from {{ set_datalake_project("us_ed_ipeds_staging.c_a") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.c_a") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__eap.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__eap.sql
@@ -54,4 +54,6 @@ select
     safe_cast(fstat5 as float64) fstat5,
     safe_cast(xfstat6 as string) xfstat6,
     safe_cast(fstat6 as float64) fstat6
-from {{ set_datalake_project("us_ed_ipeds_staging.eap") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.eap") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__ef_a.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__ef_a.sql
@@ -169,4 +169,6 @@ select
     safe_cast(efrace23 as float64) efrace23,
     safe_cast(xefrac24 as string) xefrac24,
     safe_cast(efrace24 as float64) efrace24
-from {{ set_datalake_project("us_ed_ipeds_staging.ef_a") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.ef_a") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__ef_b.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__ef_b.sql
@@ -38,4 +38,6 @@ select
     safe_cast(xefage09 as string) xefage09,
     safe_cast(efage09 as float64) efage09,
     safe_cast(section as float64) section
-from {{ set_datalake_project("us_ed_ipeds_staging.ef_b") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.ef_b") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__ef_c.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__ef_c.sql
@@ -22,4 +22,6 @@ select
     safe_cast(efres01 as int64) efres01,
     safe_cast(xefres02 as string) xefres02,
     safe_cast(efres02 as float64) efres02
-from {{ set_datalake_project("us_ed_ipeds_staging.ef_c") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.ef_c") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__ef_d.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__ef_d.sql
@@ -61,4 +61,6 @@ select
     safe_cast(cnactua as float64) cnactua,
     safe_cast(xcdactga as string) xcdactga,
     safe_cast(cdactga as float64) cdactga
-from {{ set_datalake_project("us_ed_ipeds_staging.ef_d") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.ef_d") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__effy.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__effy.sql
@@ -165,4 +165,6 @@ select
     safe_cast(fyrace23 as float64) fyrace23,
     safe_cast(xfyrac24 as string) xfyrac24,
     safe_cast(fyrace24 as float64) fyrace24
-from {{ set_datalake_project("us_ed_ipeds_staging.effy") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.effy") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__efia.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__efia.sql
@@ -33,4 +33,6 @@ select
     safe_cast(xftedpp as string) xftedpp,
     safe_cast(ftedpp as string) ftedpp,
     safe_cast(acttype as float64) acttype
-from {{ set_datalake_project("us_ed_ipeds_staging.efia") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.efia") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__f1a.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__f1a.sql
@@ -535,4 +535,6 @@ select
     safe_cast(f1c184 as float64) f1c184,
     safe_cast(xf1c185 as string) xf1c185,
     safe_cast(f1c185 as float64) f1c185
-from {{ set_datalake_project("us_ed_ipeds_staging.f1a") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.f1a") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__f2.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__f2.sql
@@ -491,4 +491,6 @@ select
     safe_cast(f2e161 as float64) f2e161,
     safe_cast(xf2e171 as string) xf2e171,
     safe_cast(f2e171 as float64) f2e171
-from {{ set_datalake_project("us_ed_ipeds_staging.f2") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.f2") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__f3.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__f3.sql
@@ -343,4 +343,6 @@ select
     safe_cast(f3e06 as float64) f3e06,
     safe_cast(xf3e07 as string) xf3e07,
     safe_cast(f3e07 as float64) f3e07
-from {{ set_datalake_project("us_ed_ipeds_staging.f3") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.f3") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__flags.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__flags.sql
@@ -194,4 +194,6 @@ select
     safe_cast(rev_sa as float64) rev_sa,
     safe_cast(rev_s as float64) rev_s,
     safe_cast(rev_eap as float64) rev_eap
-from {{ set_datalake_project("us_ed_ipeds_staging.flags") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.flags") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__gr.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__gr.sql
@@ -159,4 +159,6 @@ select
     safe_cast(grrace23 as float64) grrace23,
     safe_cast(xgrrac24 as string) xgrrac24,
     safe_cast(grrace24 as float64) grrace24
-from {{ set_datalake_project("us_ed_ipeds_staging.gr") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.gr") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__gr200.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__gr200.sql
@@ -68,4 +68,6 @@ select
     safe_cast(l4nc200 as float64) l4nc200,
     safe_cast(xl4gr200 as string) xl4gr200,
     safe_cast(l4gr200 as float64) l4gr200
-from {{ set_datalake_project("us_ed_ipeds_staging.gr200") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.gr200") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__hd.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__hd.sql
@@ -222,4 +222,6 @@ select
     safe_cast(cindfam as float64) cindfam,
     safe_cast(cinsfam as float64) cinsfam,
     safe_cast(cotsfam as float64) cotsfam
-from {{ set_datalake_project("us_ed_ipeds_staging.hd") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.hd") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__ic.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__ic.sql
@@ -264,4 +264,6 @@ select
     safe_cast(rotc1 as float64) rotc1,
     safe_cast(rotc2 as float64) rotc2,
     safe_cast(rotc3 as float64) rotc3
-from {{ set_datalake_project("us_ed_ipeds_staging.ic") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.ic") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__ic_ay.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__ic_ay.sql
@@ -308,4 +308,6 @@ select
     safe_cast(cotson as string) cotson,
     safe_cast(cotsoff as float64) cotsoff,
     safe_cast(cotsfam as float64) cotsfam
-from {{ set_datalake_project("us_ed_ipeds_staging.ic_ay") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.ic_ay") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__ic_py.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__ic_py.sql
@@ -148,4 +148,6 @@ select
     safe_cast(xcmp1py3 as string) xcmp1py3,
     safe_cast(cmp1py3 as string) cmp1py3,
     safe_cast(pg300 as float64) pg300
-from {{ set_datalake_project("us_ed_ipeds_staging.ic_py") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.ic_py") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__om.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__om.sql
@@ -82,4 +82,6 @@ select
     safe_cast(xomrcht8 as string) xomrcht8,
     safe_cast(omrcht8 as float64) omrcht8,
     safe_cast(omflag as float64) omflag
-from {{ set_datalake_project("us_ed_ipeds_staging.om") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.om") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__sal_is.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__sal_is.sql
@@ -137,4 +137,6 @@ select
     safe_cast(saavmnm as float64) saavmnm,
     safe_cast(xsaavmnw as string) xsaavmnw,
     safe_cast(saavmnw as float64) saavmnw
-from {{ set_datalake_project("us_ed_ipeds_staging.sal_is") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.sal_is") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)

--- a/models/us_ed_ipeds/us_ed_ipeds__sfa.sql
+++ b/models/us_ed_ipeds/us_ed_ipeds__sfa.sql
@@ -726,4 +726,6 @@ select
     safe_cast(totgrnt as float64) totgrnt,
     safe_cast(xtstdpel as string) xtstdpel,
     safe_cast(tstdpel as float64) tstdpel
-from {{ set_datalake_project("us_ed_ipeds_staging.sfa") }} as t
+from
+    {{ set_datalake_project("us_ed_ipeds_staging.sfa") }} as t
+    -- rematerialize us_ed_ipeds (table-approve re-trigger)


### PR DESCRIPTION
## Re-materialize `us_ed_ipeds` in prod

The original `table-approve` run for #1639 skipped all 23 IPEDS models because of the unpaginated `listFiles` bug (that PR changed 54 files; the model files fell past the 30-file page). As a result `basedosdados.us_ed_ipeds` was never materialized. The bug is fixed in #1642.

This PR appends a one-line marker comment to each of the 23 `us_ed_ipeds__*.sql` models so they register as changed files. **Merging it with the `table-approve` label re-runs the prod materialization** for all 23 tables.

- Touches only the 23 models (well under the 30-file cap), so it would materialize even without #1642 — but #1642 is now merged, so this is belt-and-suspenders.
- No data or logic changes: the marker is a trailing SQL comment. It can be removed in a later cleanup PR if undesired (that removal would itself re-fire `table-approve`, which is harmless).

### Checklist
- [x] Apply the `table-approve` label
- [ ] Merge to `main` → materializes `basedosdados.us_ed_ipeds`
- [ ] Verify tables exist in `basedosdados.us_ed_ipeds` after the Prefect run
