### PR TITLE
ci: restore check-metadata / test-dev-model PR label checks

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,0 +1,60 @@
+---
+name: pr-checks
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled, opened, synchronize]
+jobs:
+  test-dev-model:
+    name: Test DBT dev model
+    if: contains(github.event.pull_request.labels.*.name, 'test-dev-model')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          files: models/**/*.sql
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Set up Python
+        run: uv python install
+      - name: Install dependencies
+        run: uv sync --locked --only-dev
+      - name: Write DBT service account
+        run: echo '${{ secrets.DBT_SA_DEV }}' | jq '.' > dbt_sa_dev.json
+      - name: Install dbt deps
+        run: uv run dbt deps
+      - name: Run dbt test
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: uv run dbt test --select ${{ steps.changed-files.outputs.all_changed_files }}
+        env:
+          BD_SERVICE_ACCOUNT_DEV: dbt_sa_dev.json
+  check-metadata:
+    name: Metadata validation (BigQuery vs API)
+    if: contains(github.event.pull_request.labels.*.name, 'check-metadata')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Set up Python
+        run: uv python install
+      - name: Install dependencies
+        run: uv sync --locked --only-dev
+      - name: Run metadata validation
+        run: uv run .github/workflows/scripts/check_metadata.py --modified-files "${{ steps.changed-files.outputs.all_modified_files }}"
+        env:
+          BASEDOSDADOS_CONFIG: ${{ secrets.BASEDOSDADOS_CONFIG }}
+          BASEDOSDADOS_CREDENTIALS_PROD: ${{ secrets.BASEDOSDADOS_CREDENTIALS_PROD }}
+          BASEDOSDADOS_CREDENTIALS_STAGING: ${{ secrets.BASEDOSDADOS_CREDENTIALS_STAGING }}


### PR DESCRIPTION
## Problem

Adding the `check-metadata` or `test-dev-model` labels to an open PR triggers **no validation run**. The label-gated validation (`dbt test` + BigQuery-vs-API metadata check) used to live in `cd-staging.yaml` (job `pr-checks`) and `test_dbt_model.yaml`, both deleted in #1593 when the Prefect 0.15 workflows were removed. The replacement Prefect 3 workflows only handle flow *deployment* (`deploy-flow` label), so both labels went inert and `.github/workflows/scripts/check_metadata.py` was left orphaned.

## Fix

New workflow `.github/workflows/pr-checks.yaml` with two independent, label-gated jobs on a real `pull_request` trigger (`types: [labeled, opened, synchronize]`):

- **`test-dev-model`** → `dbt test` on changed `models/**/*.sql`
- **`check-metadata`** → runs the existing `check_metadata.py` against changed models

### Notes
- No `paths:` filter on the trigger: with `types: [labeled]` GitHub applies `paths:` against the PR diff and silently drops the label event when nothing matches. Scope is handled inside the job via `tj-actions/changed-files`.
- `pull_request` (not `pull_request_target`) — repo uses same-repo feature branches, so secrets are available.
- Takes effect once merged to `main` (trigger config is read from the base branch).

## Verification

Ran the `check-metadata` command locally against `br_bd_diretorios_brasil.municipio` (27 columns compared vs the API). `id_municipio` → `OK`; the check correctly flagged 3 real description discrepancies (`centroide`, `id_regiao_metropolitana`, `nome_regiao_metropolitana`), confirming it fails loudly as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated pull request checks for changed data models.
  * Added optional validation of model metadata and SQL changes.
  * Checks can run selectively based on pull request labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->