### PR TITLE
feat(us_bls_qcew): add recurring quarterly Prefect pipeline

### DIFF
--- a/pipelines/datasets/us_bls_qcew/constants.py
+++ b/pipelines/datasets/us_bls_qcew/constants.py
@@ -81,3 +81,30 @@ class constants(Enum):
     ARCHITECTURE_DIR = (
         _REPO_ROOT / "models" / "us_bls_qcew" / "code" / "architecture"
     )
+
+    # ── Recurring pipeline (NAICS only) ──────────────────────────────────────
+    # SIC is a frozen classification: BLS published it for 1975-2000 and never
+    # republishes it. The recurring pipeline therefore refreshes ONLY the 8
+    # NAICS data tables; the 8 SIC tables and the dicionario are static and are
+    # not in the pipeline's table loop.
+    NAICS_START_YEAR = 1990
+
+    NAICS_TABLES = [
+        f"naics_{f}_{g}"
+        for f in ["quarterly", "annual"]
+        for g in ["national", "state", "county", "metro"]
+    ]
+
+    # Table the source poll / commit is anchored on (its single raw source is the
+    # NAICS singlefile family). The quarterly series carries the newest period.
+    POLL_TABLE = "naics_quarterly_national"
+
+    # Primary raw data source for the NAICS tables (staging backend id). The poll
+    # and commit tasks resolve the source via the table, which must link to
+    # exactly one raw source; this is that source, recorded for reference.
+    NAICS_RAW_SOURCE_ID = "180c2c08-a8a7-4b30-88a8-e200c77acf92"
+
+    # Concurrent downloads prefetched ahead of the (serial) cleaner. Cleaning is
+    # never parallelized, so peak RAM stays one chunk; this only bounds how many
+    # multi-GB CSVs sit on the worker's disk at once.
+    PIPELINE_DOWNLOAD_WORKERS = 4

--- a/pipelines/datasets/us_bls_qcew/flows.py
+++ b/pipelines/datasets/us_bls_qcew/flows.py
@@ -1,0 +1,195 @@
+"""
+Flows for us_bls_qcew — Prefect 3.
+
+US Quarterly Census of Employment and Wages (BLS QCEW). The recurring pipeline
+refreshes only the 8 **NAICS** tables ({quarterly, annual} x {national, state,
+county, metro}); the 8 SIC tables are a frozen classification (1975-2000, never
+republished) and the dicionario is static, so neither is in the pipeline's loop.
+
+QCEW publishes a new quarter roughly one quarter after it ends and revises prior
+quarters on every release. Each run therefore re-cleans the entire NAICS history
+and does a **full replace** (dump_mode="overwrite"), not an incremental append.
+The source poll (on the newest quarter) short-circuits a scheduled run until BLS
+actually publishes a newer period, making the between-release runs cheap no-ops.
+
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers `us_bls_qcew_flow`; the
+dev pool ignores the schedule, the prod pool activates it (paused until armed).
+"""
+
+import shutil
+import tempfile
+
+from prefect import flow
+
+from pipelines.datasets.us_bls_qcew.constants import constants
+from pipelines.datasets.us_bls_qcew.tasks import (
+    clean_qcew,
+    latest_source_period,
+)
+from pipelines.utils.metadata.domain import (
+    AllFree,
+    DateFormat,
+    FreeLag,
+    PartBdpro,
+    YearOnly,
+    YearQuarter,
+)
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+NAICS_TABLES = constants.NAICS_TABLES.value
+POLL_TABLE = constants.POLL_TABLE.value
+
+# Coverage spec per NAICS table.
+#
+# The four `naics_quarterly_*` tables are refreshed quarterly, so they carry the
+# BD Pro rolling window: the most recent 6 months (the latest two closed
+# quarters) are pro-only, everything older is free. Each run recomputes
+# free_end = source_end - free_lag, rewrites both DateTimeRanges, and re-issues
+# the BigQuery Row Access Policies, so the window slides forward on its own.
+#
+# part_bdpro requires BOTH a free (is_closed=False) and a pro (is_closed=True)
+# Coverage to already exist on the table, or assert_coverage_topology raises
+# before anything is written — those were created at onboarding.
+#
+# The four `naics_annual_*` tables are lower-frequency and stay fully free.
+_QUARTERLY = PartBdpro(
+    date_column=YearQuarter(year="year", quarter="qtr"),
+    date_format=DateFormat.YEAR_MONTH,
+    free_lag=FreeLag(unit="months", value=6),
+)
+_ANNUAL = AllFree(
+    date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
+)
+_COVERAGE = {
+    table: (_QUARTERLY if "quarterly" in table else _ANNUAL)
+    for table in NAICS_TABLES
+}
+
+
+@flow(name="us_bls_qcew", log_prints=True)
+def us_bls_qcew_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+) -> None:
+    """Refresh the 8 NAICS QCEW tables from the full published history.
+
+    QCEW ships each year as a per-year singlefile and revises prior quarters on
+    every release; ``upload_to_gcs`` overwrites the whole staging table, so each
+    run re-cleans the entire NAICS history rather than a single partition. The
+    source poll short-circuits the run when BLS has not published a newer
+    quarter, which makes a scheduled run a cheap no-op between releases.
+
+    Args:
+        materialize_to_prod: Continue past the dev materialization to write the
+            prod staging bucket and run dbt against ``target="prod"``. Set False
+            to exercise only the dev half — required for a safe test run, since
+            the default writes production.
+        update_metadata: After a successful prod materialization, register table
+            coverage (rolling the BD Pro window on the quarterly tables) and
+            commit the source update. Has no effect when ``materialize_to_prod``
+            is False.
+        force_run: Materialize even when the source poll reports no new quarter.
+    """
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id="naics"
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="us_bls_qcew_")
+    try:
+        # Cheap poll first: probe BLS and read only the newest quarterly file.
+        max_ym = latest_source_period(work_dir=work_dir)
+
+        has_new_data = poll_source_for_update_task(
+            dataset_id=DATASET_ID,
+            table_id=POLL_TABLE,
+            source_max_date=max_ym,
+            env="prod",
+            date_format="%Y-%m",
+        )
+        if not has_new_data and not force_run:
+            return
+
+        # Expensive: re-clean the full NAICS history into partitioned parquet.
+        paths = clean_qcew(work_dir=work_dir)
+
+        # Dev: upload staging + materialize/test.
+        for table in NAICS_TABLES:
+            upload_to_gcs(
+                data_path=paths[table],
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados-dev",
+                dump_mode="overwrite",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="dev",
+            )
+
+        if not materialize_to_prod:
+            return
+
+        # Prod: upload staging + materialize/test.
+        for table in NAICS_TABLES:
+            upload_to_gcs(
+                data_path=paths[table],
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados",
+                dump_mode="overwrite",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="prod",
+            )
+
+        if update_metadata:
+            for table in NAICS_TABLES:
+                register_table_materialization_task(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    coverage=_COVERAGE[table],
+                    env="prod",
+                    bq_project="basedosdados",
+                )
+            commit_source_update_task(
+                dataset_id=DATASET_ID,
+                table_id=POLL_TABLE,
+                source_max_date=max_ym,
+                env="prod",
+                date_format="%Y-%m",
+            )
+    finally:
+        # Covers both early returns (no new data, dev-only) and any exception.
+        # The k8s work pool gives each run a fresh pod, but a process/local
+        # worker reuses its filesystem — the full NAICS download is tens of GB.
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# QCEW releases a quarter roughly one quarter after it ends: County Employment
+# and Wages news releases land in early March, June, September, and December.
+# Poll across the first ~10 days of those months at 16:00 BRT; the source-poll
+# guard no-ops until a new quarter actually appears in the singlefiles.
+us_bls_qcew_flow.deploy_schedules = [
+    {"cron": "0 16 1-10 3,6,9,12 *", "timezone": "America/Sao_Paulo"}
+]
+# The clean step streams ~15M-row singlefiles one chunk at a time (peak ~1.75GB
+# in pandas); give the worker headroom above that.
+us_bls_qcew_flow.job_variables = {"memory": "8Gi"}

--- a/pipelines/datasets/us_bls_qcew/tasks.py
+++ b/pipelines/datasets/us_bls_qcew/tasks.py
@@ -1,0 +1,68 @@
+"""Prefect 3 tasks for us_bls_qcew — thin wrappers over utils.py.
+
+Two tasks split the work so the source poll runs before the expensive full
+history clean: :func:`latest_source_period` cheaply probes BLS and returns the
+newest NAICS quarterly period, and :func:`clean_qcew` re-cleans the whole NAICS
+history only once the flow's poll guard confirms a new quarter (or a forced run).
+"""
+
+from pathlib import Path
+
+from prefect import task
+
+from pipelines.datasets.us_bls_qcew.constants import constants
+from pipelines.datasets.us_bls_qcew.utils import (
+    clean_naics_full_history,
+    source_max_year_month,
+)
+
+
+@task(retries=2, retry_delay_seconds=30)
+def latest_source_period(work_dir: str) -> str:
+    """Probe BLS and return the newest NAICS quarterly period as ``"YYYY-MM"``.
+
+    Downloads only the latest year's NAICS quarterly singlefile and scans its
+    ``qtr`` column, so the poll decision costs one file rather than the full
+    history. The quarter is mapped to its end month (``quarter * 3``), matching
+    the coverage date the metadata layer reads from BigQuery.
+
+    Retries twice: ``data.bls.gov`` intermittently drops the larger transfers.
+
+    Args:
+        work_dir: Directory to download into; files land under ``<work_dir>/input``.
+
+    Returns:
+        The source's max coverage period as ``"YYYY-MM"``.
+    """
+    input_dir = Path(work_dir) / "input"
+    return source_max_year_month(
+        input_dir, floor=constants.NAICS_START_YEAR.value
+    )
+
+
+@task
+def clean_qcew(work_dir: str) -> dict:
+    """Rebuild the 8 partitioned NAICS tables from the full published history.
+
+    SIC is frozen and excluded; the dicionario is rebuilt but not returned as an
+    upload target. Each singlefile is streamed in row chunks and pruned once
+    cleaned, so peak memory is one chunk and disk holds only a few CSVs at a time.
+
+    Args:
+        work_dir: Directory to write into; tables land under ``<work_dir>/output``.
+
+    Returns:
+        A mapping of each NAICS table slug to its partitioned output directory.
+    """
+    input_dir = Path(work_dir) / "input"
+    output_dir = Path(work_dir) / "output"
+    clean_naics_full_history(
+        input_dir,
+        output_dir,
+        floor=constants.NAICS_START_YEAR.value,
+        download_workers=constants.PIPELINE_DOWNLOAD_WORKERS.value,
+    )
+    return {
+        table: str(output_dir / table)
+        for table in constants.NAICS_TABLES.value
+    }

--- a/pipelines/datasets/us_bls_qcew/utils.py
+++ b/pipelines/datasets/us_bls_qcew/utils.py
@@ -14,6 +14,7 @@ by the ``agglvl_code``, which uses different schemes for NAICS and SIC. See
 
 import concurrent.futures
 import csv
+import datetime
 import logging
 import shutil
 import zipfile
@@ -96,6 +97,85 @@ def download_singlefile(
             shutil.copyfileobj(src, dst)
     zip_path.unlink()
     return marker
+
+
+def singlefile_available(classification: str, freq: str, year: int) -> bool:
+    """Return whether the (classification, freq, year) singlefile is published.
+
+    Probes the URL with a streaming GET and inspects only the status code — the
+    body is never read, so a leading-edge year that BLS has not yet published
+    (404) is detected cheaply. ``data.bls.gov`` requires a browser User-Agent.
+    """
+    url = singlefile_url(classification, freq, year)
+    with requests.get(url, headers=_HEADERS, timeout=120, stream=True) as r:
+        return r.status_code == 200
+
+
+def latest_available_year(
+    classification: str, freq: str, floor: int, ceiling: int | None = None
+) -> int:
+    """Highest published year for a (classification, freq), probing downward.
+
+    QCEW publishes each year's quarterly singlefile before that year's annual
+    singlefile (the annual file needs all four quarters), so the latest available
+    year differs between the two frequencies. Probe each frequency separately.
+
+    Args:
+        classification: ``"naics"`` or ``"sic"``.
+        freq: ``"quarterly"`` or ``"annual"``.
+        floor: earliest year to consider (the coverage start).
+        ceiling: newest year to probe; defaults to the current calendar year.
+
+    Returns:
+        The greatest year in ``[floor, ceiling]`` whose singlefile exists.
+
+    Raises:
+        RuntimeError: if no year in the range is published.
+    """
+    if ceiling is None:
+        ceiling = datetime.date.today().year
+    for year in range(ceiling, floor - 1, -1):
+        if singlefile_available(classification, freq, year):
+            return year
+    raise RuntimeError(
+        f"no published {classification}/{freq} singlefile in {floor}..{ceiling}"
+    )
+
+
+def peek_max_quarter(
+    classification: str, freq: str, year: int, input_dir: Path
+) -> int:
+    """Return the greatest quarter (1-4) present in a quarterly singlefile.
+
+    Downloads the singlefile (cached) and scans only its ``qtr`` column, so a new
+    quarter appended to an existing year's file is detected without a full clean.
+    Within one calendar year QCEW adds quarters incrementally — a mid-year file
+    may hold only Q1-Q2 — so the max quarter, not merely the year, drives the poll.
+    """
+    path = download_singlefile(classification, freq, year, input_dir)
+    col = pd.read_csv(
+        path,
+        dtype=str,
+        na_filter=False,
+        usecols=lambda c: c.strip() == "qtr",
+    ).iloc[:, 0]
+    return int(pd.to_numeric(col.str.strip(), errors="coerce").max())
+
+
+def source_max_year_month(
+    input_dir: Path, floor: int, ceiling: int | None = None
+) -> str:
+    """Latest NAICS quarterly period as ``"YYYY-MM"`` for the source poll.
+
+    A quarter is mapped to its end month (``quarter * 3``) — Q1→03, Q2→06,
+    Q3→09, Q4→12 — matching the ``DATE(year, quarter*3, 1)`` convention that
+    ``register_table_materialization`` uses to read the table's max coverage date
+    from BigQuery. Keeping the two aligned makes the poll comparison and the
+    committed source ``Update`` consistent with the stored coverage end.
+    """
+    year = latest_available_year("naics", "quarterly", floor, ceiling)
+    quarter = peek_max_quarter("naics", "quarterly", year, input_dir)
+    return f"{year}-{quarter * 3:02d}"
 
 
 def download_titles(input_dir: Path) -> Path:
@@ -481,4 +561,64 @@ def clean_all(
 
     build_dicionario(input_dir, output_dir)
     written["dicionario"] = "built"
+    return written
+
+
+def clean_naics_full_history(
+    input_dir: Path,
+    output_dir: Path,
+    floor: int,
+    ceiling: int | None = None,
+    download_workers: int = 1,
+) -> dict:
+    """Rebuild the full NAICS history (both frequencies) into partitioned parquet.
+
+    The recurring pipeline refreshes only the NAICS tables — SIC is frozen
+    (1975-2000) and never republished, so it is excluded here. QCEW revises prior
+    quarters on every release, and ``upload_to_gcs`` overwrites the whole staging
+    table, so each run re-cleans the entire NAICS history rather than a single
+    partition.
+
+    The quarterly and annual latest years differ (a year's annual singlefile is
+    published only after its four quarters), so the two frequencies are probed
+    separately. Years where both frequencies exist go through :func:`clean_all`;
+    any leading years that have a quarterly file but not yet an annual file are
+    cleaned quarterly-only via :func:`clean_year`, so the newest quarter is
+    ingested without waiting up to a year for its annual counterpart.
+
+    ``prune_input=True`` throughout: each multi-GB CSV is deleted once cleaned, so
+    a worker's disk holds at most ``download_workers`` singlefiles at a time.
+
+    Args:
+        input_dir: Root of downloaded files.
+        output_dir: Root output directory.
+        floor: earliest NAICS year (coverage start, 1990).
+        ceiling: newest year to probe; defaults to the current calendar year.
+        download_workers: concurrent downloads prefetched ahead of the cleaner.
+
+    Returns:
+        ``{table_slug: total_rows_written}`` for the 8 NAICS tables + dicionario.
+    """
+    qtrly_latest = latest_available_year("naics", "quarterly", floor, ceiling)
+    annual_latest = latest_available_year("naics", "annual", floor, ceiling)
+    log.info(
+        f"NAICS latest available: quarterly={qtrly_latest} annual={annual_latest}"
+    )
+
+    written = clean_all(
+        {"naics": list(range(floor, annual_latest + 1)), "sic": []},
+        input_dir,
+        output_dir,
+        prune_input=True,
+        download_workers=download_workers,
+    )
+
+    # Leading years with a quarterly file but no annual file yet.
+    for year in range(annual_latest + 1, qtrly_latest + 1):
+        counts = clean_year(
+            "naics", "quarterly", year, input_dir, output_dir, prune_input=True
+        )
+        for table, n in counts.items():
+            base = written.get(table, 0)
+            written[table] = (base if isinstance(base, int) else 0) + n
     return written


### PR DESCRIPTION
## What

Adds the recurring Prefect 3 pipeline for **us_bls_qcew** (BLS QCEW), a follow-up to the onboarding PR #1727 (merged, dataset live in prod).

- Refreshes the **8 NAICS tables** only (`{quarterly,annual} × {national,state,county,metro}`). The 8 SIC tables are a frozen classification (1975–2000, never republished) and `dicionario` is static, so neither is in the pipeline loop.
- **Poll-first:** probes the newest quarterly singlefile and short-circuits between BLS releases (cheap no-op). On new data, re-cleans the **full NAICS history** and does a full replace (`dump_mode="overwrite"`) — QCEW revises prior quarters and ships full history each release, so incremental append would truncate.
- **BD Pro rolling window** on the 4 `naics_quarterly_*` (`PartBdpro`, `free_lag=6mo` → latest two closed quarters paywalled); `naics_annual_*` stay `AllFree`. `register_table_materialization_task` rolls the window + re-issues Row Access Policies each run.
- Reuses the shared `clean_all`/`clean_year` transform (additive `utils.py` helpers only — the onboarding transform is untouched).
- Quarterly cron `0 16 1-10 3,6,9,12 *` (America/Sao_Paulo); `8Gi` worker.

## Verification
- Local: imports, deploy discovery (`us_bls_qcew_flow` found), metadata-policy fns (coverage window rolls correctly), real BLS source probe — all pass.
- **Needs a dev-pool run** with `{materialize_to_prod: False, update_metadata: False, force_run: True}` before arming (the `deploy-flow` label is set so the staging deploy registers it). Green Prefect state ≠ ingested — logs must show `dbt run OK` + `dbt test OK` for the 8 tables.

## Post-merge
Deploys to the prod pool **paused**; arming is a deliberate manual tick in Django admin. First armed run is the first prod upload + first Row-Access-Policy issuance for the 4 BD-Pro tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated recurring refreshes for NAICS-based QCEW data across quarterly and annual tables.
  * Added detection of newly published source periods, with support for forced refreshes.
  * Added full-history processing and refreshed staging outputs across supported geographies.
* **Bug Fixes**
  * Improved handling of missing, unchanged, and partially available source releases.
  * Added validation and metadata updates after successful production refreshes.
* **Scope**
  * SIC data remains excluded from recurring refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->