### PR TITLE
fix(br_rf_cno): lê data da fonte via HEAD/Last-Modified (PROPFIND bloqueado por WAF)

### DIFF
--- a/pipelines/crawler/rf/tasks.py
+++ b/pipelines/crawler/rf/tasks.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import shutil
 import time
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 import httpx
@@ -24,7 +24,7 @@ from pipelines.utils.utils import log
 
 
 @task
-def check_need_for_update(dataset_id: str, url: str | None = None) -> str:
+def check_need_for_update(dataset_id: str, url: str | None = None) -> date:
     """
     Checks the need for an update by reading the source file's ``Last-Modified``
     HTTP header (via a HEAD request).
@@ -39,7 +39,7 @@ def check_need_for_update(dataset_id: str, url: str | None = None) -> str:
         dataset_id (str): RF specific dataset name.
 
     Returns:
-        str: The date of the last update in 'YYYY-MM-DD' format.
+        datetime.date: The source file's last-modified date.
 
     Raises:
         httpx.HTTPStatusError: If the source returns an HTTP error status.

--- a/pipelines/crawler/rf/tasks.py
+++ b/pipelines/crawler/rf/tasks.py
@@ -42,11 +42,12 @@ def check_need_for_update(dataset_id: str, url: str | None = None) -> date:
         datetime.date: The source file's last-modified date.
 
     Raises:
-        httpx.HTTPStatusError: If the source returns an HTTP error status.
+        httpx.HTTPError: If the request keeps failing after exhausting retries.
         ValueError: If the ``Last-Modified`` header is missing/unparseable.
 
     Notes:
-        - Implementa retries com backoff exponencial para falhas de conexão.
+        - Implementa retries com backoff exponencial para falhas transitórias
+          (conexão e status 5xx).
     """
     log(f"---- Checking most recent update date for {dataset_id}")
     retries = 5
@@ -65,8 +66,8 @@ def check_need_for_update(dataset_id: str, url: str | None = None) -> date:
             )
             response.raise_for_status()
             break
-        except httpx.TransportError as e:
-            log(f"Connection attempt {attempt + 1}/{retries} failed: {e}")
+        except httpx.HTTPError as e:
+            log(f"Request attempt {attempt + 1}/{retries} failed: {e}")
             if attempt < retries - 1:
                 time.sleep(delay)
                 delay *= 2

--- a/pipelines/crawler/rf/tasks.py
+++ b/pipelines/crawler/rf/tasks.py
@@ -9,11 +9,9 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+import httpx
 import pandas as pd
-import requests
-from bs4 import BeautifulSoup
 from prefect import task
-from requests.exceptions import ConnectionError, HTTPError
 from tqdm import tqdm
 
 from pipelines.constants import constants
@@ -28,8 +26,14 @@ from pipelines.utils.utils import log
 @task
 def check_need_for_update(dataset_id: str, url: str | None = None) -> str:
     """
-    Checks the need for an update by extracting the most recent update date
-    for  source files from the url listing.
+    Checks the need for an update by reading the source file's ``Last-Modified``
+    HTTP header (via a HEAD request).
+
+    A fonte (WebDAV ownCloud da Receita Federal) passou a ficar atrás de um WAF
+    (F5 BIG-IP) que rejeita o método PROPFIND com ``HTTP 200`` + página HTML
+    "Request Rejected". Por isso a data de referência agora é lida do header
+    ``Last-Modified`` do próprio ``cno.zip`` (cujo GET/HEAD não é bloqueado),
+    em vez da listagem via PROPFIND.
 
     Args:
         dataset_id (str): RF specific dataset name.
@@ -38,11 +42,10 @@ def check_need_for_update(dataset_id: str, url: str | None = None) -> str:
         str: The date of the last update in 'YYYY-MM-DD' format.
 
     Raises:
-        requests.HTTPError: If there is an HTTP error when making the request.
-        ValueError: If the file 'cno.zip' is not found in the URL.
+        httpx.HTTPStatusError: If the source returns an HTTP error status.
+        ValueError: If the ``Last-Modified`` header is missing/unparseable.
 
     Notes:
-        - O crawler falhará se o nome do arquivo mudar.
         - Implementa retries com backoff exponencial para falhas de conexão.
     """
     log(f"---- Checking most recent update date for {dataset_id}")
@@ -50,46 +53,40 @@ def check_need_for_update(dataset_id: str, url: str | None = None) -> str:
     delay = 2
 
     if url is None:
-        url = br_rf_constants.URLS.value["url_base"]
+        url = br_rf_constants.URLS.value["url_download"]
+
     for attempt in range(retries):
         try:
-            response = requests.request(
-                method="PROPFIND",
-                url=url,
+            response = httpx.head(
+                url,
                 headers=br_rf_constants.HEADERS.value,
-                data=br_rf_constants.XML_BODY.value,
                 timeout=30,
+                follow_redirects=True,
             )
             response.raise_for_status()
             break
-        except ConnectionError as e:
+        except httpx.TransportError as e:
             log(f"Connection attempt {attempt + 1}/{retries} failed: {e}")
             if attempt < retries - 1:
                 time.sleep(delay)
                 delay *= 2
             else:
                 raise
-        except HTTPError as e:
-            raise requests.HTTPError(f"HTTP error occurred: {e}") from e
 
-    file = BeautifulSoup(response.text, "lxml")
-
-    most_recent_date = max(
-        datetime.strptime(
-            p.find("d:getlastmodified").text, "%a, %d %b %Y %H:%M:%S GMT"
-        )
-        for p in file.find_all("d:prop")
-        if p.find("d:getlastmodified")
-    ).date()
+    most_recent_date = response.headers.get("Last-Modified")
 
     if not most_recent_date:
         raise ValueError(
-            f"File not found on {url}."
-            "Check if the folder structure or file name has changed."
+            f"Could not read Last-Modified from {url}. "
+            "Check if the source or its response headers have changed."
         )
 
-    log(f"Most recent update date: {most_recent_date}")
-    return most_recent_date
+    parsed_most_recent_date = datetime.strptime(
+        most_recent_date, "%a, %d %b %Y %H:%M:%S GMT"
+    ).date()
+
+    log(f"Most recent update date: {parsed_most_recent_date}")
+    return parsed_most_recent_date
 
 
 @task


### PR DESCRIPTION
## Problema

O `check_need_for_update` (crawler `rf`) lia a data da fonte via `PROPFIND` na pasta WebDAV. A Receita Federal passou a servir o WebDAV (ownCloud) atrás de um **WAF (F5 BIG-IP)** que **rejeita o método `PROPFIND`** com `HTTP 200` + página HTML `"Request Rejected"`. Como o status é 200, o `raise_for_status()` não pega; o parser recebe HTML em vez de XML WebDAV, a lista de `getlastmodified` vem vazia e o flow quebra em `ValueError: max() iterable argument is empty` — **travando todas as tabelas do `br_rf_cno`** (é a 1ª task de todo flow).

Não é User-Agent (testado com UA de browser completo, ainda bloqueia) — é o método `PROPFIND`. O **download passa**: `HEAD`/`GET` do `cno.zip` retorna `200` normalmente.

## Correção

Lê a data pelo header **`Last-Modified`** do próprio `cno.zip`, via **`httpx.head`** (GET/HEAD não é bloqueado pelo WAF). Mesmo formato de data (`%a, %d %b %Y %H:%M:%S GMT`) e mesmo retorno (`date`). Troca `requests`+`BeautifulSoup`+`PROPFIND` por `httpx.head`; retry/backoff mantidos.

## Validação (contra a fonte real, sem Prefect)

```
status: 200
Last-Modified: Thu, 16 Jul 2026 04:36:28 GMT
parsed date: 2026-07-16 | type: date
```

## Teste

`deploy-flow` publica o flow no pool `basedosdados-dev`; rodar o deployment do `microdados` em dev confirma o flow end-to-end antes do merge. O merge deploya o flow em prod (`cd-prefect3`), destravando as atualizações do conjunto.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update detection by using the download file’s last-modified timestamp.
  * Added more reliable retry handling for network connection errors, including exponential backoff.
  * Improved validation when the last-modified timestamp is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->