### PR TITLE
[Docs] onboarding: create datasets as under_review, publish only post-merge

### DIFF
--- a/.claude/rules/metadata-schema.md
+++ b/.claude/rules/metadata-schema.md
@@ -15,6 +15,18 @@ All backend operations use the `mcp__databasis__*` MCP tools. Never write raw HT
 
 Default: `dev`. Only switch to `prod` after explicit user approval.
 
+## Dataset status lifecycle (create `under_review`, publish only post-merge)
+
+**Always create a dataset with `status_id = status.under_review`, never `status.published`** — at every stage (dev/staging and prod alike). `under_review` hides the dataset from the production frontend, so metadata registered before the onboarding PR merges (with prod cloud tables that do not yet exist) cannot leak publicly.
+
+Flip the dataset to `status.published` **only after all three hold**:
+
+1. the onboarding **PR is merged** to `main`;
+2. the GitHub **table-approve action has run successfully** (it materialises `basedosdados.<gcp_dataset_id>.*` via `dbt --target prod`);
+3. the live prod tables **and** metadata are **verified** — row counts match, cloud tables resolve, `get_dataset(slug, env="prod")` shows the expected shape.
+
+Publishing is one call: `create_update_dataset(id=<dataset_id>, …, status_id=status.published, env="prod")` (re-pass every required field — no partial updates). Do this as a **separate post-merge action**, never inside the onboarding PR. Tables are gated by the dataset's status, so they may stay `status.published`; flipping the dataset publishes everything in one step.
+
 ## ID resolution (always run first)
 
 Before registering any metadata, resolve all reference IDs with:
@@ -66,7 +78,7 @@ For individual lookups: `mcp__databasis__lookup_id(env=<env>, slug=<slug>, type=
 | `organization_ids` | list | From `discover_ids` using org slug(s) |
 | `theme_ids` | list | From `discover_ids` |
 | `tag_ids` | list | From `discover_ids`; empty list if none |
-| `status_id` | string | Use `status.published` |
+| `status_id` | string | **`status.under_review` on creation** — flip to `status.published` only post-merge (see "Dataset status lifecycle" above) |
 | `id` | string | Pass when updating an existing record |
 
 ## `create_update_table` fields
@@ -77,7 +89,7 @@ For individual lookups: `mcp__databasis__lookup_id(env=<env>, slug=<slug>, type=
 | `name_pt/en/es` | string | All 3 languages |
 | `description_pt/en/es` | string | 1–3 sentences |
 | `dataset_id` | string | From dataset step |
-| `status_id` | string | `status.published` |
+| `status_id` | string | `status.published` — tables are gated by the dataset's `under_review` status, so they may stay published (see "Dataset status lifecycle") |
 | `published_by_ids` | list | Authenticated account ID |
 | `data_cleaned_by_ids` | list | Authenticated account ID |
 | `id` | string | Pass when updating |

--- a/.claude/rules/onboarding-workflow.md
+++ b/.claude/rules/onboarding-workflow.md
@@ -15,11 +15,13 @@ Work through steps in order. Do not skip steps.
 6.  dbt                  write .sql and schema.yml files
 7.  validate             run DBT tests and data quality checks; fix or flag errors
 8.  discover             resolve all reference IDs from backend (dev)
-9.  metadata             register metadata in dev backend
+9.  metadata             register metadata in dev backend (dataset status = under_review)
 [PAUSE — verification checkpoint]
-10. metadata --env prod  promote to prod (only after human approval)
+10. metadata --env prod  promote to prod (dataset status = under_review; only after human approval)
 11. pr                   open PR with changelog
 12. pipeline             recurring sources only — add a Prefect refresh pipeline
+[PR MERGES + GH table-approve action runs + prod tables verified]
+13. publish              flip the prod dataset status under_review → published
 ```
 
 ## Step 12 — recurring pipeline (only for sources that update on a cadence)
@@ -99,6 +101,18 @@ Reply "approved" to promote to prod, or describe what needs fixing.
 ```
 
 Do not proceed to step 10 without the user replying "approved" (or equivalent).
+
+## Dataset status lifecycle (create `under_review`, publish only post-merge)
+
+**Every dataset is created with `status = under_review`, at every stage — dev/staging in step 9 and prod in step 10, never `published`.** `under_review` hides the dataset from the production frontend, so a dataset whose metadata is registered before its PR lands (and whose prod cloud tables do not yet exist) cannot leak publicly.
+
+Turn the dataset to `status = published` **only in step 13, and only after all three hold**:
+
+1. the onboarding **PR is merged** to `main`;
+2. the GitHub **table-approve action has run successfully** (it materialises `basedosdados.<gcp_dataset_id>.*` via `dbt --target prod`; watch for the phantom-model failure mode where non-model `.sql` in the PR aborts materialisation before any real table builds);
+3. the live prod tables **and** metadata are **verified** — row counts match, cloud tables resolve, and `get_dataset(slug, env="prod")` shows the expected shape.
+
+Publishing is one call: `create_update_dataset(id=<dataset_id>, …, status_id=status.published, env="prod")` (re-pass every required field — the API does no partial updates). It is a **separate post-merge action**, independent of the optional recurring-pipeline step (12); never publish inside the onboarding PR, and never publish a dataset whose PR has not merged and materialised. Tables are gated by the dataset's status, so they may remain `published`; flipping the dataset makes everything go live in one step.
 
 ## Commit discipline
 


### PR DESCRIPTION
## Descrição do PR

Torna explícito no fluxo de onboarding agêntico que **todo dataset é criado com `status = under_review`** (em dev/staging e em prod), e só passa a `status = published` **depois** que o PR de onboarding é mergeado, a **GitHub table-approve action** materializa `basedosdados.<gcp_dataset_id>.*` com sucesso, e as tabelas + metadados de prod são verificados.

**Motivação/Contexto:** um dataset registrado no backend de prod antes do PR mergear (e cujas cloud tables de prod ainda não existem) ficava visível no frontend de produção. `under_review` esconde o dataset até que tudo esteja materializado e verificado, eliminando esse vazamento.

## Detalhes Técnicos

Apenas documentação do fluxo (instruções lidas pelos agentes de onboarding) — nenhuma mudança de código, dado ou schema.

- **`.claude/rules/onboarding-workflow.md`**
  - Sequência de passos: passos 9/10 anotam `dataset status = under_review`; novo **passo 13 · publish** (flip `under_review → published`) após o merge do PR + table-approve + verificação.
  - Nova seção **"Dataset status lifecycle"** com os três pré-requisitos do flip e a chamada exata (`create_update_dataset(..., status_id=status.published, env="prod")`), marcada como ação **separada, pós-merge** e independente do passo opcional de pipeline (12).
- **`.claude/rules/metadata-schema.md`**
  - Mesma seção "Dataset status lifecycle".
  - Célula `status_id` de `create_update_dataset` passa de "Use `status.published`" para **`status.under_review` na criação**.
  - Célula `status_id` de `create_update_table` esclarece que tabelas continuam `published` (a visibilidade é controlada pelo status do dataset).

## Teste e Validações

- [x] Testado localmente (só docs; pré-commit hooks passam)
- [ ] Testado na Cloud (não aplicável)

Política já aplicada na prática no onboarding do `us_census_cps` (#1709): dataset de prod criado como `under_review` e, portanto, invisível no site até o merge.

## Riscos e Mitigações

- **Riscos conhecidos:** nenhum — mudança apenas de instruções.
- **Planos de rollback:** reverter este PR.

## Dependências
- [x] Nenhuma dependência adicional.
