### PR TITLE
[Data] world_cricsheet: Cricsheet ball-by-ball global cricket

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -121,6 +121,9 @@ models:
     us_congress_legislators:
       +materialized: table
       +schema: us_congress_legislators
+    world_cricsheet:
+      +materialized: table
+      +schema: world_cricsheet
     br_bd_indicadores:
       +materialized: table
       +schema: br_bd_indicadores

--- a/models/world_cricsheet/code/architecture/deliveries.csv
+++ b/models/world_cricsheet/code/architecture/deliveries.csv
@@ -1,0 +1,29 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,"Ano da partida, derivado da data de início",,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Derivado de start_date,start_date
+match_id,STRING,Identificador único da partida,,no,,,no,,match_id
+season,STRING,Temporada da partida no formato de ano ou intervalo de anos,,no,,,no,Ex.: 2011/12,season
+start_date,DATE,Data de início da partida,,no,,,no,,start_date
+venue,STRING,Nome do estádio ou local onde a partida foi disputada,,no,,,no,,venue
+innings,STRING,Número do turno de rebatidas na partida,,no,,,no,Ordinal de 1 a 4; não deve ser somado,innings
+ball,STRING,Identificador da bola no formato over.bola,,no,,,no,"Ex.: 0.1 corresponde ao over 0, bola 1",ball
+actual_delivery,STRING,Número da entrega efetivamente disputada no over,,no,,,no,,actual_delivery
+batting_team,STRING,Nome da equipe que está rebatendo,,no,,,no,,batting_team
+bowling_team,STRING,Nome da equipe que está arremessando,,no,,,no,,bowling_team
+striker,STRING,Nome do rebatedor que enfrenta a bola,,no,,,no,,striker
+non_striker,STRING,Nome do rebatedor na outra extremidade do campo,,no,,,no,,non_striker
+bowler,STRING,Nome do arremessador que entrega a bola,,no,,,no,,bowler
+runs_off_bat,INT64,Corridas marcadas pela rebatida do batedor nesta bola,,no,,run,no,,runs_off_bat
+extras,INT64,Total de corridas extras concedidas nesta bola,,no,,run,no,,extras
+wides,INT64,Corridas concedidas por bola larga (wide) nesta bola,,no,,run,no,,wides
+noballs,INT64,Corridas concedidas por bola inválida (no-ball) nesta bola,,no,,run,no,,noballs
+byes,INT64,Corridas concedidas por byes nesta bola,,no,,run,no,,byes
+legbyes,INT64,Corridas concedidas por leg byes nesta bola,,no,,run,no,,legbyes
+penalty,INT64,Corridas de penalidade concedidas nesta bola,,no,,run,no,,penalty
+non_boundary,STRING,Indicador de que as corridas não vieram de uma fronteira,,no,,,no,Flag 0/1; rótulos documentados em cricsheet.org,non_boundary
+wicket_type,STRING,Tipo de eliminação (wicket) registrada nesta bola,,no,,,no,Rótulos documentados em cricsheet.org,wicket_type
+player_dismissed,STRING,Nome do jogador eliminado nesta bola,,no,,,no,,player_dismissed
+other_wicket_type,STRING,Tipo da segunda eliminação registrada na mesma bola,,no,,,no,Rótulos documentados em cricsheet.org,other_wicket_type
+other_player_dismissed,STRING,Nome do segundo jogador eliminado na mesma bola,,no,,,no,,other_player_dismissed
+fielder_1,STRING,Nome do primeiro defensor envolvido na eliminação,,no,,,no,,fielder_1
+fielder_2,STRING,Nome do segundo defensor envolvido na eliminação,,no,,,no,,fielder_2
+fielder_3,STRING,Nome do terceiro defensor envolvido na eliminação,,no,,,no,,fielder_3

--- a/models/world_cricsheet/code/architecture/match_players.csv
+++ b/models/world_cricsheet/code/architecture/match_players.csv
@@ -1,6 +1,6 @@
 name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
 year,INT64,"Ano da partida, derivado da data de início",,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Derivado de start_date,start_date
 match_id,STRING,Identificador único da partida,,no,,,no,"Grão de uma linha por match_id, equipe e jogador (~500 mil linhas)",match_id
-team,STRING,Nome da equipe do jogador na partida,,no,,,no,,team
-player,STRING,Nome do jogador conforme aparece na partida,,no,,,no,,player
-player_identifier,STRING,Identificador único do jogador resolvido pelo registro,,no,,,no,Resolvido pelas linhas de registro por partida; vazio se não resolvido,player_identifier
+team_name,STRING,Nome da equipe do jogador na partida,,no,,,no,,team
+player_name,STRING,Nome do jogador conforme aparece na partida,,no,,,no,,player
+person_id,STRING,Identificador único do jogador resolvido pelo registro,,no,,,no,Resolvido pelas linhas de registro por partida; vazio se não resolvido,player_identifier

--- a/models/world_cricsheet/code/architecture/match_players.csv
+++ b/models/world_cricsheet/code/architecture/match_players.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,"Ano da partida, derivado da data de início",,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Derivado de start_date,start_date
+match_id,STRING,Identificador único da partida,,no,,,no,"Grão de uma linha por match_id, equipe e jogador (~500 mil linhas)",match_id
+team,STRING,Nome da equipe do jogador na partida,,no,,,no,,team
+player,STRING,Nome do jogador conforme aparece na partida,,no,,,no,,player
+player_identifier,STRING,Identificador único do jogador resolvido pelo registro,,no,,,no,Resolvido pelas linhas de registro por partida; vazio se não resolvido,player_identifier

--- a/models/world_cricsheet/code/architecture/matches.csv
+++ b/models/world_cricsheet/code/architecture/matches.csv
@@ -1,0 +1,34 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,"Ano da partida, derivado da data de início",,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Derivado de start_date,start_date
+match_id,STRING,Identificador único da partida,,no,,,no,Chave lógica da tabela,match_id
+season,STRING,Temporada da partida no formato de ano ou intervalo de anos,,no,,,no,Ex.: 2011/12,season
+start_date,DATE,Data de início da partida,,no,,,no,Data mínima entre as datas registradas,date
+end_date,DATE,Data de encerramento da partida,,no,,,no,Data máxima entre as datas registradas,date
+match_type,STRING,Tipo de partida,,no,,,no,"T20, ODI, Test, IT20, ODM, MDM",match_type
+team_type,STRING,Tipo de equipe,,no,,,no,Internacional ou clube,team_type
+gender,STRING,Gênero das equipes participantes,,no,,,no,,gender
+event,STRING,Nome do torneio ou evento da partida,,no,,,no,,event
+match_number,STRING,Número da partida dentro do evento,,no,,,no,"Identificador, não quantidade",match_number
+balls_per_over,INT64,Número de bolas por over,,no,,ball,no,,balls_per_over
+overs,INT64,Número máximo de overs por turno,,no,,over,no,Vazio para partidas do tipo Test,overs
+venue,STRING,Nome do estádio ou local da partida,,no,,,no,,venue
+city,STRING,Cidade onde a partida foi disputada,,no,,,no,,city
+team1,STRING,Nome da primeira equipe,,no,,,no,,team
+team2,STRING,Nome da segunda equipe,,no,,,no,,team
+toss_winner,STRING,Nome da equipe que venceu o sorteio inicial,,no,,,no,,toss_winner
+toss_decision,STRING,Decisão da equipe vencedora do sorteio,,no,,,no,Rebater ou arremessar,toss_decision
+player_of_match,STRING,Nome do jogador eleito melhor da partida,,no,,,no,,player_of_match
+winner,STRING,Nome da equipe vencedora,,no,,,no,,winner
+outcome,STRING,Resultado da partida sem vencedor definido,,no,,,no,"Empate (draw), empate técnico (tie) ou sem resultado (no result)",outcome
+winner_runs,INT64,Margem de vitória em corridas,,no,,run,no,,winner_runs
+winner_wickets,INT64,Margem de vitória em wickets,,no,,wicket,no,,winner_wickets
+winner_innings,STRING,Indicador de vitória por turno (innings),,no,,,no,Flag 0/1,winner_innings
+method,STRING,Método aplicado para definir o resultado,,no,,,no,Ex.: D/L (Duckworth-Lewis),method
+target_runs,INT64,Meta de corridas para a equipe que rebate por último,,no,,run,no,,target_runs
+target_overs,INT64,Número de overs disponíveis para atingir a meta,,no,,over,no,,target_overs
+neutral_venue,STRING,Indicador de local neutro,,no,,,no,Flag 0/1,neutral_venue
+umpire1,STRING,Nome do primeiro árbitro,,no,,,no,,umpire
+umpire2,STRING,Nome do segundo árbitro,,no,,,no,,umpire
+tv_umpire,STRING,Nome do árbitro de vídeo,,no,,,no,,tv_umpire
+reserve_umpire,STRING,Nome do árbitro reserva,,no,,,no,,reserve_umpire
+match_referee,STRING,Nome do juiz da partida,,no,,,no,,match_referee

--- a/models/world_cricsheet/code/architecture/people.csv
+++ b/models/world_cricsheet/code/architecture/people.csv
@@ -1,0 +1,23 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+identifier,STRING,Identificador único da pessoa no Cricsheet,,no,,,no,Chave lógica da tabela,identifier
+name,STRING,Nome da pessoa,,no,,,no,,name
+unique_name,STRING,Nome único usado para desambiguação de homônimos,,no,,,no,,unique_name
+key_bcci,STRING,Identificador da pessoa na fonte BCCI,,no,,,no,,key_bcci
+key_bcci_2,STRING,Segundo identificador da pessoa na fonte BCCI,,no,,,no,,key_bcci_2
+key_bigbash,STRING,Identificador da pessoa na fonte Big Bash,,no,,,no,,key_bigbash
+key_cricbuzz,STRING,Identificador da pessoa na fonte Cricbuzz,,no,,,no,,key_cricbuzz
+key_cricheroes,STRING,Identificador da pessoa na fonte CricHeroes,,no,,,no,,key_cricheroes
+key_crichq,STRING,Identificador da pessoa na fonte CricHQ,,no,,,no,,key_crichq
+key_cricinfo,STRING,Identificador da pessoa na fonte ESPNcricinfo,,no,,,no,,key_cricinfo
+key_cricinfo_2,STRING,Segundo identificador da pessoa na fonte ESPNcricinfo,,no,,,no,,key_cricinfo_2
+key_cricinfo_3,STRING,Terceiro identificador da pessoa na fonte ESPNcricinfo,,no,,,no,,key_cricinfo_3
+key_cricingif,STRING,Identificador da pessoa na fonte Cricingif,,no,,,no,,key_cricingif
+key_cricketarchive,STRING,Identificador da pessoa na fonte CricketArchive,,no,,,no,,key_cricketarchive
+key_cricketarchive_2,STRING,Segundo identificador da pessoa na fonte CricketArchive,,no,,,no,,key_cricketarchive_2
+key_cricketworld,STRING,Identificador da pessoa na fonte Cricket World,,no,,,no,,key_cricketworld
+key_nvplay,STRING,Identificador da pessoa na fonte NVPlay,,no,,,no,,key_nvplay
+key_nvplay_2,STRING,Segundo identificador da pessoa na fonte NVPlay,,no,,,no,,key_nvplay_2
+key_opta,STRING,Identificador da pessoa na fonte Opta,,no,,,no,,key_opta
+key_opta_2,STRING,Segundo identificador da pessoa na fonte Opta,,no,,,no,,key_opta_2
+key_pulse,STRING,Identificador da pessoa na fonte Pulse,,no,,,no,,key_pulse
+key_pulse_2,STRING,Segundo identificador da pessoa na fonte Pulse,,no,,,no,,key_pulse_2

--- a/models/world_cricsheet/code/architecture/people.csv
+++ b/models/world_cricsheet/code/architecture/people.csv
@@ -1,5 +1,5 @@
 name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
-identifier,STRING,Identificador único da pessoa no Cricsheet,,no,,,no,Chave lógica da tabela,identifier
+person_id,STRING,Identificador único da pessoa no Cricsheet,,no,,,no,Chave lógica da tabela,identifier
 name,STRING,Nome da pessoa,,no,,,no,,name
 unique_name,STRING,Nome único usado para desambiguação de homônimos,,no,,,no,,unique_name
 key_bcci,STRING,Identificador da pessoa na fonte BCCI,,no,,,no,,key_bcci

--- a/models/world_cricsheet/code/clean_data.py
+++ b/models/world_cricsheet/code/clean_data.py
@@ -1,0 +1,526 @@
+"""Clean the Cricsheet global cricket bundle into typed, partitioned Parquet.
+
+Produces four tables, conforming to the architecture CSVs under
+``architecture/``:
+
+- ``deliveries``     (partitioned by ``year``) — ball-by-ball, from all_matches.csv
+- ``matches``        (partitioned by ``year``) — one row per match, pivoted from
+                     each ``<id>_info.csv``
+- ``match_players``  (partitioned by ``year``) — one row per (match, team, player)
+- ``people``         (single file, dimension)  — from people.csv, all STRING
+
+Typed, one-shot onboarding path: explicit ``pa.Schema`` per table, Snappy Parquet.
+Do NOT all-STRING cast (that is the recurring-pipeline path).
+
+Usage:
+    python clean_data.py --prototype   # pivot a handful of info files, print, exit
+    python clean_data.py               # full run
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import glob
+import os
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+CODE_DIR = os.path.dirname(os.path.abspath(__file__))
+INPUT_DIR = os.path.join(CODE_DIR, "input")
+ALL_CSV2_DIR = os.path.join(INPUT_DIR, "all_csv2")
+DELIVERIES_CSV = os.path.join(ALL_CSV2_DIR, "all_matches.csv")
+PEOPLE_CSV = os.path.join(INPUT_DIR, "people.csv")
+ARCH_DIR = os.path.join(CODE_DIR, "architecture")
+OUTPUT_DIR = os.path.join(CODE_DIR, "output")
+
+# ---------------------------------------------------------------------------
+# Architecture -> arrow schema
+# ---------------------------------------------------------------------------
+BQ_TO_ARROW = {
+    "INT64": pa.int64(),
+    "FLOAT64": pa.float64(),
+    "STRING": pa.string(),
+    "DATE": pa.date32(),
+}
+
+
+def load_arch(table: str) -> list[tuple[str, str]]:
+    """Return [(column_name, bigquery_type), ...] in architecture order."""
+    path = os.path.join(ARCH_DIR, f"{table}.csv")
+    cols: list[tuple[str, str]] = []
+    with open(path, newline="", encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            cols.append((row["name"], row["bigquery_type"]))
+    return cols
+
+
+def arrow_schema(table: str) -> pa.Schema:
+    return pa.schema(
+        [(name, BQ_TO_ARROW[bqt]) for name, bqt in load_arch(table)]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Small casting helpers
+# ---------------------------------------------------------------------------
+def s_or_none(v: str | None) -> str | None:
+    """Empty string / None -> None; else stripped string."""
+    if v is None:
+        return None
+    v = v.strip()
+    return v if v != "" else None
+
+
+def i_or_none(v: str | None) -> int | None:
+    v = s_or_none(v)
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except ValueError:
+        try:
+            return int(float(v))
+        except ValueError:
+            return None
+
+
+def parse_date_slash(v: str | None):
+    """Parse Cricsheet info-file date 'YYYY/MM/DD' -> datetime.date."""
+    v = s_or_none(v)
+    if v is None:
+        return None
+    try:
+        return dt.datetime.strptime(v, "%Y/%m/%d").date()
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Table 2 + 3: parse one info file -> (match_dict, [player_dicts])
+# ---------------------------------------------------------------------------
+MATCH_SCALARS = {
+    "gender",
+    "season",
+    "match_number",
+    "event",
+    "city",
+    "venue",
+    "toss_winner",
+    "toss_decision",
+    "winner",
+    "method",
+    "match_type",
+    "team_type",
+    "tv_umpire",
+    "reserve_umpire",
+    "match_referee",
+    "outcome",
+    "winner_innings",
+    "neutral_venue",
+}
+
+
+def parse_info_file(path: str) -> tuple[dict, list[dict]]:
+    match_id = os.path.basename(path)[: -len("_info.csv")]
+
+    teams: list[str] = []
+    dates: list[dt.date] = []
+    umpires: list[str] = []
+    poms: list[str] = []  # player_of_match (may repeat on ties)
+    players: list[tuple[str, str]] = []  # (team, name)
+    registry: dict[str, str] = {}  # name -> identifier
+    scalars: dict[str, str] = {}
+    ints: dict[str, int] = {}
+    targets: dict[str, dict[str, int]] = {
+        "target_runs": {},
+        "target_overs": {},
+    }
+
+    with open(path, newline="", encoding="utf-8") as fh:
+        for row in csv.reader(fh):
+            if not row or row[0] != "info":
+                continue  # skip 'version' and blanks
+            if len(row) < 2:
+                continue
+            field = row[1]
+            val = row[2] if len(row) > 2 else None
+
+            if field == "team":
+                if val:
+                    teams.append(val.strip())
+            elif field == "date":
+                d = parse_date_slash(val)
+                if d is not None:
+                    dates.append(d)
+            elif field == "umpire":
+                if val:
+                    umpires.append(val.strip())
+            elif field == "player_of_match":
+                if val:
+                    poms.append(val.strip())
+            elif field in ("player", "players"):
+                # info,player,<team>,<name>
+                team = s_or_none(val)
+                name = s_or_none(row[3] if len(row) > 3 else None)
+                if name is not None:
+                    players.append((team, name))
+            elif field == "registry" and val == "people":
+                # info,registry,people,<name>,<identifier>
+                nm = s_or_none(row[3] if len(row) > 3 else None)
+                ident = s_or_none(row[4] if len(row) > 4 else None)
+                if nm is not None:
+                    registry[nm] = ident
+            elif field in (
+                "balls_per_over",
+                "overs",
+                "winner_runs",
+                "winner_wickets",
+            ):
+                iv = i_or_none(val)
+                if iv is not None:
+                    ints[field] = iv
+            elif field in ("target_runs", "target_overs"):
+                # info,target_runs,<innings>,<value>
+                innings = s_or_none(val)
+                tv = i_or_none(row[3] if len(row) > 3 else None)
+                if innings is not None and tv is not None:
+                    targets[field][innings] = tv
+            elif field in MATCH_SCALARS:
+                sv = s_or_none(val)
+                if sv is not None:
+                    scalars[field] = sv  # last wins
+
+    start_date = min(dates) if dates else None
+    end_date = max(dates) if dates else None
+    year = start_date.year if start_date is not None else None
+
+    match = {
+        "year": year,
+        "match_id": match_id,
+        "season": scalars.get("season"),
+        "start_date": start_date,
+        "end_date": end_date,
+        "match_type": scalars.get("match_type"),
+        "team_type": scalars.get("team_type"),
+        "gender": scalars.get("gender"),
+        "event": scalars.get("event"),
+        "match_number": scalars.get("match_number"),
+        "balls_per_over": ints.get("balls_per_over"),
+        "overs": ints.get("overs"),
+        "venue": scalars.get("venue"),
+        "city": scalars.get("city"),
+        "team1": teams[0] if len(teams) >= 1 else None,
+        "team2": teams[1] if len(teams) >= 2 else None,
+        "toss_winner": scalars.get("toss_winner"),
+        "toss_decision": scalars.get("toss_decision"),
+        "player_of_match": poms[0] if poms else None,
+        "winner": scalars.get("winner"),
+        "outcome": scalars.get("outcome"),
+        "winner_runs": ints.get("winner_runs"),
+        "winner_wickets": ints.get("winner_wickets"),
+        "winner_innings": scalars.get("winner_innings"),
+        "method": scalars.get("method"),
+        "target_runs": targets["target_runs"].get("2"),
+        "target_overs": targets["target_overs"].get("2"),
+        "neutral_venue": scalars.get("neutral_venue"),
+        "umpire1": umpires[0] if len(umpires) >= 1 else None,
+        "umpire2": umpires[1] if len(umpires) >= 2 else None,
+        "tv_umpire": scalars.get("tv_umpire"),
+        "reserve_umpire": scalars.get("reserve_umpire"),
+        "match_referee": scalars.get("match_referee"),
+        "_n_pom": len(poms),
+    }
+
+    player_rows = [
+        {
+            "year": year,
+            "match_id": match_id,
+            "team": team,
+            "player": name,
+            "player_identifier": registry.get(name),
+        }
+        for team, name in players
+    ]
+    return match, player_rows
+
+
+# ---------------------------------------------------------------------------
+# Prototype
+# ---------------------------------------------------------------------------
+def run_prototype() -> None:
+    samples = {
+        "1000851 (multi-day Test)": "1000851_info.csv",
+        "1003869 (T20 no-result / D-L target)": "1003869_info.csv",
+        "1023647 (tie)": "1023647_info.csv",
+        "1002151 (D/L with winner + target)": "1002151_info.csv",
+        "1000853 (won by an innings)": "1000853_info.csv",
+        "1239545 (uses 'players' plural)": "1239545_info.csv",
+    }
+    for label, fname in samples.items():
+        path = os.path.join(ALL_CSV2_DIR, fname)
+        if not os.path.exists(path):
+            print(f"[skip] {label}: {fname} not found")
+            continue
+        match, players = parse_info_file(path)
+        print("=" * 78)
+        print(label)
+        print("-" * 78)
+        for k, v in match.items():
+            print(f"  {k:16} = {v!r}")
+        print(f"  n_players        = {len(players)}")
+        resolved = sum(1 for p in players if p["player_identifier"])
+        print(f"  players_resolved = {resolved}/{len(players)}")
+        print("  first 3 player rows:")
+        for p in players[:3]:
+            print(f"    {p}")
+
+
+# ---------------------------------------------------------------------------
+# Table 1: deliveries (streaming, per-year ParquetWriter)
+# ---------------------------------------------------------------------------
+DELIV_INT_COLS = [
+    "runs_off_bat",
+    "extras",
+    "wides",
+    "noballs",
+    "byes",
+    "legbyes",
+    "penalty",
+]
+
+
+def build_deliveries_table(df: pd.DataFrame, schema: pa.Schema) -> pa.Table:
+    arrays = []
+    for field in schema:
+        name = field.name
+        col = df[name]
+        if name == "year":
+            arrays.append(pa.array(col.astype("Int64"), type=pa.int64()))
+        elif name == "start_date":
+            arrays.append(pa.array(col.tolist(), type=pa.date32()))
+        elif name in DELIV_INT_COLS:
+            arrays.append(
+                pa.array(
+                    pd.to_numeric(col, errors="coerce").astype("Int64"),
+                    type=pa.int64(),
+                )
+            )
+        else:  # STRING
+            s = col.astype("string").str.strip()
+            s = s.mask(s == "", pd.NA)
+            arrays.append(pa.array(s, type=pa.string()))
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
+def run_deliveries() -> dict[int, int]:
+    schema = arrow_schema("deliveries")
+    out_root = os.path.join(OUTPUT_DIR, "deliveries")
+    os.makedirs(out_root, exist_ok=True)
+
+    writers: dict[int, pq.ParquetWriter] = {}
+    counts: dict[int, int] = {}
+    total = 0
+
+    reader = pd.read_csv(
+        DELIVERIES_CSV,
+        dtype=str,
+        keep_default_na=False,
+        na_values=[],
+        chunksize=500_000,
+    )
+    for chunk in reader:
+        # year + start_date parsed from start_date (YYYY-MM-DD)
+        sd = pd.to_datetime(
+            chunk["start_date"], format="%Y-%m-%d", errors="coerce"
+        )
+        chunk = chunk.copy()
+        chunk["year"] = sd.dt.year.astype("Int64")
+        chunk["start_date"] = sd.dt.date
+
+        for yr, grp in chunk.groupby("year", dropna=False):
+            if pd.isna(yr):
+                raise ValueError(
+                    f"delivery rows with unparseable year: {len(grp)} "
+                    f"(sample start_date={grp['start_date'].head().tolist()})"
+                )
+            yr = int(yr)
+            table = build_deliveries_table(grp, schema)
+            if yr not in writers:
+                ydir = os.path.join(out_root, f"year={yr}")
+                os.makedirs(ydir, exist_ok=True)
+                writers[yr] = pq.ParquetWriter(
+                    os.path.join(ydir, "data.parquet"),
+                    schema,
+                    compression="snappy",
+                )
+            writers[yr].write_table(table)
+            counts[yr] = counts.get(yr, 0) + len(grp)
+            total += len(grp)
+        print(f"  deliveries: {total:,} rows processed", end="\r", flush=True)
+
+    for w in writers.values():
+        w.close()
+    print(f"\n  deliveries: done, {total:,} rows across {len(counts)} years")
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Tables 2 + 3: matches + match_players (loop over info files)
+# ---------------------------------------------------------------------------
+def build_typed_table(rows: list[dict], schema: pa.Schema) -> pa.Table:
+    df = pd.DataFrame(rows, columns=[f.name for f in schema])
+    arrays = []
+    for field in schema:
+        col = df[field.name]
+        if field.type == pa.int64():
+            arrays.append(
+                pa.array(
+                    pd.to_numeric(col, errors="coerce").astype("Int64"),
+                    type=pa.int64(),
+                )
+            )
+        elif field.type == pa.date32():
+            arrays.append(pa.array(col.tolist(), type=pa.date32()))
+        else:  # string
+            s = col.astype("string")
+            s = s.mask(s == "", pd.NA)
+            arrays.append(pa.array(s, type=pa.string()))
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
+def write_partitioned(
+    rows: list[dict], table_name: str, schema: pa.Schema
+) -> dict[int, int]:
+    out_root = os.path.join(OUTPUT_DIR, table_name)
+    os.makedirs(out_root, exist_ok=True)
+    by_year: dict[object, list[dict]] = {}
+    for r in rows:
+        by_year.setdefault(r["year"], []).append(r)
+    counts: dict[int, int] = {}
+    for yr, grp in by_year.items():
+        if yr is None:
+            raise ValueError(f"{table_name}: {len(grp)} rows with null year")
+        yr = int(yr)
+        table = build_typed_table(grp, schema)
+        ydir = os.path.join(out_root, f"year={yr}")
+        os.makedirs(ydir, exist_ok=True)
+        pq.write_table(
+            table, os.path.join(ydir, "data.parquet"), compression="snappy"
+        )
+        counts[yr] = len(grp)
+    return counts
+
+
+def run_matches_and_players() -> tuple[
+    dict[int, int], dict[int, int], int, int
+]:
+    matches_schema = arrow_schema("matches")
+    players_schema = arrow_schema("match_players")
+
+    info_files = sorted(glob.glob(os.path.join(ALL_CSV2_DIR, "*_info.csv")))
+    match_rows: list[dict] = []
+    player_rows: list[dict] = []
+    multi_pom = 0
+
+    for i, path in enumerate(info_files, 1):
+        match, players = parse_info_file(path)
+        if match.pop("_n_pom") > 1:
+            multi_pom += 1
+        match_rows.append(match)
+        player_rows.extend(players)
+        if i % 2000 == 0:
+            print(
+                f"  info files: {i:,}/{len(info_files):,}",
+                end="\r",
+                flush=True,
+            )
+    print(f"  info files: {len(info_files):,}/{len(info_files):,} done")
+
+    resolved = sum(1 for p in player_rows if p["player_identifier"])
+    m_counts = write_partitioned(match_rows, "matches", matches_schema)
+    p_counts = write_partitioned(player_rows, "match_players", players_schema)
+    return m_counts, p_counts, multi_pom, resolved
+
+
+# ---------------------------------------------------------------------------
+# Table 4: people (single dimension file, all STRING)
+# ---------------------------------------------------------------------------
+def run_people() -> int:
+    schema = arrow_schema("people")
+    df = pd.read_csv(
+        PEOPLE_CSV, dtype=str, keep_default_na=False, na_values=[]
+    )
+    # architecture order == source header order; assert alignment
+    arch_names = [f.name for f in schema]
+    assert list(df.columns) == arch_names, (
+        f"people header mismatch:\n  arch={arch_names}\n  csv ={list(df.columns)}"
+    )
+    arrays = []
+    for name in arch_names:
+        s = df[name].astype("string").str.strip()
+        s = s.mask(s == "", pd.NA)
+        arrays.append(pa.array(s, type=pa.string()))
+    table = pa.Table.from_arrays(arrays, schema=schema)
+    out_dir = os.path.join(OUTPUT_DIR, "people")
+    os.makedirs(out_dir, exist_ok=True)
+    pq.write_table(
+        table, os.path.join(out_dir, "data.parquet"), compression="snappy"
+    )
+    return table.num_rows
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--prototype", action="store_true")
+    args = ap.parse_args()
+
+    if args.prototype:
+        run_prototype()
+        return
+
+    print("[1/4] deliveries")
+    d_counts = run_deliveries()
+
+    print("[2/4] matches + [3/4] match_players")
+    m_counts, p_counts, multi_pom, resolved = run_matches_and_players()
+
+    print("[4/4] people")
+    n_people = run_people()
+
+    # ---------------- validation report ----------------
+    print("\n" + "=" * 78)
+    print("VALIDATION REPORT")
+    print("=" * 78)
+    n_deliv = sum(d_counts.values())
+    n_match = sum(m_counts.values())
+    n_players = sum(p_counts.values())
+    print(f"deliveries      rows: {n_deliv:,}")
+    print(f"matches         rows: {n_match:,}")
+    print(f"match_players   rows: {n_players:,}")
+    print(f"people          rows: {n_people:,}")
+    print(f"\nmatches with >1 player_of_match: {multi_pom}")
+    if n_players:
+        print(
+            f"match_players with resolved identifier: "
+            f"{resolved:,}/{n_players:,} "
+            f"({100 * resolved / n_players:.1f}%)"
+        )
+    print("\ndeliveries rows per year:")
+    for yr in sorted(d_counts):
+        print(f"  {yr}: {d_counts[yr]:,}")
+    print(f"\nyear range deliveries: {min(d_counts)}-{max(d_counts)}")
+    print(f"year range matches:    {min(m_counts)}-{max(m_counts)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/world_cricsheet/code/upload.py
+++ b/models/world_cricsheet/code/upload.py
@@ -1,0 +1,103 @@
+"""Upload cleaned world_cricsheet parquet tables to BigQuery.
+
+Usage:
+    uv run python models/world_cricsheet/code/upload.py [--env dev|prod] [table_slug ...]
+
+--env dev (default) -> basedosdados-dev; --env prod -> basedosdados. Point
+GOOGLE_APPLICATION_CREDENTIALS at the matching service account. Uploads
+sequentially (smallest first) and stops on first failure.
+"""
+
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+import basedosdados as bd  # noqa: E402
+import google.cloud.storage as gcs  # noqa: E402
+from google.cloud import bigquery  # noqa: E402
+
+_argv = sys.argv[1:]
+if "--env" in _argv:
+    _i = _argv.index("--env")
+    ENV = _argv[_i + 1]
+    _argv = _argv[:_i] + _argv[_i + 2 :]
+else:
+    ENV = "dev"
+BILLING_PROJECT = "basedosdados" if ENV == "prod" else "basedosdados-dev"
+DATASET_ID = "world_cricsheet"
+OUTPUT_ROOT = Path(__file__).resolve().parent / "output"
+
+# Monkey-patch for requester-pays bucket
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+# (table_slug, relative_path, expected_rows) — smallest first
+TABLES = [
+    ("people", "people/data.parquet", 18_362),
+    ("matches", "matches", 22_479),
+    ("match_players", "match_players", 495_892),
+    ("deliveries", "deliveries", 11_401_958),
+]
+
+
+def upload_table(slug: str, rel_path: str, expected_rows: int) -> int:
+    path = OUTPUT_ROOT / rel_path
+    if not path.exists():
+        raise FileNotFoundError(f"Missing output path: {path}")
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=slug)
+
+    # Delete stale GCS staging prefix (avoids BQ partition key conflicts)
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=slug)
+    try:
+        st.delete_table(mode="staging", not_found_ok=True)
+    except Exception as e:
+        print(f"  [warn] staging prefix cleanup: {e}")
+
+    tb.create(
+        path=str(path),
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    client = bigquery.Client(project=BILLING_PROJECT)
+    q = f"select count(*) as n from `{BILLING_PROJECT}.{DATASET_ID}_staging.{slug}`"
+    n = next(iter(client.query(q).result())).n
+
+    status = "OK" if n == expected_rows else "ROW MISMATCH"
+    print(
+        f"  {slug}: uploaded {n:,} rows (expected {expected_rows:,}) — {status}"
+    )
+    if n != expected_rows:
+        raise ValueError(
+            f"{slug}: row count {n:,} != expected {expected_rows:,}"
+        )
+    return n
+
+
+def main():
+    only = set(_argv)
+    tables = [(s, p, r) for s, p, r in TABLES if not only or s in only]
+    print(f"=== uploading to {BILLING_PROJECT} (env={ENV}) ===", flush=True)
+    for slug, rel_path, expected in tables:
+        print(f"=== {slug} ===", flush=True)
+        try:
+            upload_table(slug, rel_path, expected)
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+            sys.exit(1)
+    print("ALL TABLES UPLOADED")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/world_cricsheet/schema.yml
+++ b/models/world_cricsheet/schema.yml
@@ -235,7 +235,7 @@ models:
       resolvido.
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: [year, match_id, team, player]
+          combination_of_columns: [year, match_id, team_name, player_name]
       - not_null_proportion_multiple_columns:
           at_least: 0.05
     columns:
@@ -247,23 +247,27 @@ models:
         description: >
           Identificador único da partida
         tests: [not_null]
-      - name: team
+      - name: team_name
         description: >
           Nome da equipe do jogador na partida
-      - name: player
+      - name: player_name
         description: >
           Nome do jogador conforme aparece na partida
         tests: [not_null]
-      - name: player_identifier
+      - name: person_id
         description: >
           Identificador único do jogador resolvido pelo registro
+        tests:
+          - relationships:
+              to: ref('world_cricsheet__people')
+              field: person_id
   - name: world_cricsheet__people
     description: >
       Registro de pessoas do Cricsheet, com uma linha por pessoa e os
       identificadores correspondentes em fontes externas de dados de críquete.
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: [identifier]
+          combination_of_columns: [person_id]
       - not_null_proportion_multiple_columns:
           at_least: 0.05
           ignore_values:
@@ -282,7 +286,7 @@ models:
             - key_opta_2
             - key_pulse_2
     columns:
-      - name: identifier
+      - name: person_id
         description: >
           Identificador único da pessoa no Cricsheet
         tests: [not_null]

--- a/models/world_cricsheet/schema.yml
+++ b/models/world_cricsheet/schema.yml
@@ -1,0 +1,351 @@
+---
+version: 2
+models:
+  - name: world_cricsheet__deliveries
+    description: >
+      Registro bola a bola das partidas de críquete do Cricsheet, com uma linha
+      por entrega (bola) disputada, incluindo corridas, extras e eliminações.
+      A combinação (match_id, innings, actual_delivery) apresenta uma fração
+      residual de duplicatas (cerca de 2% dos grupos), decorrente de super
+      overs e de reenumerações de entregas na fonte, tolerada via teste de
+      unicidade relaxado.
+    tests:
+      - custom_unique_combinations_of_columns:
+          combination_of_columns: [match_id, innings, actual_delivery]
+          proportion_allowed_failures: 0.01
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - wides
+            - noballs
+            - byes
+            - legbyes
+            - penalty
+            - non_boundary
+            - wicket_type
+            - player_dismissed
+            - other_wicket_type
+            - other_player_dismissed
+            - fielder_1
+            - fielder_2
+            - fielder_3
+    columns:
+      - name: year
+        description: >
+          Ano da partida, derivado da data de início
+        tests: [not_null]
+      - name: match_id
+        description: >
+          Identificador único da partida
+        tests: [not_null]
+      - name: season
+        description: >
+          Temporada da partida no formato de ano ou intervalo de anos
+      - name: start_date
+        description: >
+          Data de início da partida
+      - name: venue
+        description: >
+          Nome do estádio ou local onde a partida foi disputada
+      - name: innings
+        description: >
+          Número do turno de rebatidas na partida
+      - name: ball
+        description: >
+          Identificador da bola no formato over.bola
+      - name: actual_delivery
+        description: >
+          Número da entrega efetivamente disputada no over
+      - name: batting_team
+        description: >
+          Nome da equipe que está rebatendo
+      - name: bowling_team
+        description: >
+          Nome da equipe que está arremessando
+      - name: striker
+        description: >
+          Nome do rebatedor que enfrenta a bola
+      - name: non_striker
+        description: >
+          Nome do rebatedor na outra extremidade do campo
+      - name: bowler
+        description: >
+          Nome do arremessador que entrega a bola
+      - name: runs_off_bat
+        description: >
+          Corridas marcadas pela rebatida do batedor nesta bola
+      - name: extras
+        description: >
+          Total de corridas extras concedidas nesta bola
+      - name: wides
+        description: >
+          Corridas concedidas por bola larga (wide) nesta bola
+      - name: noballs
+        description: >
+          Corridas concedidas por bola inválida (no-ball) nesta bola
+      - name: byes
+        description: >
+          Corridas concedidas por byes nesta bola
+      - name: legbyes
+        description: >
+          Corridas concedidas por leg byes nesta bola
+      - name: penalty
+        description: >
+          Corridas de penalidade concedidas nesta bola
+      - name: non_boundary
+        description: >
+          Indicador de que as corridas não vieram de uma fronteira
+      - name: wicket_type
+        description: >
+          Tipo de eliminação (wicket) registrada nesta bola
+      - name: player_dismissed
+        description: >
+          Nome do jogador eliminado nesta bola
+      - name: other_wicket_type
+        description: >
+          Tipo da segunda eliminação registrada na mesma bola
+      - name: other_player_dismissed
+        description: >
+          Nome do segundo jogador eliminado na mesma bola
+      - name: fielder_1
+        description: >
+          Nome do primeiro defensor envolvido na eliminação
+      - name: fielder_2
+        description: >
+          Nome do segundo defensor envolvido na eliminação
+      - name: fielder_3
+        description: >
+          Nome do terceiro defensor envolvido na eliminação
+  - name: world_cricsheet__matches
+    description: >
+      Metadados das partidas de críquete do Cricsheet, com uma linha por
+      partida, incluindo tipo, equipes, sorteio, resultado e árbitros.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [year, match_id]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values: [winner_innings, method, neutral_venue]
+    columns:
+      - name: year
+        description: >
+          Ano da partida, derivado da data de início
+        tests: [not_null]
+      - name: match_id
+        description: >
+          Identificador único da partida
+        tests: [not_null]
+      - name: season
+        description: >
+          Temporada da partida no formato de ano ou intervalo de anos
+      - name: start_date
+        description: >
+          Data de início da partida
+      - name: end_date
+        description: >
+          Data de encerramento da partida
+      - name: match_type
+        description: >
+          Tipo de partida
+      - name: team_type
+        description: >
+          Tipo de equipe
+      - name: gender
+        description: >
+          Gênero das equipes participantes
+      - name: event
+        description: >
+          Nome do torneio ou evento da partida
+      - name: match_number
+        description: >
+          Número da partida dentro do evento
+      - name: balls_per_over
+        description: >
+          Número de bolas por over
+      - name: overs
+        description: >
+          Número máximo de overs por turno
+      - name: venue
+        description: >
+          Nome do estádio ou local da partida
+      - name: city
+        description: >
+          Cidade onde a partida foi disputada
+      - name: team1
+        description: >
+          Nome da primeira equipe
+      - name: team2
+        description: >
+          Nome da segunda equipe
+      - name: toss_winner
+        description: >
+          Nome da equipe que venceu o sorteio inicial
+      - name: toss_decision
+        description: >
+          Decisão da equipe vencedora do sorteio
+      - name: player_of_match
+        description: >
+          Nome do jogador eleito melhor da partida
+      - name: winner
+        description: >
+          Nome da equipe vencedora
+      - name: outcome
+        description: >
+          Resultado da partida sem vencedor definido
+      - name: winner_runs
+        description: >
+          Margem de vitória em corridas
+      - name: winner_wickets
+        description: >
+          Margem de vitória em wickets
+      - name: winner_innings
+        description: >
+          Indicador de vitória por turno (innings)
+      - name: method
+        description: >
+          Método aplicado para definir o resultado
+      - name: target_runs
+        description: >
+          Meta de corridas para a equipe que rebate por último
+      - name: target_overs
+        description: >
+          Número de overs disponíveis para atingir a meta
+      - name: neutral_venue
+        description: >
+          Indicador de local neutro
+      - name: umpire1
+        description: >
+          Nome do primeiro árbitro
+      - name: umpire2
+        description: >
+          Nome do segundo árbitro
+      - name: tv_umpire
+        description: >
+          Nome do árbitro de vídeo
+      - name: reserve_umpire
+        description: >
+          Nome do árbitro reserva
+      - name: match_referee
+        description: >
+          Nome do juiz da partida
+  - name: world_cricsheet__match_players
+    description: >
+      Composição das equipes por partida no Cricsheet, com uma linha por
+      partida, equipe e jogador, incluindo o identificador do jogador quando
+      resolvido.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [year, match_id, team, player]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: >
+          Ano da partida, derivado da data de início
+        tests: [not_null]
+      - name: match_id
+        description: >
+          Identificador único da partida
+        tests: [not_null]
+      - name: team
+        description: >
+          Nome da equipe do jogador na partida
+      - name: player
+        description: >
+          Nome do jogador conforme aparece na partida
+        tests: [not_null]
+      - name: player_identifier
+        description: >
+          Identificador único do jogador resolvido pelo registro
+  - name: world_cricsheet__people
+    description: >
+      Registro de pessoas do Cricsheet, com uma linha por pessoa e os
+      identificadores correspondentes em fontes externas de dados de críquete.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [identifier]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - key_bcci_2
+            - key_bigbash
+            - key_cricbuzz
+            - key_cricheroes
+            - key_crichq
+            - key_cricinfo_2
+            - key_cricinfo_3
+            - key_cricingif
+            - key_cricketarchive_2
+            - key_cricketworld
+            - key_nvplay_2
+            - key_opta
+            - key_opta_2
+            - key_pulse_2
+    columns:
+      - name: identifier
+        description: >
+          Identificador único da pessoa no Cricsheet
+        tests: [not_null]
+      - name: name
+        description: >
+          Nome da pessoa
+      - name: unique_name
+        description: >
+          Nome único usado para desambiguação de homônimos
+      - name: key_bcci
+        description: >
+          Identificador da pessoa na fonte BCCI
+      - name: key_bcci_2
+        description: >
+          Segundo identificador da pessoa na fonte BCCI
+      - name: key_bigbash
+        description: >
+          Identificador da pessoa na fonte Big Bash
+      - name: key_cricbuzz
+        description: >
+          Identificador da pessoa na fonte Cricbuzz
+      - name: key_cricheroes
+        description: >
+          Identificador da pessoa na fonte CricHeroes
+      - name: key_crichq
+        description: >
+          Identificador da pessoa na fonte CricHQ
+      - name: key_cricinfo
+        description: >
+          Identificador da pessoa na fonte ESPNcricinfo
+      - name: key_cricinfo_2
+        description: >
+          Segundo identificador da pessoa na fonte ESPNcricinfo
+      - name: key_cricinfo_3
+        description: >
+          Terceiro identificador da pessoa na fonte ESPNcricinfo
+      - name: key_cricingif
+        description: >
+          Identificador da pessoa na fonte Cricingif
+      - name: key_cricketarchive
+        description: >
+          Identificador da pessoa na fonte CricketArchive
+      - name: key_cricketarchive_2
+        description: >
+          Segundo identificador da pessoa na fonte CricketArchive
+      - name: key_cricketworld
+        description: >
+          Identificador da pessoa na fonte Cricket World
+      - name: key_nvplay
+        description: >
+          Identificador da pessoa na fonte NVPlay
+      - name: key_nvplay_2
+        description: >
+          Segundo identificador da pessoa na fonte NVPlay
+      - name: key_opta
+        description: >
+          Identificador da pessoa na fonte Opta
+      - name: key_opta_2
+        description: >
+          Segundo identificador da pessoa na fonte Opta
+      - name: key_pulse
+        description: >
+          Identificador da pessoa na fonte Pulse
+      - name: key_pulse_2
+        description: >-
+          Segundo identificador da pessoa na fonte Pulse

--- a/models/world_cricsheet/world_cricsheet__deliveries.sql
+++ b/models/world_cricsheet/world_cricsheet__deliveries.sql
@@ -1,0 +1,44 @@
+{{
+    config(
+        schema="world_cricsheet",
+        alias="deliveries",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1770, "end": 2035, "interval": 1},
+        },
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(match_id as string) match_id,
+    safe_cast(season as string) season,
+    safe_cast(start_date as date) start_date,
+    safe_cast(venue as string) venue,
+    safe_cast(innings as string) innings,
+    safe_cast(ball as string) ball,
+    safe_cast(actual_delivery as string) actual_delivery,
+    safe_cast(batting_team as string) batting_team,
+    safe_cast(bowling_team as string) bowling_team,
+    safe_cast(striker as string) striker,
+    safe_cast(non_striker as string) non_striker,
+    safe_cast(bowler as string) bowler,
+    safe_cast(runs_off_bat as int64) runs_off_bat,
+    safe_cast(extras as int64) extras,
+    safe_cast(wides as int64) wides,
+    safe_cast(noballs as int64) noballs,
+    safe_cast(byes as int64) byes,
+    safe_cast(legbyes as int64) legbyes,
+    safe_cast(penalty as int64) penalty,
+    safe_cast(non_boundary as string) non_boundary,
+    safe_cast(wicket_type as string) wicket_type,
+    safe_cast(player_dismissed as string) player_dismissed,
+    safe_cast(other_wicket_type as string) other_wicket_type,
+    safe_cast(other_player_dismissed as string) other_player_dismissed,
+    safe_cast(fielder_1 as string) fielder_1,
+    safe_cast(fielder_2 as string) fielder_2,
+    safe_cast(fielder_3 as string) fielder_3
+from {{ set_datalake_project("world_cricsheet_staging.deliveries") }} as t

--- a/models/world_cricsheet/world_cricsheet__match_players.sql
+++ b/models/world_cricsheet/world_cricsheet__match_players.sql
@@ -15,7 +15,7 @@
 select
     safe_cast(year as int64) year,
     safe_cast(match_id as string) match_id,
-    safe_cast(team as string) team,
-    safe_cast(player as string) player,
-    safe_cast(player_identifier as string) player_identifier
+    safe_cast(team as string) team_name,
+    safe_cast(player as string) player_name,
+    safe_cast(player_identifier as string) person_id
 from {{ set_datalake_project("world_cricsheet_staging.match_players") }} as t

--- a/models/world_cricsheet/world_cricsheet__match_players.sql
+++ b/models/world_cricsheet/world_cricsheet__match_players.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        schema="world_cricsheet",
+        alias="match_players",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1770, "end": 2035, "interval": 1},
+        },
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(match_id as string) match_id,
+    safe_cast(team as string) team,
+    safe_cast(player as string) player,
+    safe_cast(player_identifier as string) player_identifier
+from {{ set_datalake_project("world_cricsheet_staging.match_players") }} as t

--- a/models/world_cricsheet/world_cricsheet__matches.sql
+++ b/models/world_cricsheet/world_cricsheet__matches.sql
@@ -1,0 +1,49 @@
+{{
+    config(
+        schema="world_cricsheet",
+        alias="matches",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1770, "end": 2035, "interval": 1},
+        },
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(match_id as string) match_id,
+    safe_cast(season as string) season,
+    safe_cast(start_date as date) start_date,
+    safe_cast(end_date as date) end_date,
+    safe_cast(match_type as string) match_type,
+    safe_cast(team_type as string) team_type,
+    safe_cast(gender as string) gender,
+    safe_cast(event as string) event,
+    safe_cast(match_number as string) match_number,
+    safe_cast(balls_per_over as int64) balls_per_over,
+    safe_cast(overs as int64) overs,
+    safe_cast(venue as string) venue,
+    safe_cast(city as string) city,
+    safe_cast(team1 as string) team1,
+    safe_cast(team2 as string) team2,
+    safe_cast(toss_winner as string) toss_winner,
+    safe_cast(toss_decision as string) toss_decision,
+    safe_cast(player_of_match as string) player_of_match,
+    safe_cast(winner as string) winner,
+    safe_cast(outcome as string) outcome,
+    safe_cast(winner_runs as int64) winner_runs,
+    safe_cast(winner_wickets as int64) winner_wickets,
+    safe_cast(winner_innings as string) winner_innings,
+    safe_cast(method as string) method,
+    safe_cast(target_runs as int64) target_runs,
+    safe_cast(target_overs as int64) target_overs,
+    safe_cast(neutral_venue as string) neutral_venue,
+    safe_cast(umpire1 as string) umpire1,
+    safe_cast(umpire2 as string) umpire2,
+    safe_cast(tv_umpire as string) tv_umpire,
+    safe_cast(reserve_umpire as string) reserve_umpire,
+    safe_cast(match_referee as string) match_referee
+from {{ set_datalake_project("world_cricsheet_staging.matches") }} as t

--- a/models/world_cricsheet/world_cricsheet__people.sql
+++ b/models/world_cricsheet/world_cricsheet__people.sql
@@ -1,0 +1,33 @@
+{{
+    config(
+        schema="world_cricsheet",
+        alias="people",
+        materialized="table",
+    )
+}}
+
+
+select
+    safe_cast(identifier as string) identifier,
+    safe_cast(name as string) name,
+    safe_cast(unique_name as string) unique_name,
+    safe_cast(key_bcci as string) key_bcci,
+    safe_cast(key_bcci_2 as string) key_bcci_2,
+    safe_cast(key_bigbash as string) key_bigbash,
+    safe_cast(key_cricbuzz as string) key_cricbuzz,
+    safe_cast(key_cricheroes as string) key_cricheroes,
+    safe_cast(key_crichq as string) key_crichq,
+    safe_cast(key_cricinfo as string) key_cricinfo,
+    safe_cast(key_cricinfo_2 as string) key_cricinfo_2,
+    safe_cast(key_cricinfo_3 as string) key_cricinfo_3,
+    safe_cast(key_cricingif as string) key_cricingif,
+    safe_cast(key_cricketarchive as string) key_cricketarchive,
+    safe_cast(key_cricketarchive_2 as string) key_cricketarchive_2,
+    safe_cast(key_cricketworld as string) key_cricketworld,
+    safe_cast(key_nvplay as string) key_nvplay,
+    safe_cast(key_nvplay_2 as string) key_nvplay_2,
+    safe_cast(key_opta as string) key_opta,
+    safe_cast(key_opta_2 as string) key_opta_2,
+    safe_cast(key_pulse as string) key_pulse,
+    safe_cast(key_pulse_2 as string) key_pulse_2
+from {{ set_datalake_project("world_cricsheet_staging.people") }} as t

--- a/models/world_cricsheet/world_cricsheet__people.sql
+++ b/models/world_cricsheet/world_cricsheet__people.sql
@@ -8,7 +8,7 @@
 
 
 select
-    safe_cast(identifier as string) identifier,
+    safe_cast(identifier as string) person_id,
     safe_cast(name as string) name,
     safe_cast(unique_name as string) unique_name,
     safe_cast(key_bcci as string) key_bcci,


### PR DESCRIPTION
## Dataset: world_cricsheet (Cricsheet)
Ball-by-ball and match-level data for professional and international cricket worldwide — both genders, all formats (Test, ODI, T20I, and domestic T20/list-A leagues) — compiled by Cricsheet from the ashwin-format CSV bundle. Coverage 2001–2026. License: ODC-BY (attribution to Cricsheet).

### Tables (4, merged from the sliced Cricsheet bundles)
| Table | Grain | Rows |
|---|---|---|
| `deliveries` | one row per ball bowled | 11,401,958 |
| `matches` | one row per match | 22,479 |
| `match_players` | one row per (match, team, player) | 495,892 |
| `people` | registry of players and officials | 18,362 |

- Partition column `year` (INT64) on deliveries/matches/match_players; `people` is a non-temporal dimension.
- Person id column named `person_id` (the registry includes umpires/referees, not only players); `match_players` links `person_id` → `people.person_id` (dbt relationships test).
- Observation levels: deliveries [match, delivery, year]; matches [match, year]; match_players [match, person, year]; people [person].

### Validation
- dbt run 4/4, dbt test passing (including the `person_id` relationships test); referential integrity and id resolution 100%.
- deliveries `(match_id, innings, actual_delivery)` carries ~2% unavoidable duplicates (super-overs) — relaxed via a custom uniqueness test.
- Dev BigQuery tables built and validated in `basedosdados-dev`.

### Metadata
- Registered on prod backend with dataset status `under_review` (publish deferred to post-merge, after table-approve materialises `basedosdados.world_cricsheet.*`).
- Cloud tables point at the `basedosdados` project; coverage world; ODC-BY.

### Notes
- Static onboarding only (steps 1–11). A recurring Prefect refresh pipeline (Cricsheet updates near-daily) is deliberately deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added World Cricsheet datasets covering deliveries, matches, match players, and people.
  - Included structured cricket match, player, delivery, and identifier information.
  - Added partitioning by year to support efficient data access.
  - Added automated ingestion and publication of cleaned source data.
- **Documentation**
  - Documented dataset models, fields, descriptions, and data relationships.
- **Quality**
  - Added validation checks for required fields, uniqueness, null values, and player references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->