### PR TITLE
chore(world_dasanaike_sage): re-materialize SAGE tables in prod

### DIFF
--- a/models/world_dasanaike_sage/world_dasanaike_sage__dicionario.sql
+++ b/models/world_dasanaike_sage/world_dasanaike_sage__dicionario.sql
@@ -1,3 +1,5 @@
+-- Reads staging rows built by models/world_dasanaike_sage/code/ (download.py ->
+-- clean.py -> upload.py).
 {{
     config(
         schema="world_dasanaike_sage",

--- a/models/world_dasanaike_sage/world_dasanaike_sage__election_returns.sql
+++ b/models/world_dasanaike_sage/world_dasanaike_sage__election_returns.sql
@@ -1,3 +1,5 @@
+-- Reads staging rows built by models/world_dasanaike_sage/code/ (download.py ->
+-- clean.py -> upload.py).
 {{
     config(
         schema="world_dasanaike_sage",

--- a/models/world_dasanaike_sage/world_dasanaike_sage__germany_erststimme.sql
+++ b/models/world_dasanaike_sage/world_dasanaike_sage__germany_erststimme.sql
@@ -1,3 +1,5 @@
+-- Reads staging rows built by models/world_dasanaike_sage/code/ (download.py ->
+-- clean.py -> upload.py).
 {{
     config(
         schema="world_dasanaike_sage",

--- a/models/world_dasanaike_sage/world_dasanaike_sage__netherlands_preference_votes.sql
+++ b/models/world_dasanaike_sage/world_dasanaike_sage__netherlands_preference_votes.sql
@@ -1,3 +1,5 @@
+-- Reads staging rows built by models/world_dasanaike_sage/code/ (download.py ->
+-- clean.py -> upload.py).
 {{
     config(
         schema="world_dasanaike_sage",

--- a/models/world_dasanaike_sage/world_dasanaike_sage__spatial_admin_crosswalk.sql
+++ b/models/world_dasanaike_sage/world_dasanaike_sage__spatial_admin_crosswalk.sql
@@ -1,3 +1,5 @@
+-- Reads staging rows built by models/world_dasanaike_sage/code/ (download.py ->
+-- clean.py -> upload.py).
 {{
     config(
         schema="world_dasanaike_sage",


### PR DESCRIPTION
## Why

`basedosdados.world_dasanaike_sage` is live with metadata but **empty** — 0 tables in prod, while dev has all 5 populated (`election_returns` 284.3M rows, `netherlands_preference_votes` 30.7M, `spatial_admin_crosswalk` 4.9M, `germany_erststimme` 6.0k, `dicionario` 11).

The `table-approve` run for #1656 ([29301280567](https://github.com/basedosdados/pipelines/actions/runs/29301280567), 2026-07-14) synced prod staging for all 5 tables, then launched the Prefect materialization flow for the first table (`dicionario`), which died immediately with `FileNotFoundError: Modelo dbt não encontrado: models/world_dasanaike_sage/world_dasanaike_sage__dicionario.sql`. The worker was running code checked out from the `pipelines-feat-dbt-fusion` branch, which predates the merge — so none of the 5 models existed on it and the run aborted before building any table. The worker issue is fixed since (the `in_tcpd_elections` run on 2026-07-15 succeeded); this PR just re-triggers materialization.

## What

Adds a one-line provenance comment header to the 5 models from #1656. The diff contains **only** `models/world_dasanaike_sage/**.sql`, so the selector maps it to exactly the 5 missing tables — no phantoms (same pattern as #1702 for `us_census_cbp`).

Prod staging (`basedosdados-staging.world_dasanaike_sage_staging`) already holds the data from the failed run; the models will re-sync and materialize on merge.

## Checklist

- [x] Diff restricted to `models/**.sql` (5 files, comment-only)
- [x] `dbt ls --select world_dasanaike_sage` parses — 5 models found
- [x] `table-approve` label applied (required, or nothing is materialized)
- [ ] After merge: verify `table-approve` run is green and `basedosdados.world_dasanaike_sage` has 5 tables with dev-matching row counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated documentation describing the data preparation pipeline and staging data sources.
  * Clarified the flow from downloading and cleaning source data through to uploading staging records.
  * Corrected pipeline references across multiple data models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->