### PR TITLE
fix(br_rf_cno): download passa pelo WAF (browser headers no HEAD) e valida content-length

### DIFF
--- a/pipelines/crawler/rf/tasks.py
+++ b/pipelines/crawler/rf/tasks.py
@@ -137,7 +137,9 @@ def process_file(
     if file is None:
         file = br_rf_constants.TABLES_RENAME.value[dataset_id][table_id]
     try:
-        partition_date = datetime.strptime(str(partition_date), "%Y-%m-%d")
+        partition_date = datetime.strptime(
+            str(partition_date), "%Y-%m-%d"
+        ).date()
         log(f"Partition date {partition_date}.")
     except ValueError:
         log("Invalid partition_date format. Using raw value.")

--- a/pipelines/crawler/rf/utils.py
+++ b/pipelines/crawler/rf/utils.py
@@ -10,6 +10,23 @@ from tqdm import tqdm
 from pipelines.crawler.rf.constants import constants as br_rf_cosnstants
 from pipelines.utils.utils import log
 
+_BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/80.0.3987.149 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "pt-BR,pt;q=0.8,en-US;q=0.5,en;q=0.3",
+    "Sec-GPC": "1",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "same-origin",
+    "Sec-Fetch-User": "?1",
+    "Priority": "u=0, i",
+}
+
 
 async def download_chunk(
     client: httpx.AsyncClient,
@@ -36,23 +53,7 @@ async def download_chunk(
     Returns:
         None
     """
-    headers = {
-        "Range": f"bytes={start}-{end}",
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/80.0.3987.149 Safari/537.36"
-        ),
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "pt-BR,pt;q=0.8,en-US;q=0.5,en;q=0.3",
-        "Sec-GPC": "1",
-        "Upgrade-Insecure-Requests": "1",
-        "Sec-Fetch-Dest": "document",
-        "Sec-Fetch-Mode": "navigate",
-        "Sec-Fetch-Site": "same-origin",
-        "Sec-Fetch-User": "?1",
-        "Priority": "u=0, i",
-    }
+    headers = {**_BROWSER_HEADERS, "Range": f"bytes={start}-{end}"}
 
     async with semaphore:  # controla concorrência
         response = await client.get(url, headers=headers, timeout=60.0)
@@ -78,6 +79,10 @@ async def download_file_async(root: str, url: str) -> None:
         root (str): Root directory where the file will be saved.
         url (str): The URL of the file to download.
 
+    Raises:
+        httpx.HTTPStatusError: If the source returns an HTTP error status.
+        ValueError: If the response is missing the content-length header.
+
     Returns:
         None
     """
@@ -86,12 +91,20 @@ async def download_file_async(root: str, url: str) -> None:
 
     log(f"---- Starting async download from {url}")
 
-    # Step 1: get file size
     async with httpx.AsyncClient() as client:
-        response = await client.head(url, timeout=60.0)
-        total_size = int(response.headers["content-length"])
+        response = await client.head(
+            url, timeout=60.0, headers=_BROWSER_HEADERS, follow_redirects=True
+        )
+        response.raise_for_status()
 
-    # Step 2: preallocate space
+    content_length = response.headers.get("content-length")
+    if content_length is None:
+        raise ValueError(
+            f"HEAD de {url} não retornou o header content-length — "
+            "provável bloqueio do WAF ou resposta inesperada da fonte."
+        )
+    total_size = int(content_length)
+
     with open(filepath, "wb") as f:
         f.write(b"\0" * total_size)
 
@@ -99,7 +112,6 @@ async def download_file_async(root: str, url: str) -> None:
     tasks: list[asyncio.Task] = []
     semaphore = asyncio.Semaphore(5)  # allow max 5 simultaneous downloads
 
-    # Step 3: schedule downloads
     with tqdm(
         total=total_size, unit="MB", unit_scale=True, desc=filepath
     ) as pbar:

--- a/pipelines/datasets/br_rf_cno/README.md
+++ b/pipelines/datasets/br_rf_cno/README.md
@@ -95,6 +95,23 @@ Vínculos (responsáveis) da obra. `data_fim` usa a sentinela `9999-*` para "sem
 (vínculo em aberto), e há registros com data digitada errada — valores fora do range do
 diretório de datas são nulados (ver *Histórico de Correções* #2).
 
+**Duplicatas (PENDENTE — requer aprovação de superior):** ao contrário de `areas`/`microdados`,
+`vinculos` **não tem** teste `unique_combination_of_columns`, então duplicatas passam batido —
+há **~10.656 linhas 100% duplicadas** na partição mais recente (~2,5%; a própria fonte traz
+linhas idênticas). Verificar com `COUNT(*) - COUNT(DISTINCT TO_JSON_STRING(t))`. Resolução
+**não executada** (mexe em dado público de prod → depende de OK de um superior):
+
+- **Forward:** `select distinct` no modelo (espelha a `areas`) + teste
+  `unique_combination_of_columns` em `[id_cno, id_responsavel, data_inicio, data_fim,
+  qualificacao_contribuinte]` (chave verificada: **0 colisões** após o distinct), escopado em
+  `__most_recent_date_cno__`. Obs.: o teste só fica verde quando o partition máximo estiver
+  limpo (partição nova pós-fix, ou a limpeza de histórico abaixo).
+- **Histórico:** **NÃO usar `--full-refresh`** — o staging tem só **126 das 292 partições**, então
+  full-refresh reconstruiria do staging e **perderia ~166 partições**. Limpar in-place com
+  `CREATE OR REPLACE TABLE \`basedosdados.br_rf_cno.vinculos\` PARTITION BY data_extracao AS
+  SELECT DISTINCT * FROM \`basedosdados.br_rf_cno.vinculos\`` (dropa as Row Access Policies →
+  reaplicar). Sem isso, só o distinct no modelo limpa os partitions novos; o histórico mantém os dupes.
+
 ### `br_rf_cno__areas`
 Áreas da obra. **Uma obra (`id_cno`) tem VÁRIAS áreas** (grão = uma área de uma obra, não
 uma obra). A chave natural é `[id_cno, categoria, destinacao, tipo_area, tipo_area_complementar]`.
@@ -102,8 +119,9 @@ A fonte ainda traz linhas 100% duplicadas (ruído), removidas com `select distin
 (ver *Histórico de Correções* #3).
 
 ### `br_rf_cno__cnaes`
-CNAE(s) da obra. Sem particularidade — é a única tabela sem teste de unicidade, por isso
-nunca foi afetada pelo databug.
+CNAE(s) da obra. Sem particularidade. `cnaes` e `vinculos` são as tabelas **sem** teste
+`unique_combination_of_columns`; a `cnaes` nunca foi afetada pelo databug de testes (não tinha
+teste de qualidade que reprovasse).
 
 ## Modelagem incremental e testes
 
@@ -130,6 +148,54 @@ deferido, o `Poll` (verificação) avança todo dia (mostra data recente no site
 arquivo mesmo sem materializar (resíduo). **A correção dos testes resolve os dois problemas:**
 com os flows voltando a materializar, coverage e `RawDataSource.Update` ressincronizam
 sozinhos na primeira execução bem-sucedida em prod.
+
+**Blocker final (partition-date):** mesmo com WAF e testes resolvidos, o prod continuou
+congelado porque a pasta de partição era gravada com hora (`data=YYYY-MM-DD 00:00:00`), e
+`SAFE_CAST('...00:00:00' AS DATE)=NULL` fazia o filtro incremental nunca inserir — ver
+*Histórico de Correções* 2026-07-17.
+
+## Metadados no backend (migração `br_me_cno` → `br_rf_cno`)
+
+No lado dos **dados/pipeline**, o conjunto foi migrado do GCP dataset antigo **`br_me_cno`**
+(Ministério da Economia) para **`br_rf_cno`** (Receita Federal), com renome de tabelas
+(`microdados_cnae`→`cnaes`, `microdados_vinculo`→`vinculos`). Mas o **backend do site havia
+ficado apontando para o `br_me_cno`**, que está **vazio e congelado desde 2021-08-11** — o site
+mostrava os metadados mas as *cloud tables* serviam tabelas vazias (usuário copiava o caminho BQ
+e pegava 0 linha). A capa mostrava cobertura/tamanho certos porque vêm dos *registros* de
+metadado (atualizados pelo flow), não da cloud table.
+
+Reconciliado em **2026-07-17** (via MCP `databasis` + GraphQL, em prod):
+
+- **Cloud tables** das 5 tabelas repontadas para `basedosdados.br_rf_cno.*`.
+- **Colunas** alinhadas ao BQ/`schema.yml` (o backend tinha o schema antigo do `br_me_cno`:
+  `ni_responsavel`→`id_responsavel`, `cnae_2`→`cnae_2_subclasse`, faltavam `data_extracao`/
+  `nome_pais`; descrições velhas em `id_cno`/`id_cno_vinculado`/`nome_empresarial`).
+- **`areas` registrada do zero** (não existia no backend): tabela + 8 colunas + cloud table +
+  observation level (Obra/Construção) + cobertura BD Pro (free `2024-08-05..2026-01-17`; pro
+  `2026-01-18..2026-07-17`, espelhando a `microdados`).
+- Verificado: as 5 tabelas com cloud em `br_rf_cno` e conjunto + descrições de coluna idênticos
+  ao BQ.
+
+Aprendizados de MCP/backend (para a próxima vez):
+
+- **`check_metadata.py`** compara descrição do **BQ (persist_docs do `schema.yml`)** × **API**,
+  por nome de coluna — lê o `br_rf_cno` (do `schema.yml`), não a cloud table. Ele deriva as
+  tabelas a validar dos **arquivos de modelo** mudados no PR; num PR que **não toca modelo** (só
+  crawler/flow), não acha tabela e **crasha** com `ValueError: No objects to concatenate`. Isso
+  **não** é divergência de metadado — não faz sentido a label `check-metadata` em PR de
+  crawler/flow.
+- **Rename de coluna não existe** no MCP/GraphQL: `update_column`/`CreateUpdateColumn` (mesmo com
+  `id`) atualizam descrição/flags mas **ignoram troca de `name`** → renomear = `delete_column` +
+  criar de novo. `table`/`bigqueryType` querem **UUID puro** (não `TableNode:uuid`).
+  `upload_columns_from_sheet` **cria** (não faz upsert por nome) — duplica se a coluna já existe,
+  e não seta `is_partition` (setar depois). `update_column` com `directory_column_name` só
+  *preserva* um diretório existente; para *criar* o link, GraphQL com `directoryPrimaryKey`.
+- **RAP (Row Access Policy):** o worker de **dev** não tem `bigquery.rowAccessPolicies.setIamPolicy`
+  (limitação geral do dev, afeta toda tabela BD Pro com o `pre_hook DROP ALL ROW ACCESS POLICIES`),
+  então `dbt run --target dev` falha no pre_hook; o worker de **prod** tem a permissão. Validar
+  este tipo de flow no de prod, ou conceder a permissão à SA de dev por tabela.
+- Nomes de exibição ainda são da era ME ("Microdados CNAE"/"Microdados Vínculo") — cosmético;
+  renomear o **slug** quebraria URLs públicas.
 
 ## Histórico de Correções
 
@@ -159,3 +225,19 @@ crawler compartilhado `rf`:
 2. `download_file_async`: o `HEAD` passou a mandar `_BROWSER_HEADERS` + `follow_redirects=True`, e
    valida o `content-length` (erro claro se ausente). Headers de browser extraídos para a
    constante `_BROWSER_HEADERS`, reusada pelos GETs de chunk.
+
+### 2026-07-17 — partition-date destravou o prod (branch `fix/br_rf_cno_utils`)
+Com WAF e testes resolvidos, o flow rodou end-to-end mas o **prod continuava congelado em
+`2026-01-28`**: o `dbt run` logava "OK" mas inseria **0 linhas**. Causa: `process_file`
+(`crawler/rf/tasks.py`) fazia `datetime.strptime(...)` (um **datetime**) e `process_chunk`
+(`crawler/rf/utils.py`) montava a pasta como `f"data={partition_date}"` → `data=2026-07-17
+00:00:00`. No staging (append) **todas** as partições ficavam com `data`="...00:00:00" e
+`SAFE_CAST(data AS DATE)=NULL`, então o filtro incremental `where safe_cast(data as date) >
+(select max(data_extracao) from {{this}})` nunca inseria. **Fix (data-only):** `.date()` no
+`process_file` + `f"data={partition_date:%Y-%m-%d}"` no `process_chunk`. Após o fix, o prod
+avançou `2026-01-28`→`2026-07-17` e o `dbt test` de prod passou (a partição nova entra limpa,
+com o `left join` de `sigla_uf` já aplicado). Não precisou `--full-refresh` nem mexer em RAP.
+
+### 2026-07-17 — migração de metadados no backend (`br_me_cno` → `br_rf_cno`)
+As cloud tables/colunas do backend apontavam para o `br_me_cno` (vazio); reconciliadas para o
+`br_rf_cno` e a `areas` registrada do zero. Ver a seção *Metadados no backend* acima.

--- a/pipelines/datasets/br_rf_cno/README.md
+++ b/pipelines/datasets/br_rf_cno/README.md
@@ -9,12 +9,29 @@ tributárias e obter a certidão de regularidade fiscal da obra.
 
 - **Fonte do download:** um único ZIP (~306 MB) em
   `https://arquivos.receitafederal.gov.br/public.php/dav/files/gn672Ad4CF8N6TK/Dados/Cadastros/CNO/cno.zip`.
-- **Data de referência (`data_extracao`):** obtida por um `PROPFIND` (WebDAV) no diretório
-  do CNO — pega o `getlastmodified` mais recente entre os arquivos. **Não** é derivada do
-  conteúdo dos dados. Ver `check_need_for_update` em `pipelines/crawler/rf/tasks.py`.
+- **Data de referência (`data_extracao`):** lida do header `Last-Modified` do `cno.zip` via
+  `HEAD` (httpx), em `check_need_for_update` (`pipelines/crawler/rf/tasks.py`). **Não** é
+  derivada do conteúdo dos dados. Antes usava `PROPFIND` (WebDAV), abandonado por causa do WAF
+  (ver *Acesso à fonte e o WAF*).
 - **RawDataSource registrada** aponta para a página do portal de dados abertos
   (`dados.gov.br/dados/conjuntos-dados/cadastro-nacional-de-obras-cno`), com atualização
   diária. O dicionário oficial de dados (SERPRO) descreve os arquivos e códigos.
+
+## Acesso à fonte e o WAF
+
+A fonte (servidor WebDAV ownCloud da Receita) passou a ficar atrás de um **WAF (F5 BIG-IP)**
+que interfere no acesso automatizado. Dois efeitos, com os respectivos contornos no código:
+
+- **Bloqueia o método `PROPFIND`** (responde `HTTP 200` + página HTML `"Request Rejected"`).
+  Por isso `check_need_for_update` não lista mais o diretório via `PROPFIND`; lê a data pelo
+  header `Last-Modified` do `cno.zip` via `HEAD`.
+- **Bloqueia User-Agents "crus"** (ex.: o default `python-httpx`). Por isso o download
+  (`download_file_async`/`download_chunk` em `pipelines/crawler/rf/utils.py`) envia headers de
+  browser (constante `_BROWSER_HEADERS`) tanto no `HEAD` (que lê o `content-length`) quanto nos
+  `GET` de range, com `follow_redirects=True`.
+- **É errático:** o mesmo endpoint alterna `200`/`404` e pode fazer rate-limit por IP. O `HEAD`
+  do download valida o `content-length` e falha com mensagem clara se ele não vier; a task
+  `crawl` tem `retries=2` para picos transitórios.
 
 ## Estrutura dos Flows
 
@@ -22,7 +39,7 @@ O diretório do dataset (`pipelines/datasets/br_rf_cno/flows.py`) é só um wrap
 cada tabela tem um flow que chama `_run_rf` do módulo compartilhado
 `pipelines/crawler/rf/flows.py`. Sequência de `_run_rf`:
 
-1. `check_need_for_update` → data da fonte (`getlastmodified`).
+1. `check_need_for_update` → data da fonte (header `Last-Modified` via `HEAD`).
 2. `poll_source_for_update_task` (poll **deferido**) — grava só o `Poll`, retorna se há
    novidade; **não** grava o `Update`.
 3. download → `process_file` (parquet particionado por `data=<data_extracao>`) → upload staging dev.
@@ -131,3 +148,14 @@ Correções apenas nos modelos dbt (sem tocar em flow), validadas em dev com `--
 
 `cnaes` nunca foi afetada (não tem teste de unicidade). Ao subir para prod, as quatro tabelas
 voltam a materializar e os metadados ressincronizam.
+
+### 2026-07-16 — acesso à fonte quebrado pelo WAF (PR #1681)
+Com os testes destravados, os flows passaram a falhar no **acesso à fonte** — o WAF (F5) da
+Receita bloqueando `PROPFIND` e User-Agents crus (ver *Acesso à fonte e o WAF*). Correções no
+crawler compartilhado `rf`:
+
+1. `check_need_for_update`: `PROPFIND` → `HEAD` + header `Last-Modified` (via httpx), reusando o
+   mesmo parse de data. Type hint corrigido para `-> date`.
+2. `download_file_async`: o `HEAD` passou a mandar `_BROWSER_HEADERS` + `follow_redirects=True`, e
+   valida o `content-length` (erro claro se ausente). Headers de browser extraídos para a
+   constante `_BROWSER_HEADERS`, reusada pelos GETs de chunk.

--- a/pipelines/datasets/br_rf_cno/flows.py
+++ b/pipelines/datasets/br_rf_cno/flows.py
@@ -1,5 +1,9 @@
 """
-Flows for br_rf_cno — Prefect 3.
+Flows for br_rf_cno (Cadastro Nacional de Obras — Receita Federal) — Prefect 3.
+
+Um flow por tabela (microdados, vinculos, areas, cnaes), gerado por `_cno_flow` e
+delegando a `_run_rf` (crawler compartilhado `rf`). Contexto da fonte, do WAF e das
+particularidades por tabela: ver `pipelines/datasets/br_rf_cno/README.md`.
 """
 
 from prefect import flow

--- a/pipelines/datasets/br_rf_cno/flows.py
+++ b/pipelines/datasets/br_rf_cno/flows.py
@@ -4,6 +4,9 @@ Flows for br_rf_cno (Cadastro Nacional de Obras — Receita Federal) — Prefect
 Um flow por tabela (microdados, vinculos, areas, cnaes), gerado por `_cno_flow` e
 delegando a `_run_rf` (crawler compartilhado `rf`). Contexto da fonte, do WAF e das
 particularidades por tabela: ver `pipelines/datasets/br_rf_cno/README.md`.
+
+A data de partição é gravada sem componente de hora (date-only); com hora, o
+`safe_cast(data as date)` do model virava NULL e o filtro incremental nunca inseria.
 """
 
 from prefect import flow


### PR DESCRIPTION
## Problema

Depois do #1681 (que corrigiu o `check_need_for_update`), o flow avançou mas passou a quebrar no **download**: `KeyError('content-length')` em `download_file_async`. O `HEAD` do downloader ia "cru" (UA default `python-httpx`, sem `follow_redirects`) e o WAF (F5 BIG-IP) da Receita o tratava diferente do resto (o `check_need_for_update` e os GETs de chunk já usam UA de browser) → resposta sem `content-length`.

## Correção (`pipelines/crawler/rf/utils.py`)

- Headers de browser (que o `download_chunk` já usava inline) extraídos para a constante `_BROWSER_HEADERS`, reusada no `HEAD` e nos `GET` de range.
- O `HEAD` passou a enviar `_BROWSER_HEADERS` + `follow_redirects=True` + `raise_for_status()`.
- Valida o `content-length` e falha com `ValueError` claro se ausente (em vez do `KeyError` críptico).
- Contexto do WAF documentado em `pipelines/datasets/br_rf_cno/README.md` (seção "Acesso à fonte e o WAF").

## Deploy e teste

Este PR também toca o `pipelines/datasets/br_rf_cno/flows.py` (docstring do módulo) **de propósito**: o `deploy_flows.py` só re-deploya flows dos arquivos `.py` mudados que definem um `@flow` (`load_flows_from_file` pula os demais), então uma mudança só em `utils.py` não re-deployaria os flows do `br_rf_cno`. Com o `flows.py` incluído, o `deploy-flow` re-deploya os 4 flows apontando para esta branch, permitindo testar em dev antes do merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access to the CNO source by using browser-compatible headers on initial requests, following redirects, and validating `content-length` before starting chunked downloads.
  - Updated reference-date detection for `br_rf_cno` to rely on the archive’s `Last-Modified` header (avoiding WebDAV `PROPFIND` restrictions).
- **Documentation**
  - Updated the `br_rf_cno` README with the new reference-date approach, clearer WAF/access guidance, and additional incident/partition-freezing details.
  - Expanded Prefect 3 workflow documentation to describe the generated flows and the tables processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->