### PR TITLE
fix(world_cricsheet): build all tables before testing

### DIFF
--- a/pipelines/datasets/world_cricsheet/flows.py
+++ b/pipelines/datasets/world_cricsheet/flows.py
@@ -126,7 +126,11 @@ def world_cricsheet_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload staging + materialize/test.
+        # Dev: upload + build every table first, then test every table. The
+        # cross-table relationships test (match_players.person_id -> people)
+        # is pulled in when testing either table, so all four tables must be
+        # materialized before any test runs — a per-table run+test loop fails
+        # on a fresh target when the referenced table does not exist yet.
         for table in tables:
             upload_to_gcs(
                 data_path=result[table],
@@ -139,14 +143,21 @@ def world_cricsheet_flow(
             run_dbt(
                 dataset_id=DATASET_ID,
                 table_id=table,
-                dbt_command="run/test",
+                dbt_command="run",
+                target="dev",
+            )
+        for table in tables:
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="test",
                 target="dev",
             )
 
         if not materialize_to_prod:
             return
 
-        # Prod: upload staging + materialize/test.
+        # Prod: same two-phase pattern — build all tables, then test all.
         for table in tables:
             upload_to_gcs(
                 data_path=result[table],
@@ -159,7 +170,14 @@ def world_cricsheet_flow(
             run_dbt(
                 dataset_id=DATASET_ID,
                 table_id=table,
-                dbt_command="run/test",
+                dbt_command="run",
+                target="prod",
+            )
+        for table in tables:
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="test",
                 target="prod",
             )
 


### PR DESCRIPTION
The per-table dbt run+test loop fails on a fresh prod target: testing `people` pulls in the `match_players.person_id → people` relationships test, which queries `match_players` before this run has built it. The first live prod run (after #1731 was armed) failed here; the dev verification passed only because `match_players` pre-existed from the static onboarding.

**Fix:** split each env loop into build-all (`dbt run`) then test-all (`dbt test`), so every table is materialized before any cross-table test runs.

Pipeline-only change — no dbt model changes, so no table-approve needed. Verified locally: ruff clean, flow imports, deploy discovery finds `world_cricsheet_flow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data pipeline reliability by materializing all development and production tables before running validation tests.
  * Ensured validation runs consistently across all tables after the materialization phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->