### PR TITLE
fix(metadata): poll da fonte compara com Table.Update.latest

### DIFF
--- a/pipelines/datasets/br_me_cnpj/flows.py
+++ b/pipelines/datasets/br_me_cnpj/flows.py
@@ -41,3 +41,4 @@ br_me_cnpj__simples = _me_cnpj_flow(table_id="simples", cron="0 8 * * *")
 br_me_cnpj__estabelecimentos = _me_cnpj_flow(
     table_id="estabelecimentos", cron="0 9 * * *"
 )
+# temp: trigger deploy-flow CI to redeploy to basedosdados-dev (revert before merge)

--- a/pipelines/datasets/br_me_cnpj/flows.py
+++ b/pipelines/datasets/br_me_cnpj/flows.py
@@ -41,4 +41,3 @@ br_me_cnpj__simples = _me_cnpj_flow(table_id="simples", cron="0 8 * * *")
 br_me_cnpj__estabelecimentos = _me_cnpj_flow(
     table_id="estabelecimentos", cron="0 9 * * *"
 )
-# temp: trigger deploy-flow CI to redeploy to basedosdados-dev (revert before merge)

--- a/pipelines/utils/metadata/register.py
+++ b/pipelines/utils/metadata/register.py
@@ -58,7 +58,7 @@ def register_source_poll(
     """'Olhei a fonte original hoje' — versão eager (detecta e grava de uma vez).
 
     Compõe `poll_source_for_update` (registra o `RawDataSource.Poll` de hoje e
-    detecta se a fonte tem dados mais novos que o `RawDataSource.Update.latest`
+    detecta se a fonte tem dados mais novos que o `Table.Update.latest`
     atual) com `commit_source_update` (grava esse Update). Se há novidade, grava
     o Update e devolve True; caso contrário, devolve False sem gravar.
     `source_max_date=None` é a forma explícita de "só polei, sem novidade".
@@ -273,7 +273,7 @@ def poll_source_for_update(
     """Detecta se a fonte original tem novidade, sem gravar o Update.
 
     Sempre registra um ``RawDataSource.Poll`` (data de hoje) e devolve se a
-    fonte traz dados mais novos que o ``RawDataSource.Update.latest`` atual.
+    fonte traz dados mais novos que o ``Table.Update.latest`` atual.
     Ao contrário de :func:`register_source_poll`, **não grava** o Update — essa
     escrita fica a cargo de :func:`commit_source_update`, chamada só após a
     materialização. Assim, se o flow falha no meio, o Update não avança e a run
@@ -294,8 +294,8 @@ def poll_source_for_update(
     Returns
     -------
     bool
-        ``True`` se a fonte tem dados mais novos que o último Update
-        registrado; ``False`` caso contrário.
+        ``True`` se a fonte tem dados mais novos que o ``Table.Update.latest``
+        atual; ``False`` caso contrário.
 
     See Also
     --------

--- a/pipelines/utils/metadata/register.py
+++ b/pipelines/utils/metadata/register.py
@@ -310,7 +310,7 @@ def poll_source_for_update(
     if source_max_date is None:
         return False
 
-    api_latest = client.get_raw_source_update_latest(dataset_id, table_id)
+    api_latest = client.get_table_update_latest(dataset_id, table_id)
     if not policy.should_update_raw_source(api_latest, source_max_date):
         log("Não há novas atualizações na fonte original")
         return False

--- a/pipelines/utils/metadata/tasks.py
+++ b/pipelines/utils/metadata/tasks.py
@@ -119,8 +119,8 @@ def register_source_poll_task(
     """Registra que a fonte original foi consultada hoje ("poll por data").
 
     Sempre grava um `Poll` na fonte (data de hoje). Se `source_max_date` indica
-    dados mais novos do que o último `Update` registrado, grava também esse
-    Update e devolve True; caso contrário devolve False.
+    dados mais novos do que o `Table.Update.latest` atual, grava também esse
+    `RawDataSource.Update` e devolve True; caso contrário devolve False.
 
     Use esta task quando a fonte EXPÕE uma data máxima (a maioria dos casos).
     Para fontes que só permitem detectar mudança por tamanho de arquivo, use
@@ -270,7 +270,7 @@ def poll_source_for_update_task(
     """Detecta se a fonte original tem novidade hoje, sem gravar o Update.
 
     Sempre grava um `Poll` na fonte (data de hoje) e devolve se `source_max_date`
-    indica dados mais novos do que o último `Update` registrado — mas, ao
+    indica dados mais novos do que o `Table.Update.latest` atual — mas, ao
     contrário de `register_source_poll_task`, **não grava** o Update. A gravação
     fica a cargo de `commit_source_update_task`, chamada ao fim do flow, após a
     materialização. Use as duas em par quando a gravação do Update precisa ser

--- a/pipelines/utils/tests/metadata/test_register.py
+++ b/pipelines/utils/tests/metadata/test_register.py
@@ -53,9 +53,7 @@ def test_poll_without_news_writes_only_poll():
 
 
 def test_poll_with_news_writes_poll_then_update():
-    client = FakeMetadataClient(
-        raw_source_update_latest=datetime.date(2026, 1, 1)
-    )
+    client = FakeMetadataClient(table_update_latest=datetime.date(2026, 1, 1))
     result = register_source_poll(
         client, "br_x", "tab", source_max_date=datetime.date(2026, 6, 1)
     )
@@ -67,9 +65,7 @@ def test_poll_with_news_writes_poll_then_update():
 
 
 def test_poll_with_stale_source_writes_only_poll():
-    client = FakeMetadataClient(
-        raw_source_update_latest=datetime.date(2026, 6, 1)
-    )
+    client = FakeMetadataClient(table_update_latest=datetime.date(2026, 6, 1))
     result = register_source_poll(
         client, "br_x", "tab", source_max_date=datetime.date(2026, 1, 1)
     )

--- a/pipelines/utils/tests/metadata/test_register_tasks.py
+++ b/pipelines/utils/tests/metadata/test_register_tasks.py
@@ -57,9 +57,7 @@ class TestCoerceToDate:
 
 def test_source_poll_task_coerces_string_source_date():
     """O caminho exato do flow br_bcb_agencia: string '%Y-%m' + delega."""
-    fake = FakeMetadataClient(
-        raw_source_update_latest=datetime.date(2026, 1, 1)
-    )
+    fake = FakeMetadataClient(table_update_latest=datetime.date(2026, 1, 1))
     with patch(
         "pipelines.utils.metadata.tasks.MetadataClient", return_value=fake
     ):
@@ -75,9 +73,7 @@ def test_source_poll_task_coerces_string_source_date():
 
 
 def test_source_poll_task_builds_client_with_env_and_delegates():
-    fake = FakeMetadataClient(
-        raw_source_update_latest=datetime.date(2026, 1, 1)
-    )
+    fake = FakeMetadataClient(table_update_latest=datetime.date(2026, 1, 1))
     with patch(
         "pipelines.utils.metadata.tasks.MetadataClient", return_value=fake
     ) as mk:
@@ -100,9 +96,7 @@ def test_poll_source_for_update_task_writes_poll_only_not_update():
     flow. Se alguém recolar o `upsert_raw_source_update` aqui dentro, este teste
     quebra.
     """
-    fake = FakeMetadataClient(
-        raw_source_update_latest=datetime.date(2026, 1, 1)
-    )
+    fake = FakeMetadataClient(table_update_latest=datetime.date(2026, 1, 1))
     with patch(
         "pipelines.utils.metadata.tasks.MetadataClient", return_value=fake
     ):


### PR DESCRIPTION
## O que muda

`poll_source_for_update` (em `pipelines/utils/metadata/register.py`) passa a comparar a data máxima observada na fonte original com o `Update.latest` da própria **Table** (`get_table_update_latest`) em vez do `Update.latest` do **RawDataSource** (`get_raw_source_update_latest`).

Esse passa a ser o metadado **padrão** que dispara a atualização dos flows: uma run só é considerada "há novidade" quando a fonte traz dados mais recentes que a **última materialização da tabela** — e não que o último registro do RawDataSource.

## Por quê

Alinhar o gatilho de atualização ao estado real da tabela no destino, evitando divergências entre o `Update.latest` do RawDataSource e o da Table.

## Testes

- Ajustados os testes de poll (`test_register.py`, `test_register_tasks.py`) para semear `table_update_latest` em vez de `raw_source_update_latest`.
- `uv run pytest pipelines/utils/tests/metadata/test_register.py pipelines/utils/tests/metadata/test_register_tasks.py` → 32 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source update detection by checking the table’s latest update information.
  * Ensured polling decisions correctly identify whether newer data is available.

* **Tests**
  * Updated coverage for current table update tracking, date handling, client configuration, and poll record behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->