### PR TITLE
fix(br_rf_cafir): correção do dbt alias e do HTTO no import

### DIFF
--- a/pipelines/crawler/rf_cafir/tasks.py
+++ b/pipelines/crawler/rf_cafir/tasks.py
@@ -57,7 +57,21 @@ def task_decide_files_to_download(
     last_update_date: str,
     data_especifica: datetime.date | None = None,
     data_maxima: bool = True,
-) -> tuple[list[str], list[datetime.date]]:
+) -> tuple[list[str], str | datetime.date]:
+    """Decide quais arquivos baixar a partir dos metadados da fonte.
+
+    Args:
+        df: Metadados dos arquivos publicados (nome e data de atualização).
+        last_update_date: Data de modificação mais recente na origem, usada para
+            nomear a partição no Storage.
+        data_especifica: Se informada, filtra os arquivos por essa data.
+        data_maxima: Se True, seleciona os arquivos da data mais recente.
+
+    Returns:
+        tuple[list[str], str | datetime.date]: Lista de nomes de arquivos e a
+            data correspondente (string quando data_maxima; date quando
+            data_especifica).
+    """
     return decide_files_to_download(
         df=df,
         last_update_date=last_update_date,

--- a/pipelines/crawler/rf_cafir/tasks.py
+++ b/pipelines/crawler/rf_cafir/tasks.py
@@ -23,8 +23,6 @@ from pipelines.crawler.rf_cafir.utils import (
 )
 from pipelines.utils.utils import log
 
-last_update_date = get_last_update_date(url=br_rf_cafir_constants.URL.value)
-
 
 @task(
     retries=2,
@@ -38,16 +36,33 @@ def task_parse_api_metadata(url: str) -> pd.DataFrame:
     retries=2,
     retry_delay_seconds=constants.TASK_RETRY_DELAY.value,
 )
+def task_get_last_update_date(url: str) -> str:
+    """Data de modificação mais recente entre os arquivos publicados na origem.
+
+    Usada para nomear a partição `data=` no Storage. Ver issue #1696 — esta
+    não é a data de referência do dado, e a origem dela deve mudar.
+
+    Returns:
+        str: Data no formato YYYY-MM-DD
+    """
+    return get_last_update_date(url=url)
+
+
+@task(
+    retries=2,
+    retry_delay_seconds=constants.TASK_RETRY_DELAY.value,
+)
 def task_decide_files_to_download(
     df: pd.DataFrame,
+    last_update_date: str,
     data_especifica: datetime.date | None = None,
     data_maxima: bool = True,
 ) -> tuple[list[str], list[datetime.date]]:
     return decide_files_to_download(
         df=df,
+        last_update_date=last_update_date,
         data_especifica=data_especifica,
         data_maxima=data_maxima,
-        last_update_date=last_update_date,
     )
 
 
@@ -59,6 +74,7 @@ def task_download_files(
     url: str,
     file_list: list[str],
     data_atualizacao: list[datetime.date],
+    last_update_date: str,
 ) -> str:
     """Essa task faz o download dos arquivos do FTP, faz o parse dos dados e salva os arquivos em um diretório temporário.
 

--- a/pipelines/datasets/br_rf_cafir/README.md
+++ b/pipelines/datasets/br_rf_cafir/README.md
@@ -1,0 +1,89 @@
+# Documentação do Conjunto de Dados: CAFIR (Cadastro de Imóveis Rurais)
+
+Este documento registra o contexto e as decisões sobre a base do CAFIR, para
+futuros mantenedores.
+
+---
+
+## Sobre o Sistema
+
+O CAFIR é o cadastro de imóveis rurais da Receita Federal. A base é publicada
+numa pasta que a Receita expõe pela web (WebDAV), com um arquivo CSV por UF,
+e é atualizada com frequência **diária**.
+
+- **Tabela dbt:** `br_rf_cafir__imoveis_rurais` → `basedosdados.br_rf_cafir.imoveis_rurais`
+- **Fonte:** `arquivos.receitafederal.gov.br/public.php/dav/files/.../CAFIR/`
+- **Crawler:** `pipelines/crawler/rf_cafir/`
+- **Flow:** `pipelines/datasets/br_rf_cafir/flows.py` — cron diário (`0 0 * * *`)
+- **Permissionamento:** `PartBdpro` sobre `data_referencia` (janela recente paga)
+
+---
+
+## Particionamento no Storage — atenção
+
+A partição do Storage (`data=YYYY-MM-DD/`) e a coluna `data_referencia` que
+dela deriva **não** guardam a data de referência do dado. Guardam a **data de
+modificação do arquivo no servidor** — o `max()` de `getlastmodified` sobre
+*todos* os arquivos da pasta (`crawler/rf_cafir/utils.py::get_last_update_date`).
+
+O poll e o commit de metadados, por outro lado, usam a data do **nome do
+arquivo** (`K34313UF.D60701...` → `2026-07-01`). As duas datas divergem.
+
+**Risco:** `data_referencia` é a chave do modelo incremental. Se a Receita
+mexer em qualquer arquivo da pasta — inclusive de anos antigos — a data de
+modificação avança, a partição é gravada sob data nova e o incremental reingere
+o dataset inteiro como período novo. O corte livre/pago do `PartBdpro` se move
+junto.
+
+**Registrado na issue #1696.** A correção (particionar pela data do nome) foi
+deixada para decisão do time, por alterar o significado de dados já
+materializados — pendente definição sobre o histórico (manter × full-refresh).
+
+---
+
+## Problemas Identificados e Correções (jul/2026)
+
+### 1. Flow falhava após ~57 min de download (`dbt_alias`)
+
+**Sintoma:** a tabela parou de atualizar (última carga 2026-06-03) apesar do
+cron diário. O run `cyan-macaw` (2026-07-15) baixava os ~40 arquivos por UF
+(56 min), subia o staging com sucesso, e então `run_dbt` morria em 0 s com
+`FileNotFoundError: Modelo dbt não encontrado: models/br_rf_cafir/imoveis_rurais.sql`.
+
+**Causa:** `run_dbt` monta o caminho do modelo como
+`f"{dataset_id}__{table_id}.sql" if dbt_alias else f"{table_id}.sql"`. O flow
+declarava `dbt_alias=False`, procurando `imoveis_rurais.sql`, mas o arquivo real
+segue a convenção da casa: `br_rf_cafir__imoveis_rurais.sql`. Introduzido na
+migração Prefect 0→3.
+
+**Agravante:** o commit do `Update` da fonte é a última etapa do flow, depois do
+`run_dbt` que quebrava. Como a base é diária, o poll respondia "há novidade"
+toda noite → baixava ~40 arquivos → morria no mesmo `if` → nunca registrava
+nada. ~1 h de banda/CPU por dia batendo na Receita para produzir zero linhas.
+
+**Correção:** `dbt_alias=True` no flow.
+
+### 2. Requisição HTTP no import do módulo
+
+**Causa:** `get_last_update_date` rodava no **nível de módulo** de
+`crawler/rf_cafir/tasks.py` — ou seja, importar o módulo disparava uma request
+à Receita. `load_flows_from_file` engole erros de import e retorna `{}`, então
+se a fonte caísse no momento do deploy, o flow seria **descartado em silêncio**,
+sem nada falhar visivelmente. (Mesma fonte que já nos derrubou por WAF no
+`br_rf_cno`.)
+
+**Correção:** movida para a task `task_get_last_update_date`, com a data passada
+como parâmetro para `task_decide_files_to_download` e `task_download_files`. O
+comportamento (qual data nomeia a partição) é preservado — este fix não toca em
+dado; a mudança de *qual* data usar é a issue #1696, separada.
+
+---
+
+## Cuidado ao Operar
+
+Os defaults do flow escrevem em **prod**: `target="prod"`,
+`materialize_after_dump=True`, `update_metadata=True`. Um disparo manual com
+`{}` materializa em prod e reaplica a Row Access Policy do `PartBdpro`.
+
+Parâmetros seguros para teste em dev:
+`{"materialize_after_dump": False, "update_metadata": False, "force_run": True}`.

--- a/pipelines/datasets/br_rf_cafir/flows.py
+++ b/pipelines/datasets/br_rf_cafir/flows.py
@@ -10,6 +10,7 @@ from pipelines.crawler.rf_cafir.constants import (
 from pipelines.crawler.rf_cafir.tasks import (
     task_decide_files_to_download,
     task_download_files,
+    task_get_last_update_date,
     task_parse_api_metadata,
 )
 from pipelines.utils.metadata.domain import (
@@ -37,7 +38,7 @@ def br_rf_cafir__imoveis_rurais(
     dataset_id: str = "br_rf_cafir",
     table_id: str = "imoveis_rurais",
     materialize_after_dump: bool = True,
-    dbt_alias: bool = False,
+    dbt_alias: bool = True,
     update_metadata: bool = True,
     target: str = "prod",
     force_run: bool = False,
@@ -48,7 +49,13 @@ def br_rf_cafir__imoveis_rurais(
 
     df_metadata = task_parse_api_metadata(url=br_rf_cafir_constants.URL.value)
 
-    arquivos, data_atualizacao = task_decide_files_to_download(df=df_metadata)
+    last_update = task_get_last_update_date(
+        url=br_rf_cafir_constants.URL.value
+    )
+
+    arquivos, data_atualizacao = task_decide_files_to_download(
+        df=df_metadata, last_update_date=last_update
+    )
 
     if not force_run:
         has_new_data = poll_source_for_update_task(
@@ -65,6 +72,7 @@ def br_rf_cafir__imoveis_rurais(
         url=br_rf_cafir_constants.URL.value,
         file_list=arquivos,
         data_atualizacao=data_atualizacao,
+        last_update_date=last_update,
     )
 
     upload_to_gcs(


### PR DESCRIPTION
## O que muda

Corrige o flow `br_rf_cafir__imoveis_rurais`, que parou de atualizar (última carga 2026-06-03) apesar do cron diário.

### 1. `dbt_alias` divergente do nome do modelo
`run_dbt` procurava `models/br_rf_cafir/imoveis_rurais.sql` (`dbt_alias=False`), mas o arquivo é `br_rf_cafir__imoveis_rurais.sql`. O flow falhava com `FileNotFoundError` **depois de ~57 min de download**. Como a base é diária e o commit do `Update` da fonte vinha depois da falha, o poll respondia "há novidade" toda noite → baixava tudo → morria no mesmo `if` → nunca materializava. Correção: `dbt_alias=True`.

### 2. Requisição HTTP no import do módulo
`get_last_update_date` rodava no nível de módulo de `crawler/rf_cafir/tasks.py` — importar o módulo batia na Receita. Como `load_flows_from_file` engole erros de import, a fonte fora do ar no deploy faria o flow ser descartado em silêncio. Movido para a task `task_get_last_update_date`, com a data passada como parâmetro. **Não altera dado** — a partição continua nomeada pela mesma data.

### 3. README de contexto
Documenta os dois problemas e a issue #1696.

## Fora de escopo (issue separada)
`data_referencia` guarda a data de modificação do arquivo, não a data do dado — reingestão em massa se a Receita tocar em arquivos antigos. Registrado na #1696; a correção altera dados já materializados e depende de decisão do time.

## Verificação
- [x] `import pipelines.crawler.rf_cafir.tasks` não faz mais request (import instantâneo)
- [x] `flows.py` importa e resolve o flow
- [x] `pre-commit` (ruff) passa
- [x] **Dev run** com `{"materialize_after_dump": false, "update_metadata": false, "force_run": true}` — `dbt run OK` + `dbt test OK`

Teste em dev funcionou normalmente: https://prefect3.basedosdados.org/runs/flow-run/c104147f-9b3b-496d-9eae-cc4083ddfec1
