### PR TITLE
docs(metadata): poll docstrings refletem Table.Update.latest

### DIFF
--- a/pipelines/utils/metadata/register.py
+++ b/pipelines/utils/metadata/register.py
@@ -58,7 +58,7 @@ def register_source_poll(
     """'Olhei a fonte original hoje' — versão eager (detecta e grava de uma vez).
 
     Compõe `poll_source_for_update` (registra o `RawDataSource.Poll` de hoje e
-    detecta se a fonte tem dados mais novos que o `RawDataSource.Update.latest`
+    detecta se a fonte tem dados mais novos que o `Table.Update.latest`
     atual) com `commit_source_update` (grava esse Update). Se há novidade, grava
     o Update e devolve True; caso contrário, devolve False sem gravar.
     `source_max_date=None` é a forma explícita de "só polei, sem novidade".
@@ -273,7 +273,7 @@ def poll_source_for_update(
     """Detecta se a fonte original tem novidade, sem gravar o Update.
 
     Sempre registra um ``RawDataSource.Poll`` (data de hoje) e devolve se a
-    fonte traz dados mais novos que o ``RawDataSource.Update.latest`` atual.
+    fonte traz dados mais novos que o ``Table.Update.latest`` atual.
     Ao contrário de :func:`register_source_poll`, **não grava** o Update — essa
     escrita fica a cargo de :func:`commit_source_update`, chamada só após a
     materialização. Assim, se o flow falha no meio, o Update não avança e a run
@@ -294,8 +294,8 @@ def poll_source_for_update(
     Returns
     -------
     bool
-        ``True`` se a fonte tem dados mais novos que o último Update
-        registrado; ``False`` caso contrário.
+        ``True`` se a fonte tem dados mais novos que o ``Table.Update.latest``
+        atual; ``False`` caso contrário.
 
     See Also
     --------

--- a/pipelines/utils/metadata/tasks.py
+++ b/pipelines/utils/metadata/tasks.py
@@ -119,8 +119,8 @@ def register_source_poll_task(
     """Registra que a fonte original foi consultada hoje ("poll por data").
 
     Sempre grava um `Poll` na fonte (data de hoje). Se `source_max_date` indica
-    dados mais novos do que o último `Update` registrado, grava também esse
-    Update e devolve True; caso contrário devolve False.
+    dados mais novos do que o `Table.Update.latest` atual, grava também esse
+    `RawDataSource.Update` e devolve True; caso contrário devolve False.
 
     Use esta task quando a fonte EXPÕE uma data máxima (a maioria dos casos).
     Para fontes que só permitem detectar mudança por tamanho de arquivo, use
@@ -270,7 +270,7 @@ def poll_source_for_update_task(
     """Detecta se a fonte original tem novidade hoje, sem gravar o Update.
 
     Sempre grava um `Poll` na fonte (data de hoje) e devolve se `source_max_date`
-    indica dados mais novos do que o último `Update` registrado — mas, ao
+    indica dados mais novos do que o `Table.Update.latest` atual — mas, ao
     contrário de `register_source_poll_task`, **não grava** o Update. A gravação
     fica a cargo de `commit_source_update_task`, chamada ao fim do flow, após a
     materialização. Use as duas em par quando a gravação do Update precisa ser


### PR DESCRIPTION
## O quê

O commit `6078d0f8` mudou o poll da fonte para comparar a data da fonte com `Table.Update.latest` (via `client.get_table_update_latest`), mas os docstrings ainda descreviam a comparação contra `RawDataSource.Update.latest`.

Este PR alinha a documentação ao contrato real de polling:

- `register_source_poll` / `poll_source_for_update` (register.py)
- `register_source_poll_task` / `poll_source_for_update_task` (tasks.py)

A comparação de detecção agora aponta para `Table.Update.latest`. O alvo de **gravação** continua sendo `RawDataSource.Update` (`commit_source_update`), então esses docstrings ficam intactos.

## Escopo

Apenas docstrings — nenhuma mudança de comportamento.