### PR TITLE
feat(us_congress_legislators): add US Congress legislators dataset (8 tables)

### DIFF
--- a/.dbtignore
+++ b/.dbtignore
@@ -2,3 +2,5 @@
 **.ipynb
 **.r
 models/br_bd_diretorios_us/data/**
+models/us_congress_legislators/code/**
+models/us_congress_legislators/output/**

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -85,6 +85,9 @@ models:
     br_bd_diretorios_us:
       +materialized: table
       +schema: br_bd_diretorios_us
+    us_congress_legislators:
+      +materialized: table
+      +schema: us_congress_legislators
     br_bd_indicadores:
       +materialized: table
       +schema: br_bd_indicadores

--- a/models/us_congress_legislators/code/architecture/committee.csv
+++ b/models/us_congress_legislators/code/architecture/committee.csv
@@ -1,0 +1,15 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_committee,STRING,Código THOMAS completo da comissão (comissão-mãe concatenada à subcomissão). Chave primária.,,no,,,no,,thomas_id(+sub)
+id_committee_parent,STRING,Código THOMAS da comissão-mãe (nulo para comissões de nível superior).,,no,,,no,,thomas_id(parent)
+thomas_id,STRING,Código THOMAS próprio da comissão ou subcomissão.,,no,,,no,,thomas_id
+name,STRING,Nome oficial atual ou mais recente da comissão.,,no,,,no,,name
+committee_type,STRING,"Câmara à qual a comissão pertence (house, senate ou joint).",,no,,,no,,type
+is_subcommittee,BOOLEAN,Indica se o registro corresponde a uma subcomissão.,,no,,,no,,(derived)
+is_current,BOOLEAN,Indica se a comissão está atualmente ativa.,,no,,,no,,(derived)
+house_committee_id,STRING,Código de duas letras da comissão na Câmara.,,no,,,no,,house_committee_id
+senate_committee_id,STRING,Código da comissão no Senado.,,no,,,no,,senate_committee_id
+jurisdiction,STRING,Descrição da jurisdição da comissão.,,no,,,no,,jurisdiction
+url,STRING,URL do site oficial da comissão.,,no,,,no,,url
+address,STRING,Endereço postal da comissão.,,no,,,no,,address
+phone,STRING,Telefone da comissão.,,no,,,no,,phone
+wikipedia,STRING,Título da página da comissão na Wikipédia.,,no,,,no,,wikipedia

--- a/models/us_congress_legislators/code/architecture/committee_membership.csv
+++ b/models/us_congress_legislators/code/architecture/committee_membership.csv
@@ -1,0 +1,7 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_committee,STRING,Código THOMAS completo da comissão ou subcomissão.,,no,,,no,,(key)
+id_bioguide,STRING,Identificador Bioguide do legislador membro.,,no,br_bd_diretorios_us.congress_member:id_bioguide,,no,,bioguide
+party,STRING,Posição do membro na comissão (majority ou minority).,,no,,,no,,party
+rank,INT64,Ordem aparente de antiguidade do membro dentro do partido na comissão.,,no,,,no,,rank
+title,STRING,"Cargo do membro na comissão (por exemplo, Chair, Ranking Member).",,no,,,no,,title
+chamber,STRING,"Câmara do membro (house ou senate), aplicável a comissões conjuntas.",,no,,,no,,chamber

--- a/models/us_congress_legislators/code/architecture/district_office.csv
+++ b/models/us_congress_legislators/code/architecture/district_office.csv
@@ -1,0 +1,14 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_office,STRING,Identificador do escritório distrital (formato bioguide-cidade). Chave primária.,,no,,,no,,offices[].id
+id_bioguide,STRING,Identificador Bioguide do legislador titular do escritório.,,no,br_bd_diretorios_us.congress_member:id_bioguide,,no,,id.bioguide
+building,STRING,Nome do edifício do escritório.,,no,,,no,,offices[].building
+address,STRING,Logradouro do escritório.,,no,,,no,,offices[].address
+suite,STRING,Sala ou conjunto do escritório.,,no,,,no,,offices[].suite
+city,STRING,Cidade do escritório.,,no,,,no,,offices[].city
+state,STRING,Código USPS de duas letras do estado ou território do escritório.,,no,br_bd_diretorios_us.state:abbreviation,,no,,offices[].state
+zip_code,STRING,Código postal (ZIP) de cinco dígitos do escritório.,,no,,,no,,offices[].zip
+phone,STRING,Telefone do escritório.,,no,,,no,,offices[].phone
+fax,STRING,Fax do escritório.,,no,,,no,,offices[].fax
+hours,STRING,Horário de funcionamento do escritório (texto livre).,,no,,,no,,offices[].hours
+latitude,FLOAT64,Latitude geocodificada do escritório.,,no,,,no,,offices[].latitude
+longitude,FLOAT64,Longitude geocodificada do escritório.,,no,,,no,,offices[].longitude

--- a/models/us_congress_legislators/code/architecture/executive_term.csv
+++ b/models/us_congress_legislators/code/architecture/executive_term.csv
@@ -1,0 +1,17 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_bioguide,STRING,"Identificador Bioguide, presente quando a pessoa também serviu no Congresso.",,no,br_bd_diretorios_us.congress_member:id_bioguide,,no,,id.bioguide
+id_icpsr_prez,STRING,Identificador ICPSR da posição presidencial.,,no,,,no,,id.icpsr_prez
+id_govtrack,STRING,Identificador da pessoa no GovTrack.us.,,no,,,no,,id.govtrack
+first_name,STRING,Primeiro nome.,,no,,,no,,name.first
+middle_name,STRING,Nome do meio ou inicial.,,no,,,no,,name.middle
+last_name,STRING,Sobrenome.,,no,,,no,,name.last
+suffix,STRING,Sufixo do nome.,,no,,,no,,name.suffix
+nickname,STRING,Apelido ou nome alternativo.,,no,,,no,,name.nickname
+full_name,STRING,Nome completo oficial.,,no,,,no,,name.official_full
+birthday,DATE,Data de nascimento.,,no,,,no,,bio.birthday
+gender,STRING,Sexo (M ou F).,,no,,,no,,bio.gender
+term_type,STRING,"Tipo de mandato (prez para presidente, viceprez para vice-presidente).",,no,,,no,,terms[].type
+term_start,DATE,Data de início do mandato.,,no,,,no,,terms[].start
+term_end,DATE,Data de término do mandato.,,no,,,no,,terms[].end
+party,STRING,Partido político durante o mandato.,,no,,,no,,terms[].party
+how,STRING,"Forma de acesso ao cargo (election, succession ou appointment).",,no,,,no,,terms[].how

--- a/models/us_congress_legislators/code/architecture/leadership_role.csv
+++ b/models/us_congress_legislators/code/architecture/leadership_role.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_bioguide,STRING,Identificador Bioguide do legislador.,,no,br_bd_diretorios_us.congress_member:id_bioguide,,no,,id.bioguide
+title,STRING,Nome do cargo de liderança.,,no,,,no,,leadership_roles[].title
+chamber,STRING,Câmara em que o cargo foi exercido (house ou senate).,,no,,,no,,leadership_roles[].chamber
+role_start,DATE,Data de início do exercício do cargo.,,no,,,no,,leadership_roles[].start
+role_end,DATE,Data de término do exercício do cargo.,,no,,,no,,leadership_roles[].end

--- a/models/us_congress_legislators/code/architecture/legislator.csv
+++ b/models/us_congress_legislators/code/architecture/legislator.csv
@@ -1,0 +1,26 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_bioguide,STRING,Identificador do legislador no Biographical Directory of the United States Congress (Bioguide). Chave primária.,,no,br_bd_diretorios_us.congress_member:id_bioguide,,no,,id.bioguide
+id_thomas,STRING,Identificador numérico do legislador no sistema THOMAS.,,no,,,no,,id.thomas
+id_lis,STRING,Identificador do legislador no Legislative Information System do Senado.,,no,,,no,,id.lis
+id_govtrack,STRING,Identificador do legislador no GovTrack.us.,,no,,,no,,id.govtrack
+id_icpsr,STRING,Identificador do legislador no ICPSR/VoteView.,,no,,,no,,id.icpsr
+id_opensecrets,STRING,Identificador do legislador no OpenSecrets.org.,,no,,,no,,id.opensecrets
+id_votesmart,STRING,Identificador do legislador no VoteSmart.org.,,no,,,no,,id.votesmart
+id_fec,STRING,"Identificadores do legislador na Federal Election Commission, separados por vírgula.",,no,,,no,,id.fec
+id_cspan,STRING,Identificador de vídeo do legislador no C-SPAN.,,no,,,no,,id.cspan
+id_maplight,STRING,Identificador do legislador no MapLight.org.,,no,,,no,,id.maplight
+id_house_history,STRING,"Identificador do legislador no site History, Art & Archives da Câmara.",,no,,,no,,id.house_history
+id_pictorial,STRING,Identificador do legislador no Pictorial Directory do GPO.,,no,,,no,,id.pictorial
+id_wikidata,STRING,Identificador do legislador no Wikidata.,,no,,,no,,id.wikidata
+id_google_entity,STRING,Identificador da entidade do legislador no Google Knowledge Graph.,,no,,,no,,id.google_entity_id
+name_wikipedia,STRING,Título da página do legislador na Wikipédia.,,no,,,no,,id.wikipedia
+name_ballotpedia,STRING,Título da página do legislador na Ballotpedia.org.,,no,,,no,,id.ballotpedia
+first_name,STRING,Primeiro nome do legislador.,,no,,,no,,name.first
+middle_name,STRING,Nome do meio ou inicial do legislador.,,no,,,no,,name.middle
+last_name,STRING,Sobrenome do legislador.,,no,,,no,,name.last
+suffix,STRING,"Sufixo do nome (por exemplo, Jr., III).",,no,,,no,,name.suffix
+nickname,STRING,Apelido ou nome alternativo pelo qual o legislador é conhecido.,,no,,,no,,name.nickname
+full_name,STRING,Nome completo oficial conforme registros da Câmara e do Senado.,,no,,,no,,name.official_full
+birthday,DATE,Data de nascimento do legislador.,,no,,,no,,bio.birthday
+gender,STRING,Sexo do legislador (M ou F).,,no,,,no,,bio.gender
+is_current,BOOLEAN,Indica se o legislador está atualmente em exercício.,,no,,,no,,(derived)

--- a/models/us_congress_legislators/code/architecture/social_media.csv
+++ b/models/us_congress_legislators/code/architecture/social_media.csv
@@ -1,0 +1,10 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_bioguide,STRING,Identificador Bioguide do legislador.,,no,br_bd_diretorios_us.congress_member:id_bioguide,,no,,id.bioguide
+twitter,STRING,Nome de usuário oficial no Twitter/X.,,no,,,no,,social.twitter
+twitter_id,STRING,Identificador numérico da conta no Twitter/X.,,no,,,no,,social.twitter_id
+facebook,STRING,Nome de usuário oficial no Facebook.,,no,,,no,,social.facebook
+instagram,STRING,Nome de usuário oficial no Instagram.,,no,,,no,,social.instagram
+instagram_id,STRING,Identificador numérico da conta no Instagram.,,no,,,no,,social.instagram_id
+youtube,STRING,Nome de usuário oficial no YouTube.,,no,,,no,,social.youtube
+youtube_id,STRING,Identificador do canal oficial no YouTube.,,no,,,no,,social.youtube_id
+mastodon,STRING,Identificador no Mastodon (formato @usuario@instancia).,,no,,,no,,social.mastodon

--- a/models/us_congress_legislators/code/architecture/term.csv
+++ b/models/us_congress_legislators/code/architecture/term.csv
@@ -1,0 +1,20 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_bioguide,STRING,Identificador Bioguide do legislador que exerceu o mandato.,,no,br_bd_diretorios_us.congress_member:id_bioguide,,no,,id.bioguide
+term_type,STRING,"Tipo de mandato (rep para representante/delegado, sen para senador).",,no,,,no,,terms[].type
+term_start,DATE,Data de início do mandato (posse).,,no,,,no,,terms[].start
+term_end,DATE,Data de término do mandato (último dia em exercício).,,no,,,no,,terms[].end
+state,STRING,Código USPS de duas letras do estado ou território representado. Inclui códigos históricos.,,no,br_bd_diretorios_us.state:abbreviation,,no,,terms[].state
+district,INT64,"Número do distrito eleitoral da Câmara (0 para at-large, -1 para desconhecido).",,no,,,no,,terms[].district
+senate_class,INT64,"Classe do assento no Senado (1, 2 ou 3).",,no,,,no,,terms[].class
+state_rank,STRING,Antiguidade do senador no estado (junior ou senior).,,no,,,no,,terms[].state_rank
+party,STRING,Partido político do legislador durante o mandato.,,no,,,no,,terms[].party
+caucus,STRING,Bancada partidária com a qual legisladores independentes se alinham.,,no,,,no,,terms[].caucus
+how,STRING,"Forma de acesso ao mandato (por exemplo, appointment, special-election).",,no,,,no,,terms[].how
+end_type,STRING,Tipo de encerramento do mandato.,,no,,,no,,terms[].end-type
+url,STRING,URL do site oficial do legislador durante o mandato.,,no,,,no,,terms[].url
+address,STRING,"Endereço postal do escritório em Washington, D.C.",,no,,,no,,terms[].address
+phone,STRING,"Telefone do escritório em Washington, D.C.",,no,,,no,,terms[].phone
+fax,STRING,"Fax do escritório em Washington, D.C.",,no,,,no,,terms[].fax
+contact_form,STRING,URL do formulário oficial de contato.,,no,,,no,,terms[].contact_form
+office,STRING,"Sala e edifício do escritório em Washington, D.C.",,no,,,no,,terms[].office
+rss_url,STRING,URL do feed RSS oficial do legislador.,,no,,,no,,terms[].rss_url

--- a/models/us_congress_legislators/code/clean.py
+++ b/models/us_congress_legislators/code/clean.py
@@ -1,0 +1,316 @@
+"""Clean unitedstates/congress-legislators YAML into 8 Data Basis tables.
+
+Source: https://github.com/unitedstates/congress-legislators (CC0).
+Output: one unpartitioned snappy Parquet per table under output/<table>/data.parquet.
+All columns are written as STRING; dbt applies safe_cast to final types.
+"""
+
+import pathlib
+import sys
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+HERE = pathlib.Path(__file__).resolve().parent
+INPUT = HERE / "input"
+OUTPUT = HERE.parent / "output"
+
+
+def load(name):
+    return yaml.safe_load((INPUT / f"{name}.yaml").read_text())
+
+
+def s(v):
+    """Normalize any scalar to a stripped string, or None."""
+    if v is None:
+        return None
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    v = str(v).strip()
+    return v if v != "" else None
+
+
+def joinlist(v):
+    if not v:
+        return None
+    return ",".join(str(x) for x in v)
+
+
+# ---------------------------------------------------------------- legislators
+def build_legislator():
+    rows = []
+    for is_current, fn in [
+        (True, "legislators-current"),
+        (False, "legislators-historical"),
+    ]:
+        for r in load(fn):
+            i = r.get("id", {})
+            n = r.get("name", {})
+            b = r.get("bio", {})
+            rows.append(
+                {
+                    "id_bioguide": s(i.get("bioguide")),
+                    "id_thomas": s(i.get("thomas")),
+                    "id_lis": s(i.get("lis")),
+                    "id_govtrack": s(i.get("govtrack")),
+                    "id_icpsr": s(i.get("icpsr")),
+                    "id_opensecrets": s(i.get("opensecrets")),
+                    "id_votesmart": s(i.get("votesmart")),
+                    "id_fec": joinlist(i.get("fec")),
+                    "id_cspan": s(i.get("cspan")),
+                    "id_maplight": s(i.get("maplight")),
+                    "id_house_history": s(i.get("house_history")),
+                    "id_pictorial": s(i.get("pictorial")),
+                    "id_wikidata": s(i.get("wikidata")),
+                    "id_google_entity": s(i.get("google_entity_id")),
+                    "name_wikipedia": s(i.get("wikipedia")),
+                    "name_ballotpedia": s(i.get("ballotpedia")),
+                    "first_name": s(n.get("first")),
+                    "middle_name": s(n.get("middle")),
+                    "last_name": s(n.get("last")),
+                    "suffix": s(n.get("suffix")),
+                    "nickname": s(n.get("nickname")),
+                    "full_name": s(n.get("official_full")),
+                    "birthday": s(b.get("birthday")),
+                    "gender": s(b.get("gender")),
+                    "is_current": "true" if is_current else "false",
+                }
+            )
+    df = pd.DataFrame(rows).drop_duplicates(
+        subset=["id_bioguide"], keep="first"
+    )
+    return df
+
+
+def build_term():
+    rows = []
+    for fn in ["legislators-current", "legislators-historical"]:
+        for r in load(fn):
+            bio = s(r.get("id", {}).get("bioguide"))
+            for t in r.get("terms", []):
+                rows.append(
+                    {
+                        "id_bioguide": bio,
+                        "term_type": s(t.get("type")),
+                        "term_start": s(t.get("start")),
+                        "term_end": s(t.get("end")),
+                        "state": s(t.get("state")),
+                        "district": s(t.get("district")),
+                        "senate_class": s(t.get("class")),
+                        "state_rank": s(t.get("state_rank")),
+                        "party": s(t.get("party")),
+                        "caucus": s(t.get("caucus")),
+                        "how": s(t.get("how")),
+                        "end_type": s(t.get("end-type")),
+                        "url": s(t.get("url")),
+                        "address": s(t.get("address")),
+                        "phone": s(t.get("phone")),
+                        "fax": s(t.get("fax")),
+                        "contact_form": s(t.get("contact_form")),
+                        "office": s(t.get("office")),
+                        "rss_url": s(t.get("rss_url")),
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def build_leadership_role():
+    rows = []
+    for fn in ["legislators-current", "legislators-historical"]:
+        for r in load(fn):
+            bio = s(r.get("id", {}).get("bioguide"))
+            for lr in r.get("leadership_roles", []):
+                rows.append(
+                    {
+                        "id_bioguide": bio,
+                        "title": s(lr.get("title")),
+                        "chamber": s(lr.get("chamber")),
+                        "role_start": s(lr.get("start")),
+                        "role_end": s(lr.get("end")),
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def build_social_media():
+    rows = []
+    for r in load("legislators-social-media"):
+        bio = s(r.get("id", {}).get("bioguide"))
+        soc = r.get("social", {})
+        rows.append(
+            {
+                "id_bioguide": bio,
+                "twitter": s(soc.get("twitter")),
+                "twitter_id": s(soc.get("twitter_id")),
+                "facebook": s(soc.get("facebook")),
+                "instagram": s(soc.get("instagram")),
+                "instagram_id": s(soc.get("instagram_id")),
+                "youtube": s(soc.get("youtube")),
+                "youtube_id": s(soc.get("youtube_id")),
+                "mastodon": s(soc.get("mastodon")),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------- committees
+def build_committee():
+    committees = {}  # id_committee -> row
+
+    def add(full_id, parent, thomas_id, name, ctype, is_sub, is_current, rec):
+        if full_id in committees:
+            return  # current wins (processed first)
+        committees[full_id] = {
+            "id_committee": full_id,
+            "id_committee_parent": parent,
+            "thomas_id": thomas_id,
+            "name": name,
+            "committee_type": ctype,
+            "is_subcommittee": "true" if is_sub else "false",
+            "is_current": "true" if is_current else "false",
+            "house_committee_id": s(rec.get("house_committee_id")),
+            "senate_committee_id": s(rec.get("senate_committee_id")),
+            "jurisdiction": s(rec.get("jurisdiction")),
+            "url": s(rec.get("url")),
+            "address": s(rec.get("address")),
+            "phone": s(rec.get("phone")),
+            "wikipedia": s(rec.get("wikipedia")),
+        }
+
+    for is_current, fn in [
+        (True, "committees-current"),
+        (False, "committees-historical"),
+    ]:
+        for c in load(fn):
+            tid = s(c.get("thomas_id"))
+            ctype = s(c.get("type"))
+            add(tid, None, tid, s(c.get("name")), ctype, False, is_current, c)
+            for sub in c.get("subcommittees", []):
+                sid = s(sub.get("thomas_id"))
+                full = tid + sid
+                add(
+                    full,
+                    tid,
+                    sid,
+                    s(sub.get("name")),
+                    ctype,
+                    True,
+                    is_current,
+                    sub,
+                )
+
+    return pd.DataFrame(list(committees.values()))
+
+
+def build_committee_membership():
+    rows = []
+    for cid, members in load("committee-membership-current").items():
+        for m in members:
+            rows.append(
+                {
+                    "id_committee": s(cid),
+                    "id_bioguide": s(m.get("bioguide")),
+                    "party": s(m.get("party")),
+                    "rank": s(m.get("rank")),
+                    "title": s(m.get("title")),
+                    "chamber": s(m.get("chamber")),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def build_district_office():
+    rows = []
+    for r in load("legislators-district-offices"):
+        bio = s(r.get("id", {}).get("bioguide"))
+        for o in r.get("offices", []):
+            rows.append(
+                {
+                    "id_office": s(o.get("id")),
+                    "id_bioguide": bio,
+                    "building": s(o.get("building")),
+                    "address": s(o.get("address")),
+                    "suite": s(o.get("suite")),
+                    "city": s(o.get("city")),
+                    "state": s(o.get("state")),
+                    "zip_code": s(o.get("zip")),
+                    "phone": s(o.get("phone")),
+                    "fax": s(o.get("fax")),
+                    "hours": s(o.get("hours")),
+                    "latitude": s(o.get("latitude")),
+                    "longitude": s(o.get("longitude")),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def build_executive_term():
+    rows = []
+    for r in load("executive"):
+        i = r.get("id", {})
+        n = r.get("name", {})
+        b = r.get("bio", {})
+        for t in r.get("terms", []):
+            rows.append(
+                {
+                    "id_bioguide": s(i.get("bioguide")),
+                    "id_icpsr_prez": s(i.get("icpsr_prez")),
+                    "id_govtrack": s(i.get("govtrack")),
+                    "first_name": s(n.get("first")),
+                    "middle_name": s(n.get("middle")),
+                    "last_name": s(n.get("last")),
+                    "suffix": s(n.get("suffix")),
+                    "nickname": s(n.get("nickname")),
+                    "full_name": s(n.get("official_full")),
+                    "birthday": s(b.get("birthday")),
+                    "gender": s(b.get("gender")),
+                    "term_type": s(t.get("type")),
+                    "term_start": s(t.get("start")),
+                    "term_end": s(t.get("end")),
+                    "party": s(t.get("party")),
+                    "how": s(t.get("how")),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+BUILDERS = {
+    "legislator": build_legislator,
+    "term": build_term,
+    "social_media": build_social_media,
+    "leadership_role": build_leadership_role,
+    "committee": build_committee,
+    "committee_membership": build_committee_membership,
+    "district_office": build_district_office,
+    "executive_term": build_executive_term,
+}
+
+
+def write_table(slug, df):
+    out = OUTPUT / slug
+    out.mkdir(parents=True, exist_ok=True)
+    for p in out.glob("*.parquet"):
+        p.unlink()
+    df = df.astype(object).where(pd.notna(df), None)
+    schema = pa.schema([(c, pa.string()) for c in df.columns])
+    table = pa.Table.from_pandas(df, schema=schema, preserve_index=False)
+    pq.write_table(table, out / "data.parquet", compression="snappy")
+    print(
+        f"  {slug:22s} {len(df):>6d} rows  {len(df.columns):>2d} cols -> {out}/data.parquet"
+    )
+
+
+def main():
+    targets = sys.argv[1:] or list(BUILDERS)
+    print("Cleaning congress-legislators tables:")
+    for slug in targets:
+        if slug not in BUILDERS:
+            print(f"  ! unknown table {slug}")
+            continue
+        write_table(slug, BUILDERS[slug]())
+
+
+if __name__ == "__main__":
+    main()

--- a/models/us_congress_legislators/code/upload.py
+++ b/models/us_congress_legislators/code/upload.py
@@ -1,0 +1,95 @@
+"""Upload cleaned parquet tables of us_congress_legislators to BigQuery.
+
+Uploads each table to the staging bucket and creates
+<project>_staging.us_congress_legislators_staging.<table_slug> (via bd.Table),
+then verifies row counts. Stops at the first failure.
+
+Default billing/target project is basedosdados-dev (staging metadata path).
+For the prod materialization path, run with env BILLING_PROJECT=basedosdados-staging
+and GOOGLE_APPLICATION_CREDENTIALS pointing at the matching SA.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import basedosdados as bd
+import google.cloud.storage as gcs
+
+BILLING_PROJECT = os.environ.get("BILLING_PROJECT", "basedosdados-dev")
+DATASET_ID = "us_congress_legislators"
+ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_DIR = ROOT / "output"
+
+# Monkey-patch for requester-pays bucket
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+# (table_slug, expected_row_count) — upload in this order
+TABLES = [
+    ("legislator", 12767),
+    ("term", 45532),
+    ("social_media", 519),
+    ("leadership_role", 156),
+    ("committee", 559),
+    ("committee_membership", 3879),
+    ("district_office", 1312),
+    ("executive_term", 131),
+]
+
+
+def upload_table(table_slug: str, expected_rows: int) -> int:
+    path = OUTPUT_DIR / table_slug / "data.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"Missing parquet file: {path}")
+
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=table_slug)
+    st.delete_table(mode="staging", not_found_ok=True)
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=table_slug)
+    tb.create(
+        path=path,
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    query = (
+        f"select count(*) as n from "
+        f"`{BILLING_PROJECT}.{DATASET_ID}_staging.{table_slug}`"
+    )
+    df = bd.read_sql(query, billing_project_id=BILLING_PROJECT, from_file=True)
+    n = int(df["n"].iloc[0])
+    match = "MATCH" if n == expected_rows else "MISMATCH"
+    print(
+        f"[{table_slug}] uploaded — rows={n} expected={expected_rows} {match}"
+    )
+    if n != expected_rows:
+        raise ValueError(
+            f"Row count mismatch for {table_slug}: got {n}, expected {expected_rows}"
+        )
+    return n
+
+
+def main() -> None:
+    only = sys.argv[1:] or None
+    for table_slug, expected in TABLES:
+        if only and table_slug not in only:
+            continue
+        try:
+            upload_table(table_slug, expected)
+        except Exception as e:
+            print(f"[{table_slug}] FAILED — {e}")
+            sys.exit(1)
+    print("All uploads complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/us_congress_legislators/schema.yml
+++ b/models/us_congress_legislators/schema.yml
@@ -80,6 +80,12 @@ models:
       Mandatos exercidos por legisladores federais dos Estados Unidos. Uma
       linha por mandato (par legislador-mandato), com câmara, período, estado,
       distrito, partido e informações de contato do escritório em Washington.
+      A coluna state é validada contra o diretório de estados
+      (br_bd_diretorios_us.state); siglas de territórios extintos (DK —
+      Território de Dakota, OL — Território de Orleans, PI — Ilhas Filipinas)
+      são exceções históricas conhecidas e ficam de fora do teste, de modo que
+      qualquer outra sigla ausente do diretório (por exemplo, um erro de
+      digitação) faça o teste falhar.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns: [id_bioguide, term_start]
@@ -112,6 +118,11 @@ models:
         description: >
           Código USPS de duas letras do estado ou território representado. Inclui
           códigos históricos não presentes no diretório de estados atual.
+        tests:
+          - custom_relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: abbreviation
+              ignore_values: [DK, OL, PI]
       - name: district
         description: Número do distrito eleitoral da Câmara (0 para at-large, -1 para
           desconhecido).

--- a/models/us_congress_legislators/schema.yml
+++ b/models/us_congress_legislators/schema.yml
@@ -1,0 +1,392 @@
+---
+version: 2
+models:
+  - name: us_congress_legislators__legislator
+    description: >
+      Diretório de legisladores federais dos Estados Unidos (membros da Câmara
+      dos Representantes e do Senado), atuais e históricos, com dados
+      biográficos e identificadores cruzados de diferentes fontes. Uma linha
+      por legislador, identificada pelo código Bioguide.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_bioguide]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values: [id_lis, id_pictorial, suffix, nickname]
+    columns:
+      - name: id_bioguide
+        description: >
+          Identificador do legislador no Biographical Directory of the United
+          States Congress (Bioguide). Chave primária.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_us__congress_member')
+              field: id_bioguide
+      - name: id_thomas
+        description: Identificador numérico do legislador no sistema THOMAS (Biblioteca
+          do Congresso).
+      - name: id_lis
+        description: Identificador do legislador no Legislative Information System
+          do Senado.
+      - name: id_govtrack
+        description: Identificador do legislador no GovTrack.us.
+      - name: id_icpsr
+        description: Identificador do legislador no ICPSR/VoteView.
+      - name: id_opensecrets
+        description: Identificador do legislador no OpenSecrets.org.
+      - name: id_votesmart
+        description: Identificador do legislador no VoteSmart.org.
+      - name: id_fec
+        description: Identificadores do legislador na Federal Election Commission,
+          separados por vírgula.
+      - name: id_cspan
+        description: Identificador de vídeo do legislador no C-SPAN.
+      - name: id_maplight
+        description: Identificador do legislador no MapLight.org.
+      - name: id_house_history
+        description: Identificador do legislador no site History, Art & Archives da
+          Câmara.
+      - name: id_pictorial
+        description: Identificador do legislador no Pictorial Directory do GPO.
+      - name: id_wikidata
+        description: Identificador do legislador no Wikidata.
+      - name: id_google_entity
+        description: Identificador da entidade do legislador no Google Knowledge Graph.
+      - name: name_wikipedia
+        description: Título da página do legislador na Wikipédia.
+      - name: name_ballotpedia
+        description: Título da página do legislador na Ballotpedia.org.
+      - name: first_name
+        description: Primeiro nome do legislador.
+      - name: middle_name
+        description: Nome do meio ou inicial do legislador.
+      - name: last_name
+        description: Sobrenome do legislador.
+      - name: suffix
+        description: Sufixo do nome (por exemplo, Jr., III).
+      - name: nickname
+        description: Apelido ou nome alternativo pelo qual o legislador é conhecido.
+      - name: full_name
+        description: Nome completo oficial conforme registros da Câmara e do Senado.
+      - name: birthday
+        description: Data de nascimento do legislador.
+      - name: gender
+        description: Sexo do legislador (M ou F).
+      - name: is_current
+        description: Indica se o legislador está atualmente em exercício.
+  - name: us_congress_legislators__term
+    description: >
+      Mandatos exercidos por legisladores federais dos Estados Unidos. Uma
+      linha por mandato (par legislador-mandato), com câmara, período, estado,
+      distrito, partido e informações de contato do escritório em Washington.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_bioguide, term_start]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - state_rank
+            - caucus
+            - how
+            - end_type
+            - fax
+            - contact_form
+            - rss_url
+    columns:
+      - name: id_bioguide
+        description: Identificador Bioguide do legislador que exerceu o mandato.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('us_congress_legislators__legislator')
+              field: id_bioguide
+      - name: term_type
+        description: Tipo de mandato (rep para representante/delegado, sen para senador).
+      - name: term_start
+        description: Data de início do mandato (posse).
+        tests: [not_null]
+      - name: term_end
+        description: Data de término do mandato (último dia em exercício).
+      - name: state
+        description: >
+          Código USPS de duas letras do estado ou território representado. Inclui
+          códigos históricos não presentes no diretório de estados atual.
+      - name: district
+        description: Número do distrito eleitoral da Câmara (0 para at-large, -1 para
+          desconhecido).
+      - name: senate_class
+        description: Classe do assento no Senado (1, 2 ou 3).
+      - name: state_rank
+        description: Antiguidade do senador no estado (junior ou senior).
+      - name: party
+        description: Partido político do legislador durante o mandato.
+      - name: caucus
+        description: Bancada partidária com a qual legisladores independentes se alinham.
+      - name: how
+        description: Forma de acesso ao mandato (por exemplo, appointment, special-election).
+      - name: end_type
+        description: Tipo de encerramento do mandato.
+      - name: url
+        description: URL do site oficial do legislador durante o mandato.
+      - name: address
+        description: Endereço postal do escritório em Washington, D.C.
+      - name: phone
+        description: Telefone do escritório em Washington, D.C.
+      - name: fax
+        description: Fax do escritório em Washington, D.C.
+      - name: contact_form
+        description: URL do formulário oficial de contato.
+      - name: office
+        description: Sala e edifício do escritório em Washington, D.C.
+      - name: rss_url
+        description: URL do feed RSS oficial do legislador.
+  - name: us_congress_legislators__social_media
+    description: >
+      Contas oficiais de redes sociais de legisladores federais dos Estados
+      Unidos em exercício. Uma linha por legislador, identificada pelo código
+      Bioguide.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_bioguide]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values: [mastodon]
+    columns:
+      - name: id_bioguide
+        description: Identificador Bioguide do legislador.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('us_congress_legislators__legislator')
+              field: id_bioguide
+      - name: twitter
+        description: Nome de usuário oficial no Twitter/X.
+      - name: twitter_id
+        description: Identificador numérico da conta no Twitter/X.
+      - name: facebook
+        description: Nome de usuário oficial no Facebook.
+      - name: instagram
+        description: Nome de usuário oficial no Instagram.
+      - name: instagram_id
+        description: Identificador numérico da conta no Instagram.
+      - name: youtube
+        description: Nome de usuário oficial no YouTube.
+      - name: youtube_id
+        description: Identificador do canal oficial no YouTube.
+      - name: mastodon
+        description: Identificador no Mastodon (formato @usuario@instancia).
+  - name: us_congress_legislators__leadership_role
+    description: >
+      Cargos de liderança exercidos por legisladores federais dos Estados
+      Unidos (por exemplo, Speaker, Majority Leader). Uma linha por
+      legislador-cargo-período.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_bioguide, title, role_start, role_end]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: id_bioguide
+        description: Identificador Bioguide do legislador.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('us_congress_legislators__legislator')
+              field: id_bioguide
+      - name: title
+        description: Nome do cargo de liderança.
+      - name: chamber
+        description: Câmara em que o cargo foi exercido (house ou senate).
+      - name: role_start
+        description: Data de início do exercício do cargo.
+      - name: role_end
+        description: Data de término do exercício do cargo.
+  - name: us_congress_legislators__committee
+    description: >
+      Comissões e subcomissões do Congresso dos Estados Unidos, atuais e
+      históricas. Uma linha por comissão, identificada pelo código THOMAS
+      completo (código da comissão-mãe concatenado ao da subcomissão).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_committee]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - id_committee_parent
+            - house_committee_id
+            - senate_committee_id
+            - jurisdiction
+            - url
+            - address
+            - phone
+            - wikipedia
+    columns:
+      - name: id_committee
+        description: >
+          Código THOMAS completo da comissão. Para subcomissões, corresponde ao
+          código da comissão-mãe concatenado ao código da subcomissão. Chave
+          primária.
+        tests: [not_null]
+      - name: id_committee_parent
+        description: Código THOMAS da comissão-mãe (nulo para comissões de nível superior).
+      - name: thomas_id
+        description: Código THOMAS próprio da comissão ou subcomissão.
+      - name: name
+        description: Nome oficial atual ou mais recente da comissão.
+      - name: committee_type
+        description: Câmara à qual a comissão pertence (house, senate ou joint).
+      - name: is_subcommittee
+        description: Indica se o registro corresponde a uma subcomissão.
+      - name: is_current
+        description: Indica se a comissão está atualmente ativa.
+      - name: house_committee_id
+        description: Código de duas letras da comissão na Câmara.
+      - name: senate_committee_id
+        description: Código da comissão no Senado.
+      - name: jurisdiction
+        description: Descrição da jurisdição da comissão.
+      - name: url
+        description: URL do site oficial da comissão.
+      - name: address
+        description: Endereço postal da comissão.
+      - name: phone
+        description: Telefone da comissão.
+      - name: wikipedia
+        description: Título da página da comissão na Wikipédia.
+  - name: us_congress_legislators__committee_membership
+    description: >
+      Composição atual das comissões e subcomissões do Congresso dos Estados
+      Unidos. Uma linha por par comissão-legislador.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_committee, id_bioguide]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values: [title, chamber]
+    columns:
+      - name: id_committee
+        description: Código THOMAS completo da comissão ou subcomissão.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('us_congress_legislators__committee')
+              field: id_committee
+      - name: id_bioguide
+        description: Identificador Bioguide do legislador membro.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('us_congress_legislators__legislator')
+              field: id_bioguide
+      - name: party
+        description: Posição do membro na comissão (majority ou minority).
+      - name: rank
+        description: Ordem aparente de antiguidade do membro dentro do partido na
+          comissão.
+      - name: title
+        description: Cargo do membro na comissão (por exemplo, Chair, Ranking Member).
+      - name: chamber
+        description: Câmara do membro (house ou senate), aplicável apenas a comissões
+          conjuntas.
+  - name: us_congress_legislators__district_office
+    description: >
+      Escritórios distritais de legisladores federais dos Estados Unidos em
+      exercício. Uma linha por escritório, com endereço, contato e
+      geolocalização.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_office]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values: [building, fax, hours]
+    columns:
+      - name: id_office
+        description: Identificador do escritório distrital (formato bioguide-cidade).
+          Chave primária.
+        tests: [not_null]
+      - name: id_bioguide
+        description: Identificador Bioguide do legislador titular do escritório.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('us_congress_legislators__legislator')
+              field: id_bioguide
+      - name: building
+        description: Nome do edifício do escritório.
+      - name: address
+        description: Logradouro do escritório.
+      - name: suite
+        description: Sala ou conjunto do escritório.
+      - name: city
+        description: Cidade do escritório.
+      - name: state
+        description: Código USPS de duas letras do estado ou território do escritório.
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_us__state')
+              field: abbreviation
+      - name: zip_code
+        description: Código postal (ZIP) de cinco dígitos do escritório.
+      - name: phone
+        description: Telefone do escritório.
+      - name: fax
+        description: Fax do escritório.
+      - name: hours
+        description: Horário de funcionamento do escritório (texto livre).
+      - name: latitude
+        description: Latitude geocodificada do escritório.
+      - name: longitude
+        description: Longitude geocodificada do escritório.
+  - name: us_congress_legislators__executive_term
+    description: >
+      Mandatos de presidentes e vice-presidentes dos Estados Unidos, com dados
+      biográficos. Uma linha por mandato (par pessoa-mandato).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_govtrack, term_start]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - id_bioguide
+            - id_icpsr_prez
+            - middle_name
+            - suffix
+            - nickname
+            - full_name
+    columns:
+      - name: id_bioguide
+        description: Identificador Bioguide, presente quando a pessoa também serviu
+          no Congresso.
+      - name: id_icpsr_prez
+        description: Identificador ICPSR da posição presidencial.
+      - name: id_govtrack
+        description: Identificador da pessoa no GovTrack.us.
+        tests: [not_null]
+      - name: first_name
+        description: Primeiro nome.
+      - name: middle_name
+        description: Nome do meio ou inicial.
+      - name: last_name
+        description: Sobrenome.
+      - name: suffix
+        description: Sufixo do nome.
+      - name: nickname
+        description: Apelido ou nome alternativo.
+      - name: full_name
+        description: Nome completo oficial.
+      - name: birthday
+        description: Data de nascimento.
+      - name: gender
+        description: Sexo (M ou F).
+      - name: term_type
+        description: Tipo de mandato (prez para presidente, viceprez para vice-presidente).
+      - name: term_start
+        description: Data de início do mandato.
+        tests: [not_null]
+      - name: term_end
+        description: Data de término do mandato.
+      - name: party
+        description: Partido político durante o mandato.
+      - name: how
+        description: Forma de acesso ao cargo (election, succession ou appointment).

--- a/models/us_congress_legislators/us_congress_legislators__committee.sql
+++ b/models/us_congress_legislators/us_congress_legislators__committee.sql
@@ -1,0 +1,23 @@
+{{
+    config(
+        alias="committee",
+        schema="us_congress_legislators",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_committee as string) id_committee,
+    safe_cast(id_committee_parent as string) id_committee_parent,
+    safe_cast(thomas_id as string) thomas_id,
+    safe_cast(name as string) name,
+    safe_cast(committee_type as string) committee_type,
+    safe_cast(is_subcommittee as bool) is_subcommittee,
+    safe_cast(is_current as bool) is_current,
+    safe_cast(house_committee_id as string) house_committee_id,
+    safe_cast(senate_committee_id as string) senate_committee_id,
+    safe_cast(jurisdiction as string) jurisdiction,
+    safe_cast(url as string) url,
+    safe_cast(address as string) address,
+    safe_cast(phone as string) phone,
+    safe_cast(wikipedia as string) wikipedia
+from {{ set_datalake_project("us_congress_legislators_staging.committee") }} as t

--- a/models/us_congress_legislators/us_congress_legislators__committee_membership.sql
+++ b/models/us_congress_legislators/us_congress_legislators__committee_membership.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        alias="committee_membership",
+        schema="us_congress_legislators",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_committee as string) id_committee,
+    safe_cast(id_bioguide as string) id_bioguide,
+    safe_cast(party as string) party,
+    safe_cast(rank as int64) rank,
+    safe_cast(title as string) title,
+    safe_cast(chamber as string) chamber
+from
+    {{ set_datalake_project("us_congress_legislators_staging.committee_membership") }}
+    as t

--- a/models/us_congress_legislators/us_congress_legislators__district_office.sql
+++ b/models/us_congress_legislators/us_congress_legislators__district_office.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        alias="district_office",
+        schema="us_congress_legislators",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_office as string) id_office,
+    safe_cast(id_bioguide as string) id_bioguide,
+    safe_cast(building as string) building,
+    safe_cast(address as string) address,
+    safe_cast(suite as string) suite,
+    safe_cast(city as string) city,
+    safe_cast(state as string) state,
+    safe_cast(zip_code as string) zip_code,
+    safe_cast(phone as string) phone,
+    safe_cast(fax as string) fax,
+    safe_cast(hours as string) hours,
+    safe_cast(latitude as float64) latitude,
+    safe_cast(longitude as float64) longitude
+from {{ set_datalake_project("us_congress_legislators_staging.district_office") }} as t

--- a/models/us_congress_legislators/us_congress_legislators__executive_term.sql
+++ b/models/us_congress_legislators/us_congress_legislators__executive_term.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        alias="executive_term",
+        schema="us_congress_legislators",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_bioguide as string) id_bioguide,
+    safe_cast(id_icpsr_prez as string) id_icpsr_prez,
+    safe_cast(id_govtrack as string) id_govtrack,
+    safe_cast(first_name as string) first_name,
+    safe_cast(middle_name as string) middle_name,
+    safe_cast(last_name as string) last_name,
+    safe_cast(suffix as string) suffix,
+    safe_cast(nickname as string) nickname,
+    safe_cast(full_name as string) full_name,
+    safe_cast(birthday as date) birthday,
+    safe_cast(gender as string) gender,
+    safe_cast(term_type as string) term_type,
+    safe_cast(term_start as date) term_start,
+    safe_cast(term_end as date) term_end,
+    safe_cast(party as string) party,
+    safe_cast(how as string) how
+from {{ set_datalake_project("us_congress_legislators_staging.executive_term") }} as t

--- a/models/us_congress_legislators/us_congress_legislators__leadership_role.sql
+++ b/models/us_congress_legislators/us_congress_legislators__leadership_role.sql
@@ -1,0 +1,14 @@
+{{
+    config(
+        alias="leadership_role",
+        schema="us_congress_legislators",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_bioguide as string) id_bioguide,
+    safe_cast(title as string) title,
+    safe_cast(chamber as string) chamber,
+    safe_cast(role_start as date) role_start,
+    safe_cast(role_end as date) role_end
+from {{ set_datalake_project("us_congress_legislators_staging.leadership_role") }} as t

--- a/models/us_congress_legislators/us_congress_legislators__legislator.sql
+++ b/models/us_congress_legislators/us_congress_legislators__legislator.sql
@@ -1,0 +1,34 @@
+{{
+    config(
+        alias="legislator",
+        schema="us_congress_legislators",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_bioguide as string) id_bioguide,
+    safe_cast(id_thomas as string) id_thomas,
+    safe_cast(id_lis as string) id_lis,
+    safe_cast(id_govtrack as string) id_govtrack,
+    safe_cast(id_icpsr as string) id_icpsr,
+    safe_cast(id_opensecrets as string) id_opensecrets,
+    safe_cast(id_votesmart as string) id_votesmart,
+    safe_cast(id_fec as string) id_fec,
+    safe_cast(id_cspan as string) id_cspan,
+    safe_cast(id_maplight as string) id_maplight,
+    safe_cast(id_house_history as string) id_house_history,
+    safe_cast(id_pictorial as string) id_pictorial,
+    safe_cast(id_wikidata as string) id_wikidata,
+    safe_cast(id_google_entity as string) id_google_entity,
+    safe_cast(name_wikipedia as string) name_wikipedia,
+    safe_cast(name_ballotpedia as string) name_ballotpedia,
+    safe_cast(first_name as string) first_name,
+    safe_cast(middle_name as string) middle_name,
+    safe_cast(last_name as string) last_name,
+    safe_cast(suffix as string) suffix,
+    safe_cast(nickname as string) nickname,
+    safe_cast(full_name as string) full_name,
+    safe_cast(birthday as date) birthday,
+    safe_cast(gender as string) gender,
+    safe_cast(is_current as bool) is_current
+from {{ set_datalake_project("us_congress_legislators_staging.legislator") }} as t

--- a/models/us_congress_legislators/us_congress_legislators__social_media.sql
+++ b/models/us_congress_legislators/us_congress_legislators__social_media.sql
@@ -1,0 +1,18 @@
+{{
+    config(
+        alias="social_media",
+        schema="us_congress_legislators",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_bioguide as string) id_bioguide,
+    safe_cast(twitter as string) twitter,
+    safe_cast(twitter_id as string) twitter_id,
+    safe_cast(facebook as string) facebook,
+    safe_cast(instagram as string) instagram,
+    safe_cast(instagram_id as string) instagram_id,
+    safe_cast(youtube as string) youtube,
+    safe_cast(youtube_id as string) youtube_id,
+    safe_cast(mastodon as string) mastodon
+from {{ set_datalake_project("us_congress_legislators_staging.social_media") }} as t

--- a/models/us_congress_legislators/us_congress_legislators__term.sql
+++ b/models/us_congress_legislators/us_congress_legislators__term.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        alias="term",
+        schema="us_congress_legislators",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_bioguide as string) id_bioguide,
+    safe_cast(term_type as string) term_type,
+    safe_cast(term_start as date) term_start,
+    safe_cast(term_end as date) term_end,
+    safe_cast(state as string) state,
+    safe_cast(district as int64) district,
+    safe_cast(senate_class as int64) senate_class,
+    safe_cast(state_rank as string) state_rank,
+    safe_cast(party as string) party,
+    safe_cast(caucus as string) caucus,
+    safe_cast(how as string) how,
+    safe_cast(end_type as string) end_type,
+    safe_cast(url as string) url,
+    safe_cast(address as string) address,
+    safe_cast(phone as string) phone,
+    safe_cast(fax as string) fax,
+    safe_cast(contact_form as string) contact_form,
+    safe_cast(office as string) office,
+    safe_cast(rss_url as string) rss_url
+from {{ set_datalake_project("us_congress_legislators_staging.term") }} as t


### PR DESCRIPTION
## us_congress_legislators — US Congress legislators dataset

Onboards `unitedstates/congress-legislators` (CC0) as a standalone dataset: the full biographical, service, committee, social-media, and district-office record of US federal legislators, plus presidents and vice presidents. Follows the merged US directories PR (#1640) and links into it by foreign key.

### Tables (8)
| table | grain | rows | primary key |
|---|---|---|---|
| `legislator` | person | 12,767 | `id_bioguide` |
| `term` | person-term | 45,532 | `id_bioguide`, `term_start` |
| `social_media` | person | 519 | `id_bioguide` |
| `leadership_role` | person-role | 156 | `id_bioguide`, `title`, `role_start`, `role_end` |
| `committee` | committee | 559 | `id_committee` |
| `committee_membership` | committee-person | 3,879 | `id_committee`, `id_bioguide` |
| `district_office` | person-office | 1,312 | `id_office` |
| `executive_term` | person-term | 131 | `id_govtrack`, `term_start` |

English column names; PT/EN/ES descriptions. All IDs zero-padded strings.

### Source
`unitedstates/congress-legislators` (CC0), compiled from official congressional records (Biographical Directory, House/Senate). One raw data source; eight YAML files parsed into the tables above.

### What's included
- Cleaning code: `models/us_congress_legislators/code/clean.py` (YAML → unpartitioned Parquet)
- Upload script: `models/us_congress_legislators/code/upload.py`
- Architecture CSVs (107 columns) under `code/architecture/`
- 8 dbt models + `schema.yml` with uniqueness, not-null, and relationship tests
- `dbt_project.yml` / `.dbtignore` entries

### Foreign keys into the US directory
- `id_bioguide` → `br_bd_diretorios_us.congress_member` (7 tables) — dbt `relationships` tests + backend directory links
- `state` → `br_bd_diretorios_us.state` (`term`, `district_office`) — dbt `relationships` test on `abbreviation`

### Data decisions
- `legislator` merges current + historical (12,767 people); `is_current` flags active members
- `committee` merges current + historical, subcommittees flattened under `id_committee_parent`; `is_current` / `is_subcommittee` flags disambiguate reused THOMAS codes
- `term.state` retains historical USPS codes not present in the modern state directory (relationship test scoped accordingly)
- `executive_term` keyed on `id_govtrack` (bioguide is null for pre-Congress executives)

### Test plan
```
uv run dbt run  --select us_congress_legislators
uv run dbt test --select us_congress_legislators
```
8/8 models pass, 36/36 tests green on dev. Metadata registered in staging and prod.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new U.S. Congress legislators dataset with tables covering legislators, terms, committees, memberships, leadership roles, social media, district offices, and executive terms.
  * Standardized data types and structured records for consistent analysis.
  * Added automated data quality checks, including uniqueness, completeness, and relationship validation.
  * Added data preparation and publishing workflows with row-count validation.
* **Documentation**
  * Added detailed descriptions and schema definitions for all dataset tables and columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->