### PR TITLE
fix(br_rf_cno): documenta coluna nome_pais em microdados

### DIFF
--- a/models/br_rf_cno/schema.yml
+++ b/models/br_rf_cno/schema.yml
@@ -173,6 +173,8 @@ models:
                 where: __most_recent_date_cno__
       - name: id_pais
         description: ID País
+      - name: nome_pais
+        description: Nome do país
       - name: sigla_uf
         description: Sigla da Unidade da Federação
         tests:


### PR DESCRIPTION
Documenta no `schema.yml` a coluna `nome_pais` de `br_rf_cno.microdados` — existe na tabela mas não estava no schema nem registrada no catálogo. Parte da dívida de metadados exposta pelo check-metadata no #1661.

O registro no backend e a materialização (persist_docs) são passos posteriores; ver issue.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the country name field to the microdata model, displayed alongside the country identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->