### PR TITLE
feat(us_bls_cpi): onboard US Consumer Price Index (BLS)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -97,6 +97,9 @@ models:
     us_bls_atus:
       +materialized: table
       +schema: us_bls_atus
+    us_bls_cpi:
+      +materialized: table
+      +schema: us_bls_cpi
     us_congress_legislators:
       +materialized: table
       +schema: us_congress_legislators

--- a/models/us_bls_cpi/.gitignore
+++ b/models/us_bls_cpi/.gitignore
@@ -1,0 +1,3 @@
+input/
+output/
+*.parquet

--- a/models/us_bls_cpi/ONBOARDING_PLAN.md
+++ b/models/us_bls_cpi/ONBOARDING_PLAN.md
@@ -1,0 +1,137 @@
+# us_bls_cpi — Onboarding Plan
+
+US Consumer Price Index (CPI), U.S. Bureau of Labor Statistics.
+
+## Source
+
+- Landing page: https://www.bls.gov/cpi/data.htm
+- Flat files (authoritative, machine-readable, monthly refresh):
+  - CPI-U: https://download.bls.gov/pub/time.series/cu/
+  - CPI-W: https://download.bls.gov/pub/time.series/cw/
+- Format: BLS `time.series` tab-delimited flat files.
+- Access note: `download.bls.gov` returns **403 without a browser User-Agent**. All
+  fetches must send a UA string that includes a contact email (BLS policy), e.g.
+  `Mozilla/5.0 ... rdahis@basedosdados.org`.
+- License: US federal government work → **public domain** (US Government Work).
+
+### File anatomy (per survey directory)
+
+| File | Role |
+|------|------|
+| `<s>.series` | series_id, area_code, item_code, seasonal, periodicity_code, base_code, base_period, series_title, begin/end year+period |
+| `<s>.data.N.*` | series_id, year, period, value, footnote_codes (the observations) |
+| `<s>.area` | area_code → area_name (+ display_level, sort_sequence) |
+| `<s>.item` | item_code → item_name (+ display_level, sort_sequence) |
+| `<s>.period` | M01–M12 (months), M13 (annual avg), S01–S03 (semiannual) |
+| `<s>.seasonal` | S = Seasonally Adjusted, U = Not Seasonally Adjusted |
+| `<s>.base` / `<s>.periodicity` | base + periodicity code lookups |
+
+`series_id` = `CU`/`CW` + seasonal(`S`/`U`) + periodicity(`R`/`S`) + area(4) + item(rest),
+e.g. `CUUR0000SA0` = CPI-U, not-seasonally-adjusted, monthly, US city average, All items.
+Cleaning resolves dimensions by **joining data → `.series`** (authoritative), not by
+string-splitting the id.
+
+Coverage: monthly from **1947**; CPI-W similar. ~8,100 CPI-U series, ~2,000 CPI-W series.
+
+## Scope decisions (approved by user, 2026-07-16)
+
+1. **Surveys:** CPI-U (`cu`) + CPI-W (`cw`). Distinguished by a `survey` column.
+2. **Derived rates:** store the published `index_value` **and** compute
+   `monthly_change` and `twelve_month_change` per series (matches `br_ibge_ipca`).
+3. **Frequencies → separate tables:** monthly, annual (M13), semiannual (S01/S02).
+4. **Language:** English table slugs and column names (US dataset; consistent with
+   `us_bls_atus`, `us_ed_ipeds`). Partition on `year` (INT64), not `ano`.
+
+## Tables
+
+All partitioned by `year` (INT64). `area_id`, `item_id`, `survey`,
+`seasonal_adjustment` are STRING codes covered by the `dicionario` table.
+`index_value` is FLOAT64 (index number); base differs by series, carried in
+`base_period`. Change columns are FLOAT64 percentages (derived).
+
+### 1. `monthly` — period M01–M12
+Key: `(year, month, survey, seasonal_adjustment, area_id, item_id)`
+
+| column | type | notes |
+|--------|------|-------|
+| year | INT64 | partition |
+| month | INT64 | 1–12 |
+| survey | STRING | CPI-U / CPI-W (dict) |
+| seasonal_adjustment | STRING | S / U (dict) |
+| area_id | STRING | cu/cw area code (dict) |
+| item_id | STRING | cu/cw item code (dict) |
+| base_period | STRING | e.g. `1982-84=100` |
+| index_value | FLOAT64 | CPI index |
+| monthly_change | FLOAT64 | % vs previous month (derived) |
+| twelve_month_change | FLOAT64 | % vs same month prior year (derived) |
+
+### 2. `annual` — period M13 (annual average)
+Key: `(year, survey, seasonal_adjustment, area_id, item_id)`
+Columns as monthly minus `month`/`monthly_change`/`twelve_month_change`, plus
+`annual_change` FLOAT64 (% vs prior year annual average).
+Note: `M13` only (annual average of monthly series). `S03` (annual average of
+semiannual series) is excluded — it collides on the natural key with `M13` where
+an area has both a monthly and semiannual series, and equals the mean of the two
+halves already in the `semiannual` table.
+
+### 3. `semiannual` — period S01/S02
+Key: `(year, half, survey, seasonal_adjustment, area_id, item_id)`
+Adds `half` INT64 (1/2); `index_value` + `semiannual_change` FLOAT64.
+
+### 4. `dicionario` — standard BD dictionary
+Value→label maps for `survey`, `seasonal_adjustment`, `area_id`, `item_id`
+(union of CPI-U and CPI-W dimension files, deduplicated). Uses the platform-standard
+`dicionario` schema (columns `id_tabela`, `nome_coluna`, `chave`,
+`cobertura_temporal`, `valor`) so the website's `covered_by_dictionary` linkage
+renders — matching `us_bls_atus`.
+
+### Deferred (noted, not in MVP)
+- Item/area **hierarchy** (`display_level`, `sort_sequence`) — enables the CPI tree
+  (All items → Food → Food at home → …). Candidate future column or reference table.
+- Mapping CPI `area_id` to a US geography directory once `br_bd_diretorios_us` covers
+  CPI regions/metros.
+- C-CPI-U (`su`) survey.
+
+## Step sequence (per .claude/rules/onboarding-workflow.md)
+
+1. context — done inline (this doc)
+2. architecture — build 4 Google Sheets (one per table) on Drive
+3. download — pull cu.* and cw.* flat files → input/ (UA required)
+4. clean — Python: join data↔series↔period, split by frequency, compute changes →
+   partitioned parquet
+5. upload — parquet → BigQuery dev (`basedosdados-dev.us_bls_cpi_staging`)
+6. dbt — 4 models + schema.yml
+7. validate — dbt tests + spot-check against published headline CPI numbers
+8. discover — resolve backend reference IDs (dev)
+9. metadata — register in dev backend
+   **[PAUSE — verification checkpoint, await "approved"]**
+10. metadata --env prod
+11. pr — open PR with changelog
+
+## Cleaning validation (2026-07-16)
+
+| Table | Rows | Dup keys | Years | Null index |
+|-------|------|----------|-------|------------|
+| monthly | 2,638,757 | 0 | 1913–2026 | 0.15% (BLS `-` markers) |
+| annual | 229,016 | 0 | 1913–2025 | 0.00% |
+| semiannual | 392,891 | 0 | 1984–2026 | 0.00% |
+| dicionario | 1,386 | — | — | — |
+
+Spot-checks against published CPI-U All items, US city average, NSA
+(`CUUR0000SA0`, base 1982-84=100): 2024 annual average 313.689 / +2.95%;
+2022-06 index 296.311 / +9.06% (peak); 2020-12 +1.36%. All match BLS.
+Duplicate raw observations (~706k across both surveys; series cross-listed in
+multiple by-group data files, identical values) are deduplicated on
+`(series_id, year, period)`.
+
+## Monthly update (Prefect) — future
+
+Design cleaning idempotent and re-runnable so a Prefect flow can: re-fetch `cu`/`cw`
+flat files monthly, rebuild parquet, re-upload with `if_exists="replace"`, rerun dbt.
+Not built in this pass; noted for a follow-up.
+
+## Meta-goal
+
+First onboarding driven with Claude. Capture friction and lessons into
+`.claude/agents/*` and `.claude/skills/*` as we go (e.g. BLS UA requirement,
+English-naming rule for non-BR datasets, join-on-.series pattern).

--- a/models/us_bls_cpi/code/architecture/annual.csv
+++ b/models/us_bls_cpi/code/architecture/annual.csv
@@ -1,0 +1,9 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the index observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,year
+survey,STRING,CPI survey population: CPI-U for all urban consumers or CPI-W for urban wage earners and clerical workers,,yes,,,no,Derived from the series_id prefix (CU or CW),series_id
+seasonal_adjustment,STRING,Whether the series is seasonally adjusted (S) or not seasonally adjusted (U),,yes,,,no,,seasonal
+area_id,STRING,BLS CPI area code identifying the geographic coverage of the series,,yes,,,no,"Codes are CPI-specific (national, regions, size classes, metros); could map to a US geography directory in the future",area_code
+item_id,STRING,BLS CPI item code identifying the expenditure category of the series,,yes,,,no,Codes follow the CPI item hierarchy (item.display_level not yet loaded),item_code
+base_period,STRING,"Index reference base period at which the index equals 100, which varies by series",,no,,,no,,base_period
+index_value,FLOAT64,"Annual average Consumer Price Index level for the item, area, and period, relative to the base period",,no,,index,no,,value
+annual_change,FLOAT64,Percent change in the annual average index relative to the previous year,,no,,percent,no,Computed by Data Basis from the index series; not published by BLS,value

--- a/models/us_bls_cpi/code/architecture/dicionario.csv
+++ b/models/us_bls_cpi/code/architecture/dicionario.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_tabela,STRING,Slug of the us_bls_cpi table the dictionary entry describes,,no,,,no,,id_tabela
+nome_coluna,STRING,Name of the column the dictionary entry describes,,no,,,no,,nome_coluna
+chave,STRING,Coded value (key) exactly as stored in the data,,no,,,no,,chave
+cobertura_temporal,STRING,Temporal coverage of the key,,no,,,no,,cobertura_temporal
+valor,STRING,Human-readable label corresponding to the coded value,,no,,,no,,valor

--- a/models/us_bls_cpi/code/architecture/monthly.csv
+++ b/models/us_bls_cpi/code/architecture/monthly.csv
@@ -1,0 +1,11 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the index observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,year
+month,INT64,"Reference month of the index observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,Derived from the BLS period code M01-M12,period
+survey,STRING,CPI survey population: CPI-U for all urban consumers or CPI-W for urban wage earners and clerical workers,,yes,,,no,Derived from the series_id prefix (CU or CW),series_id
+seasonal_adjustment,STRING,Whether the series is seasonally adjusted (S) or not seasonally adjusted (U),,yes,,,no,,seasonal
+area_id,STRING,BLS CPI area code identifying the geographic coverage of the series,,yes,,,no,"Codes are CPI-specific (national, regions, size classes, metros); could map to a US geography directory in the future",area_code
+item_id,STRING,BLS CPI item code identifying the expenditure category of the series,,yes,,,no,Codes follow the CPI item hierarchy (item.display_level not yet loaded),item_code
+base_period,STRING,"Index reference base period at which the index equals 100, which varies by series",,no,,,no,,base_period
+index_value,FLOAT64,"Monthly Consumer Price Index level for the item, area, and period, relative to the base period",,no,,index,no,,value
+monthly_change,FLOAT64,Percent change in the index relative to the previous month,,no,,percent,no,Computed by Data Basis from the index series; not published by BLS,value
+twelve_month_change,FLOAT64,Percent change in the index relative to the same month of the previous year,,no,,percent,no,Computed by Data Basis from the index series; not published by BLS,value

--- a/models/us_bls_cpi/code/architecture/semiannual.csv
+++ b/models/us_bls_cpi/code/architecture/semiannual.csv
@@ -1,0 +1,10 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the index observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,year
+half,INT64,"Half of the year for semiannual series, 1 for the first half and 2 for the second half",,no,,,no,Derived from the BLS period code S01-S02,period
+survey,STRING,CPI survey population: CPI-U for all urban consumers or CPI-W for urban wage earners and clerical workers,,yes,,,no,Derived from the series_id prefix (CU or CW),series_id
+seasonal_adjustment,STRING,Whether the series is seasonally adjusted (S) or not seasonally adjusted (U),,yes,,,no,,seasonal
+area_id,STRING,BLS CPI area code identifying the geographic coverage of the series,,yes,,,no,"Codes are CPI-specific (national, regions, size classes, metros); could map to a US geography directory in the future",area_code
+item_id,STRING,BLS CPI item code identifying the expenditure category of the series,,yes,,,no,Codes follow the CPI item hierarchy (item.display_level not yet loaded),item_code
+base_period,STRING,"Index reference base period at which the index equals 100, which varies by series",,no,,,no,,base_period
+index_value,FLOAT64,"Semiannual Consumer Price Index level for the item, area, and period, relative to the base period",,no,,index,no,,value
+semiannual_change,FLOAT64,Percent change in the index relative to the previous half-year period,,no,,percent,no,Computed by Data Basis from the index series; not published by BLS,value

--- a/models/us_bls_cpi/code/build_architecture.py
+++ b/models/us_bls_cpi/code/build_architecture.py
@@ -1,0 +1,233 @@
+"""Generate architecture CSVs for us_bls_cpi.
+
+One CSV per table (monthly, annual, semiannual) plus the standard `dicionario`.
+Header follows the Data Basis architecture schema (see .claude/rules/data-basis-style.md).
+Column descriptions are English (US dataset), first letter capitalized, no trailing period.
+"""
+
+import csv
+from pathlib import Path
+
+HEADER = [
+    "name",
+    "bigquery_type",
+    "description",
+    "temporal_coverage",
+    "covered_by_dictionary",
+    "directory_column",
+    "measurement_unit",
+    "has_sensitive_data",
+    "observations",
+    "original_name",
+]
+
+# Reusable column definitions (name -> row without the name)
+YEAR = [
+    "INT64",
+    "Reference year of the index observation",
+    "",
+    "no",
+    "br_bd_diretorios_data_tempo.ano:ano",
+    "year",
+    "no",
+    "Partition column",
+    "year",
+]
+MONTH = [
+    "INT64",
+    "Reference month of the index observation, from 1 to 12",
+    "",
+    "no",
+    "br_bd_diretorios_data_tempo.mes:mes",
+    "month",
+    "no",
+    "Derived from the BLS period code M01-M12",
+    "period",
+]
+SURVEY = [
+    "STRING",
+    "CPI survey population: CPI-U for all urban consumers or CPI-W for urban wage earners and clerical workers",
+    "",
+    "yes",
+    "",
+    "",
+    "no",
+    "Derived from the series_id prefix (CU or CW)",
+    "series_id",
+]
+SEASONAL = [
+    "STRING",
+    "Whether the series is seasonally adjusted (S) or not seasonally adjusted (U)",
+    "",
+    "yes",
+    "",
+    "",
+    "no",
+    "",
+    "seasonal",
+]
+AREA = [
+    "STRING",
+    "BLS CPI area code identifying the geographic coverage of the series",
+    "",
+    "yes",
+    "",
+    "",
+    "no",
+    "Codes are CPI-specific (national, regions, size classes, metros); could map to a US geography directory in the future",
+    "area_code",
+]
+ITEM = [
+    "STRING",
+    "BLS CPI item code identifying the expenditure category of the series",
+    "",
+    "yes",
+    "",
+    "",
+    "no",
+    "Codes follow the CPI item hierarchy (item.display_level not yet loaded)",
+    "item_code",
+]
+BASE = [
+    "STRING",
+    "Index reference base period at which the index equals 100, which varies by series",
+    "",
+    "no",
+    "",
+    "",
+    "no",
+    "",
+    "base_period",
+]
+
+
+def index_value(kind):
+    return [
+        "FLOAT64",
+        f"{kind} Consumer Price Index level for the item, area, and period, relative to the base period",
+        "",
+        "no",
+        "",
+        "index",
+        "no",
+        "",
+        "value",
+    ]
+
+
+def change(desc):
+    return [
+        "FLOAT64",
+        desc,
+        "",
+        "no",
+        "",
+        "percent",
+        "no",
+        "Computed by Data Basis from the index series; not published by BLS",
+        "value",
+    ]
+
+
+TABLES = {
+    "monthly": [
+        ("year", YEAR),
+        ("month", MONTH),
+        ("survey", SURVEY),
+        ("seasonal_adjustment", SEASONAL),
+        ("area_id", AREA),
+        ("item_id", ITEM),
+        ("base_period", BASE),
+        ("index_value", index_value("Monthly")),
+        (
+            "monthly_change",
+            change(
+                "Percent change in the index relative to the previous month"
+            ),
+        ),
+        (
+            "twelve_month_change",
+            change(
+                "Percent change in the index relative to the same month of the previous year"
+            ),
+        ),
+    ],
+    "annual": [
+        ("year", YEAR),
+        ("survey", SURVEY),
+        ("seasonal_adjustment", SEASONAL),
+        ("area_id", AREA),
+        ("item_id", ITEM),
+        ("base_period", BASE),
+        ("index_value", index_value("Annual average")),
+        (
+            "annual_change",
+            change(
+                "Percent change in the annual average index relative to the previous year"
+            ),
+        ),
+    ],
+    "semiannual": [
+        ("year", YEAR),
+        (
+            "half",
+            [
+                "INT64",
+                "Half of the year for semiannual series, 1 for the first half and 2 for the second half",
+                "",
+                "no",
+                "",
+                "",
+                "no",
+                "Derived from the BLS period code S01-S02",
+                "period",
+            ],
+        ),
+        ("survey", SURVEY),
+        ("seasonal_adjustment", SEASONAL),
+        ("area_id", AREA),
+        ("item_id", ITEM),
+        ("base_period", BASE),
+        ("index_value", index_value("Semiannual")),
+        (
+            "semiannual_change",
+            change(
+                "Percent change in the index relative to the previous half-year period"
+            ),
+        ),
+    ],
+}
+
+DICIONARIO = [
+    (
+        "id_tabela",
+        "Slug of the us_bls_cpi table the dictionary entry describes",
+    ),
+    ("nome_coluna", "Name of the column the dictionary entry describes"),
+    ("chave", "Coded value (key) exactly as stored in the data"),
+    ("cobertura_temporal", "Temporal coverage of the key"),
+    ("valor", "Human-readable label corresponding to the coded value"),
+]
+
+
+def main():
+    out = Path(__file__).resolve().parent / "architecture"
+    out.mkdir(parents=True, exist_ok=True)
+    for table, cols in TABLES.items():
+        with open(out / f"{table}.csv", "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(HEADER)
+            for name, rest in cols:
+                w.writerow([name, *rest])
+    with open(out / "dicionario.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(HEADER)
+        for name, desc in DICIONARIO:
+            w.writerow(
+                [name, "STRING", desc, "", "no", "", "", "no", "", name]
+            )
+    print("wrote:", ", ".join(sorted(p.name for p in out.glob("*.csv"))))
+
+
+if __name__ == "__main__":
+    main()

--- a/models/us_bls_cpi/code/build_columns_json.py
+++ b/models/us_bls_cpi/code/build_columns_json.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Emit columns_json payloads for mcp__databasis__bulk_upsert_columns, one per table.
+
+Reads the architecture CSVs (English descriptions + type/dictionary/unit flags)
+and attaches Portuguese and Spanish translations from TRANSLATIONS below, so
+columns can be registered directly (no Google Sheet). Writes
+code/columns_json/<table>.json.
+
+Usage:
+    python models/us_bls_cpi/code/build_columns_json.py
+"""
+
+import csv
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARCH = ROOT / "code" / "architecture"
+OUT = ROOT / "code" / "columns_json"
+
+# name -> (description_pt, description_es). English comes from the architecture CSV.
+TRANSLATIONS = {
+    "year": (
+        "Ano de referência da observação do índice",
+        "Año de referencia de la observación del índice",
+    ),
+    "month": (
+        "Mês de referência da observação do índice, de 1 a 12",
+        "Mes de referencia de la observación del índice, de 1 a 12",
+    ),
+    "half": (
+        "Semestre do ano para séries semestrais, 1 para o primeiro semestre e 2 para o segundo semestre",
+        "Semestre del año para series semestrales, 1 para el primer semestre y 2 para el segundo semestre",
+    ),
+    "survey": (
+        "População da pesquisa do IPC: CPI-U para todos os consumidores urbanos ou CPI-W para assalariados urbanos e trabalhadores administrativos",
+        "Población de la encuesta del IPC: CPI-U para todos los consumidores urbanos o CPI-W para asalariados urbanos y trabajadores administrativos",
+    ),
+    "seasonal_adjustment": (
+        "Indica se a série é ajustada sazonalmente (S) ou não ajustada sazonalmente (U)",
+        "Indica si la serie está ajustada estacionalmente (S) o no ajustada estacionalmente (U)",
+    ),
+    "area_id": (
+        "Código de área do IPC do BLS que identifica a cobertura geográfica da série",
+        "Código de área del IPC del BLS que identifica la cobertura geográfica de la serie",
+    ),
+    "item_id": (
+        "Código de item do IPC do BLS que identifica a categoria de despesa da série",
+        "Código de ítem del IPC del BLS que identifica la categoría de gasto de la serie",
+    ),
+    "base_period": (
+        "Período base de referência do índice no qual o índice é igual a 100, que varia por série",
+        "Período base de referencia del índice en el que el índice es igual a 100, que varía según la serie",
+    ),
+    "index_value:monthly": (
+        "Nível mensal do Índice de Preços ao Consumidor para o item, área e período, relativo ao período base",
+        "Nivel mensual del Índice de Precios al Consumidor para el ítem, área y período, relativo al período base",
+    ),
+    "index_value:annual": (
+        "Nível médio anual do Índice de Preços ao Consumidor para o item, área e ano, relativo ao período base",
+        "Nivel promedio anual del Índice de Precios al Consumidor para el ítem, área y año, relativo al período base",
+    ),
+    "index_value:semiannual": (
+        "Nível semestral do Índice de Preços ao Consumidor para o item, área e semestre, relativo ao período base",
+        "Nivel semestral del Índice de Precios al Consumidor para el ítem, área y semestre, relativo al período base",
+    ),
+    "monthly_change": (
+        "Variação percentual do índice em relação ao mês anterior, calculada pela Data Basis",
+        "Variación porcentual del índice respecto al mes anterior, calculada por Data Basis",
+    ),
+    "twelve_month_change": (
+        "Variação percentual do índice em relação ao mesmo mês do ano anterior, calculada pela Data Basis",
+        "Variación porcentual del índice respecto al mismo mes del año anterior, calculada por Data Basis",
+    ),
+    "annual_change": (
+        "Variação percentual da média anual do índice em relação ao ano anterior, calculada pela Data Basis",
+        "Variación porcentual del promedio anual del índice respecto al año anterior, calculada por Data Basis",
+    ),
+    "semiannual_change": (
+        "Variação percentual do índice em relação ao semestre anterior, calculada pela Data Basis",
+        "Variación porcentual del índice respecto al semestre anterior, calculada por Data Basis",
+    ),
+    "id_tabela": (
+        "Slug da tabela de us_bls_cpi que a entrada do dicionário descreve",
+        "Slug de la tabla de us_bls_cpi que describe la entrada del diccionario",
+    ),
+    "nome_coluna": (
+        "Nome da coluna que a entrada do dicionário descreve",
+        "Nombre de la columna que describe la entrada del diccionario",
+    ),
+    "chave": (
+        "Valor codificado (chave) exatamente como armazenado nos dados",
+        "Valor codificado (clave) exactamente como se almacena en los datos",
+    ),
+    "cobertura_temporal": (
+        "Cobertura temporal da chave",
+        "Cobertura temporal de la clave",
+    ),
+    "valor": (
+        "Rótulo legível correspondente ao valor codificado",
+        "Etiqueta legible correspondiente al valor codificado",
+    ),
+}
+
+
+def tr(name, table):
+    return TRANSLATIONS.get(f"{name}:{table}") or TRANSLATIONS[name]
+
+
+def main():
+    OUT.mkdir(parents=True, exist_ok=True)
+    for csv_path in sorted(ARCH.glob("*.csv")):
+        table = csv_path.stem
+        cols = []
+        with open(csv_path, newline="") as fh:
+            rows = list(csv.DictReader(fh))
+        for r in rows:
+            pt, es = tr(r["name"], table)
+            col = {
+                "name": r["name"],
+                "bigquery_type": r["bigquery_type"],
+                "description_pt": pt,
+                "description_en": r["description"],
+                "description_es": es,
+                "covered_by_dictionary": r["covered_by_dictionary"]
+                .strip()
+                .lower()
+                == "yes",
+                "has_sensitive_data": r["has_sensitive_data"].strip().lower()
+                == "yes",
+            }
+            if r["directory_column"].strip():
+                col["directory_column"] = r["directory_column"].strip()
+            if r["measurement_unit"].strip():
+                col["measurement_unit"] = r["measurement_unit"].strip()
+            cols.append(col)
+        (OUT / f"{table}.json").write_text(
+            json.dumps(cols, ensure_ascii=False, indent=2)
+        )
+        print(
+            f"{table}: {len(cols)} columns -> code/columns_json/{table}.json"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/us_bls_cpi/code/build_dicionario.py
+++ b/models/us_bls_cpi/code/build_dicionario.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Build the us_bls_cpi `dicionario` table from the BLS dimension files.
+
+Emits one row per (id_tabela, nome_coluna, chave, valor) for every coded column
+(survey, seasonal_adjustment, area_id, item_id) across the three data tables.
+Area/item labels are the union of the CPI-U and CPI-W dimension files (CPI-U wins
+on overlap). Writes output/dicionario/data.parquet (flat, not partitioned).
+
+Usage:
+    uv run python models/us_bls_cpi/code/build_dicionario.py
+"""
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+ROOT = Path(__file__).resolve().parents[1]
+INPUT = ROOT / "input"
+OUTPUT = ROOT / "output"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("dicionario")
+
+DATA_TABLES = ["monthly", "annual", "semiannual"]
+SCHEMA = pa.schema(
+    [
+        pa.field("id_tabela", pa.string()),
+        pa.field("nome_coluna", pa.string()),
+        pa.field("chave", pa.string()),
+        pa.field("cobertura_temporal", pa.string()),
+        pa.field("valor", pa.string()),
+    ]
+)
+
+SURVEY = {
+    "CPI-U": "All Urban Consumers",
+    "CPI-W": "Urban Wage Earners and Clerical Workers",
+}
+SEASONAL = {"S": "Seasonally Adjusted", "U": "Not Seasonally Adjusted"}
+
+
+def dim_map(fname, code_col, name_col):
+    """Union CPI-U and CPI-W dimension files; CPI-U label wins on overlap."""
+    out = {}
+    for s in ("cw", "cu"):  # cu last so it overrides cw
+        df = pd.read_csv(
+            INPUT / s / f"{s}.{fname}", sep="\t", dtype=str, na_filter=False
+        )
+        df.columns = [c.strip() for c in df.columns]
+        for _, r in df.iterrows():
+            out[r[code_col].strip()] = r[name_col].strip()
+    return out
+
+
+def main():
+    maps = {
+        "survey": SURVEY,
+        "seasonal_adjustment": SEASONAL,
+        "area_id": dim_map("area", "area_code", "area_name"),
+        "item_id": dim_map("item", "item_code", "item_name"),
+    }
+    rows = []
+    for tbl in DATA_TABLES:
+        for col, mapping in maps.items():
+            for key, label in mapping.items():
+                rows.append((tbl, col, key, None, label))
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "id_tabela",
+            "nome_coluna",
+            "chave",
+            "cobertura_temporal",
+            "valor",
+        ],
+    )
+    pdir = OUTPUT / "dicionario"
+    pdir.mkdir(parents=True, exist_ok=True)
+    pq.write_table(
+        pa.Table.from_pandas(df, schema=SCHEMA, preserve_index=False),
+        pdir / "data.parquet",
+        compression="snappy",
+    )
+    log.info(
+        f"dicionario: {len(df):,} rows "
+        f"({len(maps['area_id'])} areas, {len(maps['item_id'])} items) -> output/dicionario/"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/us_bls_cpi/code/clean_data.py
+++ b/models/us_bls_cpi/code/clean_data.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Clean the BLS CPI-U and CPI-W time.series flat files into hive-partitioned Parquet.
+
+Reads the raw dimension + data files in ../input/{cu,cw}, resolves each series'
+dimensions by joining the observations to <s>.series (authoritative), splits by
+period frequency, computes percent-change columns, and writes
+output/<table>/year=YYYY/data.parquet (snappy, explicit pyarrow schema).
+
+Tables:
+    monthly     period M01-M12  -> month 1-12, monthly_change, twelve_month_change
+    annual      period M13, S03 -> annual average, annual_change
+    semiannual  period S01, S02 -> half 1-2, semiannual_change
+    dicionario  built by build_dicionario.py (not here)
+
+Percent changes are gap-safe (self-merge on a period ordinal, not pct_change) and
+computed within series (survey x seasonal x area x item). BLS does not publish them.
+
+Usage:
+    uv run python models/us_bls_cpi/code/clean_data.py [table ...]
+"""
+
+import csv
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+ROOT = Path(__file__).resolve().parents[1]
+INPUT = ROOT / "input"
+OUTPUT = ROOT / "output"
+ARCH = ROOT / "code" / "architecture"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("clean")
+
+PA = {"STRING": pa.string(), "INT64": pa.int64(), "FLOAT64": pa.float64()}
+SURVEYS = {"cu": "CPI-U", "cw": "CPI-W"}
+KEYS = ["survey", "seasonal_adjustment", "area_id", "item_id"]
+
+
+def read_arch(tbl):
+    with open(ARCH / f"{tbl}.csv", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def load_series(survey_dir: str) -> pd.DataFrame:
+    """<s>.series -> one row per series_id with resolved dimensions."""
+    s = survey_dir
+    df = pd.read_csv(
+        INPUT / s / f"{s}.series",
+        sep="\t",
+        dtype=str,
+        na_filter=False,
+    )
+    df.columns = [c.strip() for c in df.columns]
+    out = pd.DataFrame(
+        {
+            "series_id": df["series_id"].str.strip(),
+            "survey": SURVEYS[s],
+            "seasonal_adjustment": df["seasonal"].str.strip(),
+            "area_id": df["area_code"].str.strip(),
+            "item_id": df["item_code"].str.strip(),
+            "base_period": df["base_period"].str.strip(),
+        }
+    )
+    return out
+
+
+def load_data(survey_dir: str) -> pd.DataFrame:
+    """All <s>.data.1..20 files -> stripped observations. Skips data.0.Current
+    (a recent-only subset already contained in the by-group history files)."""
+    s = survey_dir
+    frames = []
+    for path in sorted((INPUT / s).glob(f"{s}.data.*")):
+        if path.name.endswith(".0.Current"):
+            continue
+        d = pd.read_csv(path, sep="\t", dtype=str, na_filter=False)
+        d.columns = [c.strip() for c in d.columns]
+        frames.append(d[["series_id", "year", "period", "value"]])
+    df = pd.concat(frames, ignore_index=True)
+    df["series_id"] = df["series_id"].str.strip()
+    df["period"] = df["period"].str.strip()
+    df["year"] = pd.to_numeric(df["year"], errors="coerce").astype("int64")
+    # "-" and blanks are BLS missing markers -> NaN
+    df["index_value"] = pd.to_numeric(
+        df["value"].str.strip().replace({"-": ""}).replace({"": None}),
+        errors="coerce",
+    )
+    return df[["series_id", "year", "period", "index_value"]]
+
+
+def build_long() -> pd.DataFrame:
+    series = pd.concat([load_series(s) for s in SURVEYS], ignore_index=True)
+    data = pd.concat([load_data(s) for s in SURVEYS], ignore_index=True)
+    # The by-group data files cross-list ~1,400 series (identical values), so a
+    # given (series_id, year, period) can repeat. Dedup to keep one observation.
+    n0 = len(data)
+    data = data.drop_duplicates(
+        ["series_id", "year", "period"], ignore_index=True
+    )
+    log.info(
+        f"raw observations: {n0:,}; after dedup: {len(data):,}; series: {len(series):,}"
+    )
+    df = data.merge(series, on="series_id", how="left", validate="many_to_one")
+    missing = df["survey"].isna().sum()
+    if missing:
+        log.warning(f"{missing:,} rows had no series metadata (dropped)")
+        df = df[df["survey"].notna()]
+    for c in [*KEYS, "base_period"]:
+        df[c] = df[c].astype("category")
+    return df
+
+
+def add_change(df, ordinal, lag, name):
+    """Percent change vs the observation `lag` ordinal-steps earlier, per series."""
+    prev = df[["_key", ordinal, "index_value"]].copy()
+    prev[ordinal] = prev[ordinal] + lag
+    prev = prev.rename(columns={"index_value": "_prev"})
+    df = df.merge(prev, on=["_key", ordinal], how="left")
+    df[name] = ((df["index_value"] / df["_prev"] - 1.0) * 100).round(4)
+    return df.drop(columns=["_prev"])
+
+
+def build_table(df, tbl):
+    p = df["period"]
+    if tbl == "monthly":
+        sub = df[p.str.startswith("M") & (p != "M13")].copy()
+        sub["month"] = sub["period"].str.slice(1).astype("int64")
+        sub["_key"] = sub[KEYS].astype(str).agg("|".join, axis=1)
+        sub["_t"] = sub["year"] * 12 + (sub["month"] - 1)
+        sub = add_change(sub, "_t", 1, "monthly_change")
+        sub = add_change(sub, "_t", 12, "twelve_month_change")
+    elif tbl == "annual":
+        # M13 = annual average of monthly (R) series. S03 (annual average of
+        # semiannual (S) series) is intentionally excluded: it collides on the
+        # natural key with M13 for areas that have both a monthly and a
+        # semiannual series, and it is just the mean of the two halves already
+        # present in the semiannual table.
+        sub = df[p == "M13"].copy()
+        sub["_key"] = sub[KEYS].astype(str).agg("|".join, axis=1)
+        sub["_t"] = sub["year"]
+        sub = add_change(sub, "_t", 1, "annual_change")
+    elif tbl == "semiannual":
+        sub = df[(p == "S01") | (p == "S02")].copy()
+        sub["half"] = sub["period"].str.slice(2).astype("int64")
+        sub["_key"] = sub[KEYS].astype(str).agg("|".join, axis=1)
+        sub["_t"] = sub["year"] * 2 + (sub["half"] - 1)
+        sub = add_change(sub, "_t", 1, "semiannual_change")
+    else:
+        raise ValueError(tbl)
+    return sub
+
+
+def write_partitioned(sub, tbl):
+    arch = read_arch(tbl)
+    order = [a["name"] for a in arch]
+    schema = pa.schema(
+        [pa.field(a["name"], PA[a["bigquery_type"]]) for a in arch]
+    )
+    for c in [*KEYS, "base_period"]:
+        if c in sub:
+            sub[c] = sub[c].astype("object")
+    out = sub[order]
+    total = 0
+    for year, g in out.groupby("year", sort=True):
+        pdir = OUTPUT / tbl / f"year={int(year)}"
+        pdir.mkdir(parents=True, exist_ok=True)
+        at = pa.Table.from_pandas(g, schema=schema, preserve_index=False)
+        pq.write_table(at, pdir / "data.parquet", compression="snappy")
+        total += len(g)
+    log.info(
+        f"{tbl}: {total:,} rows, {len(order)} cols, {out['year'].nunique()} years -> output/{tbl}/"
+    )
+    return total
+
+
+def main():
+    want = set(sys.argv[1:]) or {"monthly", "annual", "semiannual"}
+    df = build_long()
+    for tbl in ("monthly", "annual", "semiannual"):
+        if tbl in want:
+            write_partitioned(build_table(df, tbl), tbl)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/us_bls_cpi/code/columns_json/annual.json
+++ b/models/us_bls_cpi/code/columns_json/annual.json
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "year",
+    "bigquery_type": "INT64",
+    "description_pt": "Ano de referência da observação do índice",
+    "description_en": "Reference year of the index observation",
+    "description_es": "Año de referencia de la observación del índice",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.ano:ano",
+    "measurement_unit": "year"
+  },
+  {
+    "name": "survey",
+    "bigquery_type": "STRING",
+    "description_pt": "População da pesquisa do IPC: CPI-U para todos os consumidores urbanos ou CPI-W para assalariados urbanos e trabalhadores administrativos",
+    "description_en": "CPI survey population: CPI-U for all urban consumers or CPI-W for urban wage earners and clerical workers",
+    "description_es": "Población de la encuesta del IPC: CPI-U para todos los consumidores urbanos o CPI-W para asalariados urbanos y trabajadores administrativos",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "seasonal_adjustment",
+    "bigquery_type": "STRING",
+    "description_pt": "Indica se a série é ajustada sazonalmente (S) ou não ajustada sazonalmente (U)",
+    "description_en": "Whether the series is seasonally adjusted (S) or not seasonally adjusted (U)",
+    "description_es": "Indica si la serie está ajustada estacionalmente (S) o no ajustada estacionalmente (U)",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "area_id",
+    "bigquery_type": "STRING",
+    "description_pt": "Código de área do IPC do BLS que identifica a cobertura geográfica da série",
+    "description_en": "BLS CPI area code identifying the geographic coverage of the series",
+    "description_es": "Código de área del IPC del BLS que identifica la cobertura geográfica de la serie",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "item_id",
+    "bigquery_type": "STRING",
+    "description_pt": "Código de item do IPC do BLS que identifica a categoria de despesa da série",
+    "description_en": "BLS CPI item code identifying the expenditure category of the series",
+    "description_es": "Código de ítem del IPC del BLS que identifica la categoría de gasto de la serie",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "base_period",
+    "bigquery_type": "STRING",
+    "description_pt": "Período base de referência do índice no qual o índice é igual a 100, que varia por série",
+    "description_en": "Index reference base period at which the index equals 100, which varies by series",
+    "description_es": "Período base de referencia del índice en el que el índice es igual a 100, que varía según la serie",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "index_value",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Nível médio anual do Índice de Preços ao Consumidor para o item, área e ano, relativo ao período base",
+    "description_en": "Annual average Consumer Price Index level for the item, area, and period, relative to the base period",
+    "description_es": "Nivel promedio anual del Índice de Precios al Consumidor para el ítem, área y año, relativo al período base",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "index"
+  },
+  {
+    "name": "annual_change",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Variação percentual da média anual do índice em relação ao ano anterior, calculada pela Data Basis",
+    "description_en": "Percent change in the annual average index relative to the previous year",
+    "description_es": "Variación porcentual del promedio anual del índice respecto al año anterior, calculada por Data Basis",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  }
+]

--- a/models/us_bls_cpi/code/columns_json/dicionario.json
+++ b/models/us_bls_cpi/code/columns_json/dicionario.json
@@ -1,0 +1,47 @@
+[
+  {
+    "name": "id_tabela",
+    "bigquery_type": "STRING",
+    "description_pt": "Slug da tabela de us_bls_cpi que a entrada do dicionário descreve",
+    "description_en": "Slug of the us_bls_cpi table the dictionary entry describes",
+    "description_es": "Slug de la tabla de us_bls_cpi que describe la entrada del diccionario",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "nome_coluna",
+    "bigquery_type": "STRING",
+    "description_pt": "Nome da coluna que a entrada do dicionário descreve",
+    "description_en": "Name of the column the dictionary entry describes",
+    "description_es": "Nombre de la columna que describe la entrada del diccionario",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "chave",
+    "bigquery_type": "STRING",
+    "description_pt": "Valor codificado (chave) exatamente como armazenado nos dados",
+    "description_en": "Coded value (key) exactly as stored in the data",
+    "description_es": "Valor codificado (clave) exactamente como se almacena en los datos",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "cobertura_temporal",
+    "bigquery_type": "STRING",
+    "description_pt": "Cobertura temporal da chave",
+    "description_en": "Temporal coverage of the key",
+    "description_es": "Cobertura temporal de la clave",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "valor",
+    "bigquery_type": "STRING",
+    "description_pt": "Rótulo legível correspondente ao valor codificado",
+    "description_en": "Human-readable label corresponding to the coded value",
+    "description_es": "Etiqueta legible correspondiente al valor codificado",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  }
+]

--- a/models/us_bls_cpi/code/columns_json/monthly.json
+++ b/models/us_bls_cpi/code/columns_json/monthly.json
@@ -1,0 +1,99 @@
+[
+  {
+    "name": "year",
+    "bigquery_type": "INT64",
+    "description_pt": "Ano de referência da observação do índice",
+    "description_en": "Reference year of the index observation",
+    "description_es": "Año de referencia de la observación del índice",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.ano:ano",
+    "measurement_unit": "year"
+  },
+  {
+    "name": "month",
+    "bigquery_type": "INT64",
+    "description_pt": "Mês de referência da observação do índice, de 1 a 12",
+    "description_en": "Reference month of the index observation, from 1 to 12",
+    "description_es": "Mes de referencia de la observación del índice, de 1 a 12",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.mes:mes",
+    "measurement_unit": "month"
+  },
+  {
+    "name": "survey",
+    "bigquery_type": "STRING",
+    "description_pt": "População da pesquisa do IPC: CPI-U para todos os consumidores urbanos ou CPI-W para assalariados urbanos e trabalhadores administrativos",
+    "description_en": "CPI survey population: CPI-U for all urban consumers or CPI-W for urban wage earners and clerical workers",
+    "description_es": "Población de la encuesta del IPC: CPI-U para todos los consumidores urbanos o CPI-W para asalariados urbanos y trabajadores administrativos",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "seasonal_adjustment",
+    "bigquery_type": "STRING",
+    "description_pt": "Indica se a série é ajustada sazonalmente (S) ou não ajustada sazonalmente (U)",
+    "description_en": "Whether the series is seasonally adjusted (S) or not seasonally adjusted (U)",
+    "description_es": "Indica si la serie está ajustada estacionalmente (S) o no ajustada estacionalmente (U)",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "area_id",
+    "bigquery_type": "STRING",
+    "description_pt": "Código de área do IPC do BLS que identifica a cobertura geográfica da série",
+    "description_en": "BLS CPI area code identifying the geographic coverage of the series",
+    "description_es": "Código de área del IPC del BLS que identifica la cobertura geográfica de la serie",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "item_id",
+    "bigquery_type": "STRING",
+    "description_pt": "Código de item do IPC do BLS que identifica a categoria de despesa da série",
+    "description_en": "BLS CPI item code identifying the expenditure category of the series",
+    "description_es": "Código de ítem del IPC del BLS que identifica la categoría de gasto de la serie",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "base_period",
+    "bigquery_type": "STRING",
+    "description_pt": "Período base de referência do índice no qual o índice é igual a 100, que varia por série",
+    "description_en": "Index reference base period at which the index equals 100, which varies by series",
+    "description_es": "Período base de referencia del índice en el que el índice es igual a 100, que varía según la serie",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "index_value",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Nível mensal do Índice de Preços ao Consumidor para o item, área e período, relativo ao período base",
+    "description_en": "Monthly Consumer Price Index level for the item, area, and period, relative to the base period",
+    "description_es": "Nivel mensual del Índice de Precios al Consumidor para el ítem, área y período, relativo al período base",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "index"
+  },
+  {
+    "name": "monthly_change",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Variação percentual do índice em relação ao mês anterior, calculada pela Data Basis",
+    "description_en": "Percent change in the index relative to the previous month",
+    "description_es": "Variación porcentual del índice respecto al mes anterior, calculada por Data Basis",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  },
+  {
+    "name": "twelve_month_change",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Variação percentual do índice em relação ao mesmo mês do ano anterior, calculada pela Data Basis",
+    "description_en": "Percent change in the index relative to the same month of the previous year",
+    "description_es": "Variación porcentual del índice respecto al mismo mes del año anterior, calculada por Data Basis",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  }
+]

--- a/models/us_bls_cpi/code/columns_json/semiannual.json
+++ b/models/us_bls_cpi/code/columns_json/semiannual.json
@@ -1,0 +1,87 @@
+[
+  {
+    "name": "year",
+    "bigquery_type": "INT64",
+    "description_pt": "Ano de referência da observação do índice",
+    "description_en": "Reference year of the index observation",
+    "description_es": "Año de referencia de la observación del índice",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.ano:ano",
+    "measurement_unit": "year"
+  },
+  {
+    "name": "half",
+    "bigquery_type": "INT64",
+    "description_pt": "Semestre do ano para séries semestrais, 1 para o primeiro semestre e 2 para o segundo semestre",
+    "description_en": "Half of the year for semiannual series, 1 for the first half and 2 for the second half",
+    "description_es": "Semestre del año para series semestrales, 1 para el primer semestre y 2 para el segundo semestre",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "survey",
+    "bigquery_type": "STRING",
+    "description_pt": "População da pesquisa do IPC: CPI-U para todos os consumidores urbanos ou CPI-W para assalariados urbanos e trabalhadores administrativos",
+    "description_en": "CPI survey population: CPI-U for all urban consumers or CPI-W for urban wage earners and clerical workers",
+    "description_es": "Población de la encuesta del IPC: CPI-U para todos los consumidores urbanos o CPI-W para asalariados urbanos y trabajadores administrativos",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "seasonal_adjustment",
+    "bigquery_type": "STRING",
+    "description_pt": "Indica se a série é ajustada sazonalmente (S) ou não ajustada sazonalmente (U)",
+    "description_en": "Whether the series is seasonally adjusted (S) or not seasonally adjusted (U)",
+    "description_es": "Indica si la serie está ajustada estacionalmente (S) o no ajustada estacionalmente (U)",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "area_id",
+    "bigquery_type": "STRING",
+    "description_pt": "Código de área do IPC do BLS que identifica a cobertura geográfica da série",
+    "description_en": "BLS CPI area code identifying the geographic coverage of the series",
+    "description_es": "Código de área del IPC del BLS que identifica la cobertura geográfica de la serie",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "item_id",
+    "bigquery_type": "STRING",
+    "description_pt": "Código de item do IPC do BLS que identifica a categoria de despesa da série",
+    "description_en": "BLS CPI item code identifying the expenditure category of the series",
+    "description_es": "Código de ítem del IPC del BLS que identifica la categoría de gasto de la serie",
+    "covered_by_dictionary": true,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "base_period",
+    "bigquery_type": "STRING",
+    "description_pt": "Período base de referência do índice no qual o índice é igual a 100, que varia por série",
+    "description_en": "Index reference base period at which the index equals 100, which varies by series",
+    "description_es": "Período base de referencia del índice en el que el índice es igual a 100, que varía según la serie",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "index_value",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Nível semestral do Índice de Preços ao Consumidor para o item, área e semestre, relativo ao período base",
+    "description_en": "Semiannual Consumer Price Index level for the item, area, and period, relative to the base period",
+    "description_es": "Nivel semestral del Índice de Precios al Consumidor para el ítem, área y semestre, relativo al período base",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "index"
+  },
+  {
+    "name": "semiannual_change",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Variação percentual do índice em relação ao semestre anterior, calculada pela Data Basis",
+    "description_en": "Percent change in the index relative to the previous half-year period",
+    "description_es": "Variación porcentual del índice respecto al semestre anterior, calculada por Data Basis",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  }
+]

--- a/models/us_bls_cpi/code/upload.py
+++ b/models/us_bls_cpi/code/upload.py
@@ -1,0 +1,94 @@
+"""Upload cleaned us_bls_cpi parquet tables to BigQuery dev (basedosdados-dev).
+
+Usage:
+    uv run python models/us_bls_cpi/code/upload.py [table_slug ...]
+
+Uploads sequentially (smallest first). Stops on first failure. Requires
+GOOGLE_APPLICATION_CREDENTIALS to point at the basedosdados-dev service account.
+"""
+
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+import basedosdados as bd  # noqa: E402
+import google.cloud.storage as gcs  # noqa: E402
+from google.cloud import bigquery  # noqa: E402
+
+BILLING_PROJECT = "basedosdados-dev"
+DATASET_ID = "us_bls_cpi"
+OUTPUT_ROOT = Path(__file__).resolve().parent.parent / "output"
+
+# Monkey-patch for requester-pays bucket
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+# (table_slug, expected_rows) — smallest first
+TABLES = [
+    ("dicionario", 1_386),
+    ("annual", 229_016),
+    ("semiannual", 392_891),
+    ("monthly", 2_638_757),
+]
+
+
+def upload_table(slug: str, expected_rows: int) -> int:
+    path = OUTPUT_ROOT / slug
+    if not path.exists():
+        raise FileNotFoundError(f"Missing output path: {path}")
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=slug)
+
+    # Delete stale GCS staging prefix (avoids BQ partition key conflicts)
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=slug)
+    try:
+        st.delete_table(mode="staging", not_found_ok=True)
+    except Exception as e:
+        print(f"  [warn] staging prefix cleanup: {e}")
+
+    tb.create(
+        path=str(path),
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    client = bigquery.Client(project=BILLING_PROJECT)
+    q = f"select count(*) as n from `{BILLING_PROJECT}.{DATASET_ID}_staging.{slug}`"
+    n = next(iter(client.query(q).result())).n
+
+    status = "OK" if n == expected_rows else "ROW MISMATCH"
+    print(
+        f"  {slug}: uploaded {n:,} rows (expected {expected_rows:,}) — {status}"
+    )
+    if n != expected_rows:
+        raise ValueError(
+            f"{slug}: row count {n:,} != expected {expected_rows:,}"
+        )
+    return n
+
+
+def main():
+    only = set(sys.argv[1:])
+    tables = [(s, r) for s, r in TABLES if not only or s in only]
+    for slug, expected in tables:
+        print(f"=== {slug} ===", flush=True)
+        try:
+            upload_table(slug, expected)
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+            sys.exit(1)
+    print("ALL TABLES UPLOADED")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/us_bls_cpi/code/upload.py
+++ b/models/us_bls_cpi/code/upload.py
@@ -1,10 +1,11 @@
-"""Upload cleaned us_bls_cpi parquet tables to BigQuery dev (basedosdados-dev).
+"""Upload cleaned us_bls_cpi parquet tables to BigQuery.
 
 Usage:
-    uv run python models/us_bls_cpi/code/upload.py [table_slug ...]
+    uv run python models/us_bls_cpi/code/upload.py [--env dev|prod] [table_slug ...]
 
-Uploads sequentially (smallest first). Stops on first failure. Requires
-GOOGLE_APPLICATION_CREDENTIALS to point at the basedosdados-dev service account.
+--env dev (default) -> basedosdados-dev; --env prod -> basedosdados. Point
+GOOGLE_APPLICATION_CREDENTIALS at the matching service account. Uploads
+sequentially (smallest first) and stops on first failure.
 """
 
 import sys
@@ -17,7 +18,14 @@ import basedosdados as bd  # noqa: E402
 import google.cloud.storage as gcs  # noqa: E402
 from google.cloud import bigquery  # noqa: E402
 
-BILLING_PROJECT = "basedosdados-dev"
+_argv = sys.argv[1:]
+if "--env" in _argv:
+    _i = _argv.index("--env")
+    ENV = _argv[_i + 1]
+    _argv = _argv[:_i] + _argv[_i + 2 :]
+else:
+    ENV = "dev"
+BILLING_PROJECT = "basedosdados" if ENV == "prod" else "basedosdados-dev"
 DATASET_ID = "us_bls_cpi"
 OUTPUT_ROOT = Path(__file__).resolve().parent.parent / "output"
 
@@ -78,8 +86,9 @@ def upload_table(slug: str, expected_rows: int) -> int:
 
 
 def main():
-    only = set(sys.argv[1:])
+    only = set(_argv)
     tables = [(s, r) for s, r in TABLES if not only or s in only]
+    print(f"=== uploading to {BILLING_PROJECT} (env={ENV}) ===", flush=True)
     for slug, expected in tables:
         print(f"=== {slug} ===", flush=True)
         try:

--- a/models/us_bls_cpi/schema.yml
+++ b/models/us_bls_cpi/schema.yml
@@ -1,0 +1,202 @@
+---
+version: 2
+models:
+  - name: us_bls_cpi__monthly
+    description: >-
+      Consumer Price Index monthly index levels for CPI-U and CPI-W, one row per
+      survey, seasonal adjustment, area, item, and month, with index level and
+      Data Basis-computed month-over-month and 12-month percent changes.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - survey
+            - seasonal_adjustment
+            - area_id
+            - item_id
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the index observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the index observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: survey
+        description: >-
+          CPI survey population: CPI-U for all urban consumers or CPI-W for urban
+          wage earners and clerical workers
+        tests: [not_null]
+      - name: seasonal_adjustment
+        description: >-
+          Whether the series is seasonally adjusted (S) or not seasonally
+          adjusted (U)
+        tests: [not_null]
+      - name: area_id
+        description: BLS CPI area code identifying the geographic coverage of the
+          series
+        tests: [not_null]
+      - name: item_id
+        description: BLS CPI item code identifying the expenditure category of the
+          series
+        tests: [not_null]
+      - name: base_period
+        description: >-
+          Index reference base period at which the index equals 100, which varies
+          by series
+      - name: index_value
+        description: >-
+          Monthly Consumer Price Index level for the item, area, and period,
+          relative to the base period
+      - name: monthly_change
+        description: >-
+          Percent change in the index relative to the previous month, computed by
+          Data Basis
+      - name: twelve_month_change
+        description: >-
+          Percent change in the index relative to the same month of the previous
+          year, computed by Data Basis
+  - name: us_bls_cpi__annual
+    description: >-
+      Consumer Price Index annual average index levels for CPI-U and CPI-W, one
+      row per survey, seasonal adjustment, area, item, and year, with the annual
+      average index and Data Basis-computed year-over-year percent change.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - survey
+            - seasonal_adjustment
+            - area_id
+            - item_id
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the annual average
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: survey
+        description: >-
+          CPI survey population: CPI-U for all urban consumers or CPI-W for urban
+          wage earners and clerical workers
+        tests: [not_null]
+      - name: seasonal_adjustment
+        description: >-
+          Whether the series is seasonally adjusted (S) or not seasonally
+          adjusted (U)
+        tests: [not_null]
+      - name: area_id
+        description: BLS CPI area code identifying the geographic coverage of the
+          series
+        tests: [not_null]
+      - name: item_id
+        description: BLS CPI item code identifying the expenditure category of the
+          series
+        tests: [not_null]
+      - name: base_period
+        description: >-
+          Index reference base period at which the index equals 100, which varies
+          by series
+      - name: index_value
+        description: >-
+          Annual average Consumer Price Index level for the item, area, and year,
+          relative to the base period
+      - name: annual_change
+        description: >-
+          Percent change in the annual average index relative to the previous
+          year, computed by Data Basis
+  - name: us_bls_cpi__semiannual
+    description: >-
+      Consumer Price Index semiannual index levels for CPI-U and CPI-W in areas
+      surveyed twice a year, one row per survey, seasonal adjustment, area, item,
+      year, and half, with index level and Data Basis-computed period-over-period
+      percent change.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - half
+            - survey
+            - seasonal_adjustment
+            - area_id
+            - item_id
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the index observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: half
+        description: >-
+          Half of the year for semiannual series, 1 for the first half and 2 for
+          the second half
+        tests: [not_null]
+      - name: survey
+        description: >-
+          CPI survey population: CPI-U for all urban consumers or CPI-W for urban
+          wage earners and clerical workers
+        tests: [not_null]
+      - name: seasonal_adjustment
+        description: >-
+          Whether the series is seasonally adjusted (S) or not seasonally
+          adjusted (U)
+        tests: [not_null]
+      - name: area_id
+        description: BLS CPI area code identifying the geographic coverage of the
+          series
+        tests: [not_null]
+      - name: item_id
+        description: BLS CPI item code identifying the expenditure category of the
+          series
+        tests: [not_null]
+      - name: base_period
+        description: >-
+          Index reference base period at which the index equals 100, which varies
+          by series
+      - name: index_value
+        description: >-
+          Semiannual Consumer Price Index level for the item, area, and half,
+          relative to the base period
+      - name: semiannual_change
+        description: >-
+          Percent change in the index relative to the previous half-year period,
+          computed by Data Basis
+  - name: us_bls_cpi__dicionario
+    description: >-
+      Dictionary mapping the coded columns of us_bls_cpi (survey, seasonal
+      adjustment, area, item) to their human-readable labels.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_tabela, nome_coluna, chave]
+    columns:
+      - name: id_tabela
+        description: Slug of the us_bls_cpi table the dictionary entry describes
+        tests: [not_null]
+      - name: nome_coluna
+        description: Name of the column the dictionary entry describes
+        tests: [not_null]
+      - name: chave
+        description: Coded value (key) exactly as stored in the data
+        tests: [not_null]
+      - name: cobertura_temporal
+        description: Temporal coverage of the key
+      - name: valor
+        description: Human-readable label corresponding to the coded value

--- a/models/us_bls_cpi/us_bls_cpi__annual.sql
+++ b/models/us_bls_cpi/us_bls_cpi__annual.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        schema="us_bls_cpi",
+        alias="annual",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1913, "end": 2031, "interval": 1},
+        },
+        cluster_by=["survey", "area_id"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(survey as string) survey,
+    safe_cast(seasonal_adjustment as string) seasonal_adjustment,
+    safe_cast(area_id as string) area_id,
+    safe_cast(item_id as string) item_id,
+    safe_cast(base_period as string) base_period,
+    safe_cast(index_value as float64) index_value,
+    safe_cast(annual_change as float64) annual_change
+from {{ set_datalake_project("us_bls_cpi_staging.annual") }} as t

--- a/models/us_bls_cpi/us_bls_cpi__dicionario.sql
+++ b/models/us_bls_cpi/us_bls_cpi__dicionario.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        schema="us_bls_cpi",
+        alias="dicionario",
+        materialized="table",
+    )
+}}
+
+
+select
+    safe_cast(id_tabela as string) id_tabela,
+    safe_cast(nome_coluna as string) nome_coluna,
+    safe_cast(chave as string) chave,
+    safe_cast(cobertura_temporal as string) cobertura_temporal,
+    safe_cast(valor as string) valor
+from {{ set_datalake_project("us_bls_cpi_staging.dicionario") }} as t

--- a/models/us_bls_cpi/us_bls_cpi__monthly.sql
+++ b/models/us_bls_cpi/us_bls_cpi__monthly.sql
@@ -1,0 +1,27 @@
+{{
+    config(
+        schema="us_bls_cpi",
+        alias="monthly",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1913, "end": 2031, "interval": 1},
+        },
+        cluster_by=["survey", "area_id"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(survey as string) survey,
+    safe_cast(seasonal_adjustment as string) seasonal_adjustment,
+    safe_cast(area_id as string) area_id,
+    safe_cast(item_id as string) item_id,
+    safe_cast(base_period as string) base_period,
+    safe_cast(index_value as float64) index_value,
+    safe_cast(monthly_change as float64) monthly_change,
+    safe_cast(twelve_month_change as float64) twelve_month_change
+from {{ set_datalake_project("us_bls_cpi_staging.monthly") }} as t

--- a/models/us_bls_cpi/us_bls_cpi__semiannual.sql
+++ b/models/us_bls_cpi/us_bls_cpi__semiannual.sql
@@ -1,0 +1,26 @@
+{{
+    config(
+        schema="us_bls_cpi",
+        alias="semiannual",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1913, "end": 2031, "interval": 1},
+        },
+        cluster_by=["survey", "area_id"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(half as int64) half,
+    safe_cast(survey as string) survey,
+    safe_cast(seasonal_adjustment as string) seasonal_adjustment,
+    safe_cast(area_id as string) area_id,
+    safe_cast(item_id as string) item_id,
+    safe_cast(base_period as string) base_period,
+    safe_cast(index_value as float64) index_value,
+    safe_cast(semiannual_change as float64) semiannual_change
+from {{ set_datalake_project("us_bls_cpi_staging.semiannual") }} as t


### PR DESCRIPTION
## Summary
Onboards the US Consumer Price Index (BLS) as `us_bls_cpi` (dataset slug `cpi`),
covering CPI-U and CPI-W from the BLS `time.series` flat files.

## Tables (partitioned by `year`)
- **monthly** (2,638,757 rows, 1913–2026) — index + `monthly_change` + `twelve_month_change`
- **annual** (229,016) — M13 annual averages + `annual_change`
- **semiannual** (392,891, 1984–2026) — halves + `semiannual_change`
- **dicionario** (1,386) — labels for survey / seasonal_adjustment / area / item

Long-fact design keyed by `(year[,month/half], survey, seasonal_adjustment,
area_id, item_id)`. Percent changes are derived by Data Basis (BLS ships index
levels only); dimensions resolved by joining observations to `<s>.series`.

## Validation
- dbt run PASS=4; **dbt test PASS=31/31** (unique keys, not_null, not_null_proportion, year/month directory relationships).
- Headline CPI-U (All items, US city avg, NSA) matches published BLS exactly: 2024 annual avg 313.689 / +2.95%, 2022-06 peak +9.06%.
- ~706k cross-listed duplicate observations deduplicated; BLS `-` markers → NULL.

## Notes
- English column names + `year` partition (consistent with `us_bls_atus`); `dicionario` kept on the standard schema so website dictionary rendering works.
- Registered on the staging backend; prod promotion (basedosdados-staging → `dbt --target prod`) runs via deploy/CI.
- Source updates monthly → a Prefect refresh pipeline is the planned follow-up (`upload.py` already takes `--env dev|prod`).
- Raw/parquet excluded via `models/us_bls_cpi/.gitignore`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added U.S. BLS Consumer Price Index data in monthly, annual, and semiannual formats.
  * Included index values, period-over-period changes, 12-month changes, survey details, geographic areas, and item identifiers.
  * Added a reference dictionary translating coded dimensions into readable labels.
  * Added multilingual field descriptions and dataset metadata.
* **Documentation**
  * Added onboarding guidance covering data sources, structure, validation, and refresh workflows.
* **Data Quality**
  * Added checks for uniqueness, required fields, valid time references, and data relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->