### PR TITLE
[Docs] fold the us_bls_cpi pipeline lessons into step 12

### DIFF
--- a/.claude/agents/pipeline.md
+++ b/.claude/agents/pipeline.md
@@ -60,10 +60,24 @@ to date. Add this only after static onboarding is verified in dev.
    discovery via `load_flows_from_file`). If the flow uses `PartBdpro`, also
    unit-test the window: `assert_coverage_topology`, `compute_coverage_ranges`
    at the real `source_end`, and that `free_end` rolls when the source advances
-   — these are pure functions. State clearly that the upload/dbt/metadata halves
-   run on the deployed worker and were not exercised locally; the same goes for
-   `apply_row_access_policies`, which issues real BigQuery DDL.
-9. **Fill in the Update/Poll records.** A recurring dataset needs all three, and
+   — these are pure functions.
+9. **Then actually run it — this is the gate, not step 8.** Local checks pass
+   while the interesting bugs sit in the parts they cannot reach; on
+   `us_bls_cpi` three separate ones survived a clean local pass. Ask the user to
+   add the **`deploy-flow`** label (no label → the staging deploy is `skipped`
+   and nothing is deployed, silently), confirm `cd-prefect3 (staging)` logs
+   `registrado`, then trigger the deployment with **prod off**:
+   `{"materialize_to_prod": False, "update_metadata": False, "force_run": True}`.
+   Defaults are `True/True/False`, so a run triggered with `{}` writes prod data
+   and metadata and applies the paywall — the metadata tasks are pinned
+   `env="prod"` even from the dev pool. Done = all tasks `COMPLETED` **and**
+   `dbt run OK` + `dbt test OK` in the logs for every table. Inspect with
+   `mcp__databasis__list_flow_runs` / `get_flow_run_logs`.
+   **Green ≠ ingested**: the poll guard returns early and still reports
+   `COMPLETED` — check the logs, not the state.
+   Say plainly what remains unexercised: the prod upload and, for `part_bdpro`,
+   `apply_row_access_policies` only run once armed.
+10. **Fill in the Update/Poll records.** A recurring dataset needs all three, and
    the flow only writes them on a run with `update_metadata=True` — so create
    the missing ones by hand rather than assuming the first run will:
    - `Update` on the **table** — when we last refreshed (wall clock), plus
@@ -74,8 +88,10 @@ to date. Add this only after static onboarding is verified in dev.
      task).
    Verify all three exist afterwards; see "Update and Poll records" in
    `prefect-pipeline-conventions`.
-10. **Commit**: `feat(<dataset_id>): add recurring Prefect pipeline`. Never commit
-   data. Pre-format `.py` files before committing.
+11. **Commit**: `feat(<dataset_id>): add recurring Prefect pipeline`. Never commit
+   data. Pre-format `.py` files before committing. Keep framework changes
+   (`pipelines/utils`, `AGENTS.md`) out of the dataset PR — they change behaviour
+   for every pipeline and deserve their own review.
 
 ## Output
 

--- a/.claude/rules/bigquery-conventions.md
+++ b/.claude/rules/bigquery-conventions.md
@@ -80,6 +80,13 @@ join basedosdados.<gcp_dataset_id>.<table_slug> on ...
   - State: `output/<table_slug>/ano=<year>/sigla_uf=<uf>/data.parquet`
   - National: `output/<table_slug>/ano=<year>/data.parquet`
 - Always build an explicit `pa.Schema` to prevent INT64/FLOAT64 type mismatches across partitions.
+- **Exception — parquet uploaded by a Prefect pipeline via `upload_to_gcs`.** There the
+  staging table's schema is inferred from a header that `gcs.py::dump_header` stringifies,
+  so typed parquet is rejected (`has type DOUBLE which does not match the target cpp_type
+  STRING_PIECE`). Build the table with the architecture's real types as above, then **cast
+  to an all-string schema via arrow** (never `astype(str)` — it turns NULL into `"nan"`)
+  before writing. See "Staging parquet must be all-STRING" in `prefect-pipeline-conventions`.
+  This applies only to the pipeline path; the one-shot onboarding upload keeps typed parquet.
 
 ## Upload prerequisites
 

--- a/.claude/rules/metadata-schema.md
+++ b/.claude/rules/metadata-schema.md
@@ -238,6 +238,27 @@ released data today.
 > the read/write split (poll reads Table.Update, commit writes RawDataSource.Update) is a
 > known open bug, not something to work around per dataset.
 
+## Reading many records: `first: N` silently truncates
+
+Backend GraphQL list queries cap the page and **do not tell you**. `allRawdatasource(first: 400)`
+returns exactly 400; `first: 1500` returns exactly 1500 — both with `pageInfo.hasNextPage: True`
+— and `first: 3000` errors. The real total was 1603. A survey written the obvious way reports a
+confidently wrong number, and the number *looks* plausible.
+
+Whenever you count or audit across records, **cursor-paginate and assert you reached the end**:
+
+```graphql
+query($after: String) {
+  allRawdatasource(first: 500, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    edges { node { id } }
+  }
+}
+```
+
+Loop until `hasNextPage` is false, passing `endCursor` as `after`. If a count is round or equal
+to your `first`, treat it as truncated until proven otherwise.
+
 ## Known issues
 
 **M2M fields (organizations, themes, tags, raw_data_source_ids):** These are Django ManyToManyFields. Pass them and verify with `get_dataset` after saving. If they appear empty despite being passed, it is a backend deployment issue — note and continue; do not retry indefinitely.

--- a/.claude/rules/onboarding-workflow.md
+++ b/.claude/rules/onboarding-workflow.md
@@ -55,8 +55,9 @@ the logs via `mcp__databasis__get_flow_run_logs`, or check whether coverage move
 **Merging does not arm it.** The prod deploy lands `paused=True` and the backend sync
 registers an unknown deployment with `is_schedule_active=False`. Arming is a manual tick
 in Django admin (`/admin/admin_data_tools/disabledflowschedule/`), and the first armed run
-is the first-ever execution of the prod upload and the Row Access Policies. Do it
-deliberately, watching.
+is the first-ever execution of the prod upload — and, **only for a `part_bdpro` table**, of
+the Row Access Policies (`needs_row_access_policy` is `isinstance(spec, PartBdpro)`, so an
+all-free pipeline never issues them). Do it deliberately, watching.
 
 **Update and Poll records.** A recurring dataset must carry all three: the table `Update`
 (when we last refreshed), the raw data source `Update` (the source's **max coverage

--- a/.claude/rules/onboarding-workflow.md
+++ b/.claude/rules/onboarding-workflow.md
@@ -35,6 +35,29 @@ Follow `prefect-pipeline-conventions` (structure, flow recipe, shared
 CSVs, and cleaning transform from steps 2–6 — it does not redesign them; the
 cleaning transform is shared with `models/<ds>/code/` rather than duplicated.
 
+**A dev run is the definition of done — not a clean local check.** Local verification
+(imports, transform parity, deploy discovery) cannot reach the parts that break: on
+`us_bls_cpi` it passed while three separate bugs waited in the upload, the poll, and the
+staging schema. Step 12 is not finished until the flow has run on the **dev pool** with
+`{"materialize_to_prod": False, "update_metadata": False, "force_run": True}` and the logs
+show `dbt run OK` + `dbt test OK` for every table. Two traps around that run:
+
+- The PR needs the **`deploy-flow` label** or the staging deploy is `skipped` and nothing
+  is deployed — silently.
+- The defaults are `materialize_to_prod=True, update_metadata=True`, and the metadata
+  tasks are pinned `env="prod"` even from the dev pool. A run triggered with `{}` writes
+  **prod** data and metadata and applies the paywall.
+
+**Green ≠ ingested.** The poll guard returns early and Prefect still reports `COMPLETED`,
+so a dead pipeline looks healthy (`br_ibge_ipca`: 4 ingests in 60 completed runs). Read
+the logs via `mcp__databasis__get_flow_run_logs`, or check whether coverage moved.
+
+**Merging does not arm it.** The prod deploy lands `paused=True` and the backend sync
+registers an unknown deployment with `is_schedule_active=False`. Arming is a manual tick
+in Django admin (`/admin/admin_data_tools/disabledflowschedule/`), and the first armed run
+is the first-ever execution of the prod upload and the Row Access Policies. Do it
+deliberately, watching.
+
 **Update and Poll records.** A recurring dataset must carry all three: the table `Update`
 (when we last refreshed), the raw data source `Update` (the source's **max coverage
 date**, not today), and the raw data source `Poll` (when we last looked). The flow writes

--- a/.claude/rules/prefect-pipeline-conventions.md
+++ b/.claude/rules/prefect-pipeline-conventions.md
@@ -363,9 +363,11 @@ returns nothing.
 
 ### 4. What is NOT verifiable before arming
 
-The prod upload (`bucket_name="basedosdados"`) and `apply_row_access_policies` need the
-worker's rights and run for the first time on the first armed run. Say so plainly rather
-than implying the pipeline is proven end-to-end.
+The prod upload (`bucket_name="basedosdados"`) needs the worker's rights and runs for the
+first time on the first armed run. So does `apply_row_access_policies` — but **only if a
+table is `part_bdpro`**; an all-free pipeline never issues them, so there is nothing
+unexercised on that front. Say which of the two applies, plainly, rather than implying the
+pipeline is proven end-to-end.
 
 ## Commit discipline
 

--- a/.claude/rules/prefect-pipeline-conventions.md
+++ b/.claude/rules/prefect-pipeline-conventions.md
@@ -91,6 +91,45 @@ guard makes a scheduled run a no-op until the source actually publishes.
 each release, like BLS flat files). No `"replace"`. `source_format="parquet"` is
 supported; `data_path` may be a hive-partitioned directory (`.../year=YYYY/data.parquet`).
 
+### Staging parquet must be all-STRING (current limitation)
+
+`upload_to_gcs` builds the staging table from a one-row header written by
+`gcs.py::dump_header`, and the parquet branch does `.to_pandas().astype(str)` — so
+BigQuery infers **every column as STRING**. Emitting *typed* parquet then fails on read:
+
+```
+Parquet column 'index_value' has type DOUBLE which does not match the
+target cpp_type STRING_PIECE
+```
+
+Until `dump_header` is fixed, a pipeline writing parquet must cast to an all-string
+schema. Two details are load-bearing:
+
+- **Cast via arrow, never `astype(str)`** — the latter renders NULL as the literal
+  `"nan"`, which `safe_cast` will not turn back into NULL.
+- **Pass through the architecture's real types first**, then cast. Otherwise `year`
+  serializes as `"1959.0"` and `safe_cast(year as int64)` yields NULL.
+
+This costs nothing downstream: staging is all-STRING by house convention anyway and the
+dbt model `safe_cast`s every column. `us_bls_cpi/utils.py::write_partitioned` is the
+reference. Note `bigquery-conventions.md` tells you to pin an explicit `pa.Schema` —
+correct for the one-shot onboarding upload, wrong here. → `project_dump_header_parquet_bug`
+
+### One raw data source per table (current limitation)
+
+`client._raw_source_id` resolves the table's raw source via `_query_id`, which **raises
+when a table has 2+ raw sources**:
+
+```
+allRawdatasource: mais de um nó encontrado para {'tables_Id': …}
+```
+
+The poll and commit tasks both go through it, so a table linked to two sources cannot
+run a recurring pipeline at all — it fails at the first poll. The data model permits the
+M2M; the client is over-constrained. Until it is fixed, link each table to exactly **one**
+raw source (the primary one), and note in the dataset's memory that the others should be
+re-linked afterwards. → `project_metadata_multi_raw_source_bug`
+
 ### Coverage domain types (`utils.metadata.domain`)
 
 Build a `CoverageSpec` per table; the `date_column.kind` must match `date_format`:
@@ -241,22 +280,92 @@ my_flow.job_variables = {"memory": "8Gi"}   # optional; size to the clean step's
 ```
 
 Deploy is CI, via `.github/scripts/deploy_flows.py`:
-- Dev pool (`--pool basedosdados-dev`, on PR): schedules **stripped** — manual runs only.
-- Prod pool (`--pool basedosdados --all`, on merge to main): schedules become
-  `Cron` objects; deployed **`paused=True`**, activated by backend sync.
+- **Dev pool** (`cd-prefect3-staging.yaml`, `--pool basedosdados-dev`, on PR):
+  runs **only if the PR carries the `deploy-flow` label** — no label, no deploy, and
+  the job reports `skipped`, not failed. A PR without it deploys **nothing** and
+  looks fine. The workflow triggers on `labeled` and `synchronize`, so adding the
+  label is itself enough. Schedules are **stripped** — manual runs only.
+- **Prod pool** (`cd-prefect3.yaml`, `--pool basedosdados --all`, on merge to main):
+  schedules become `Cron` objects; deployed **`paused=True`**.
 - Cron in `America/Sao_Paulo`; see crontab.guru. For a monthly source, poll across
   a few release-window days — the source-poll guard no-ops until a new period lands.
 
-## Local verification (what you CAN check without infra)
+### Arming is a manual step — merging does NOT start the schedule
+
+Merging deploys to prod **paused**. CI then POSTs `admin-tools/sync-deployments/`,
+which for an **unknown** deployment creates a `DisabledFlowSchedule` row with
+`is_schedule_active=False` — so it **stays paused**. Sync only *enforces* the stored
+state for deployments it already knows; it never arms a new one.
+
+To arm: **https://backend.basedosdados.org/admin/admin_data_tools/disabledflowschedule/**
+→ find `flow_name` → tick `is_schedule_active` → save. The admin's `save_model` calls
+`Prefect3Client().set_paused(deployment_id, paused=False)`, so the tick un-pauses
+Prefect directly; unticking re-pauses it (the kill switch).
+
+Note a paused deployment still shows its schedule as `active=True` — deployment-level
+`paused` wins. Read `paused`, not the schedule flag.
+
+**Before arming, know what the first run does**: it is the first execution of the prod
+upload (`bucket_name="basedosdados"`) and, for `part_bdpro`, of
+`apply_row_access_policies` — i.e. the paywall goes live and the open-data export
+starts excluding the pro window. Neither is exercisable locally. Watch that run.
+
+## Verification — a dev run is part of the job, not a bonus
+
+**Local checks do not tell you whether the pipeline works.** On `us_bls_cpi` they all
+passed while three separate bugs waited in the parts they cannot reach: a raw-source
+link that made the poll raise, typed parquet BigQuery refused, and an upload whose
+staging schema contradicted the data. Each surfaced on the first real run. Do the local
+checks to fail fast, then **run it**.
+
+### 1. Local (fail fast, proves little)
 
 1. **Imports**: `uv run python -c "from pipelines.datasets.<ds> import flows; print(flows.<flow>.name)"`.
 2. **Transform parity**: run `clean_all` on the existing `input/` and assert the
    same row counts as the onboarding validation.
 3. **Download**: fetch one small dimension file via `requests` + the real headers.
 4. **Deploy discovery**: run `deploy_flows.load_flows_from_file("pipelines/datasets/<ds>/flows.py")`
-   and confirm the flow name appears.
-5. The `upload_to_gcs`/`run_dbt`/metadata halves run on the worker — do not expect
-   them to pass locally; state that plainly.
+   and confirm the flow name appears. `load_flows_from_file` **swallows import errors**
+   and returns `{}`, so a broken import means a silent no-deploy.
+5. Pure metadata policy (`compute_coverage_ranges`, `assert_coverage_topology`,
+   `needs_row_access_policy`) is unit-testable — test the window and its roll.
+
+### 2. A real dev run (the actual gate)
+
+Add the **`deploy-flow`** label, wait for `cd-prefect3 (staging)` to report
+`registrado`, then trigger the deployment manually **with prod off**:
+
+```
+parameters = {"materialize_to_prod": False, "update_metadata": False, "force_run": True}
+```
+
+**All three matter.** The flow defaults are `materialize_to_prod=True,
+update_metadata=True` — a run triggered with `{}` writes **prod data, prod metadata,
+and applies the paywall**, from the dev pool, because the metadata tasks are pinned
+`env="prod"` regardless of pool. `force_run=True` bypasses the poll guard, which
+otherwise returns before doing anything.
+
+Done means: every task `COMPLETED`, and the logs show `dbt run OK` **and**
+`dbt test OK` for each table.
+
+### 3. Reading the result — green does not mean it ingested
+
+The poll guard returns early and Prefect still reports **`COMPLETED`**. A dead pipeline
+is indistinguishable from a working one by state alone; `br_ibge_ipca` sat at 4 ingests
+in 60 completed runs unnoticed. To tell them apart, read the logs
+(`Não há novas atualizações na fonte original` = polled, did nothing) or check whether
+the coverage/Update records moved.
+
+Use the `mcp__databasis__*` Prefect tools — `list_flow_runs(flow_name=…)`,
+`get_flow_run_logs(<run_id>)`, `get_failed_flow_runs()`. They speak the Prefect 3 REST
+API; anything pointing at `prefect.basedosdados.org` is the retired Prefect 2 host and
+returns nothing.
+
+### 4. What is NOT verifiable before arming
+
+The prod upload (`bucket_name="basedosdados"`) and `apply_row_access_policies` need the
+worker's rights and run for the first time on the first armed run. Say so plainly rather
+than implying the pipeline is proven end-to-end.
 
 ## Commit discipline
 

--- a/.claude/skills/onboarding-pipeline.md
+++ b/.claude/skills/onboarding-pipeline.md
@@ -24,9 +24,10 @@ force_run=True`; the defaults would write prod and apply the paywall). Done mean
 `dbt run OK` + `dbt test OK` per table, read from the logs — a green state alone
 proves nothing, since the poll guard returns early and still reports `COMPLETED`.
 
-The prod upload and the Row Access Policies only run once the schedule is armed
-(a manual tick in Django admin — merging does **not** arm it), so the agent says
-plainly that those remain unexercised.
+The prod upload only runs once the schedule is armed (a manual tick in Django
+admin — merging does **not** arm it), and the Row Access Policies only if a table
+is `part_bdpro` — an all-free pipeline never issues them. The agent says plainly
+which of those remain unexercised.
 
 It also sets the **BD Pro rolling window**: any table refreshing monthly or more
 often gets `PartBdpro` (default `free_lag=6 months`) so its recent window is

--- a/.claude/skills/onboarding-pipeline.md
+++ b/.claude/skills/onboarding-pipeline.md
@@ -13,12 +13,20 @@ references, confirms the shared `pipelines/utils` signatures, and writes
 `prefect-pipeline-conventions`.
 
 It shares the cleaning transform with `models/<dataset_id>/code/` (no
-duplication), sets an inline schedule with a source-poll guard, and verifies
-locally what can be verified (imports, transform parity, download, deploy
-discovery). The upload/dbt/metadata halves run on the deployed Prefect worker
-(dev pool on PR **only when the PR carries the `deploy-flow` label**; prod pool
-on merge with schedule), so they are not exercised locally — the agent says so
-explicitly.
+duplication) and sets an inline schedule with a source-poll guard.
+
+**It is not done until the flow has actually run.** Local checks (imports,
+transform parity, download, deploy discovery) fail fast but reach none of the
+parts that break. The agent adds the **`deploy-flow`** label — without it the
+staging deploy is `skipped` and nothing deploys, silently — and triggers a dev-pool
+run with prod off (`materialize_to_prod=False, update_metadata=False,
+force_run=True`; the defaults would write prod and apply the paywall). Done means
+`dbt run OK` + `dbt test OK` per table, read from the logs — a green state alone
+proves nothing, since the poll guard returns early and still reports `COMPLETED`.
+
+The prod upload and the Row Access Policies only run once the schedule is armed
+(a manual tick in Django admin — merging does **not** arm it), so the agent says
+plainly that those remain unexercised.
 
 It also sets the **BD Pro rolling window**: any table refreshing monthly or more
 often gets `PartBdpro` (default `free_lag=6 months`) so its recent window is


### PR DESCRIPTION
Building the first recurring pipeline surfaced ten things step 12 did not say —
one of which it said wrongly.

**Corrected a false claim.** The rule said prod deploys are "activated by backend
sync". They are not: sync registers an unknown deployment with
is_schedule_active=False and it stays paused. Arming is a manual tick in Django
admin (/admin/admin_data_tools/disabledflowschedule/), which calls
set_paused(False) on Prefect. An agent trusting the old text would report a
pipeline live while it sat inert.

**The `deploy-flow` label.** cd-prefect3-staging only runs if the PR carries it;
without it the job reports `skipped` and nothing deploys. This was documented in
the skill but not the rule or the agent, and its absence is why us_bls_cpi
silently deployed nothing.

**A dev run is now the definition of done.** Local checks (imports, transform
parity, deploy discovery) all passed on us_bls_cpi while three separate bugs sat
in the parts they cannot reach — the raw-source link, the parquet types, the
staging schema. Each appeared on the first real run. Step 12, the agent and the
skill now require a dev-pool run with
{"materialize_to_prod": False, "update_metadata": False, "force_run": True} and
`dbt run OK` + `dbt test OK` in the logs.

That parameter set is not incidental: the defaults are True/True, and the metadata
tasks are pinned env="prod" even from the dev pool, so a run triggered with {}
writes prod data and metadata and applies the paywall.

**Green != ingested.** The poll guard returns early and Prefect still reports
COMPLETED, which is how br_ibge_ipca reached 4 ingests in 60 completed runs
unnoticed. Documented how to tell them apart, via the (now working)
mcp__databasis__ Prefect tools.

**Two current limitations, with pointers** rather than as rules, since both
disappear when the underlying bug is fixed:
- staging parquet must be all-STRING (dump_header stringifies the header, so typed
  parquet dies on cpp_type STRING_PIECE) → project_dump_header_parquet_bug
- exactly one raw source per table (_query_id raises on 2+, so the poll cannot run)
  → project_metadata_multi_raw_source_bug

bigquery-conventions told you to pin an explicit pa.Schema, which contradicts the
first of those; reconciled with an explicit exception for the pipeline path.

**metadata-schema:** backend list queries silently truncate — first: 400 returns
400, first: 1500 returns 1500 with hasNextPage still true, real total 1603. Any
audit must cursor-paginate; a round count is a truncated count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded onboarding and deployment guidance for recurring data pipelines.
  * Added end-to-end verification steps, including staging deployment labels, log checks, and dev execution parameters.
  * Documented safeguards for production activation, including paused schedules and manual arming.
  * Clarified Parquet schema handling and NULL preservation for pipeline uploads.
  * Added cursor-pagination guidance to prevent silently truncated metadata results.
  * Documented limitations involving raw-source configuration and poll-guard completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->