### PR TITLE
feat(au_nsw_bocsar_crime): onboard NSW BOCSAR crime statistics

### DIFF
--- a/.claude/rules/data-basis-style.md
+++ b/.claude/rules/data-basis-style.md
@@ -14,10 +14,26 @@ Always fetch the language-appropriate style manual before designing columns:
 
 Default language: Portuguese for Brazilian government datasets.
 
+## Column names follow the data's language (English data → English names)
+
+**Column names must be in the same language as the dataset's data and metadata, not Portuguese by default.** Brazilian government datasets are Portuguese; a US/UK/Australian/international dataset is English. Picking the language is the first naming decision — get it right before writing the architecture, because renaming later is expensive.
+
+The recurring error is defaulting temporal/geographic columns to Portuguese on an English dataset. For an **English-language** dataset:
+
+| Portuguese (Brazilian data) | English (English data) |
+|---|---|
+| `ano` | `year` |
+| `mes` | `month` |
+| `data` | `date` |
+| `sigla_uf` / `id_municipio` | the source country's own geography names/codes (e.g. `id_sa4`, `lga_name`, `country_iso3_code`) — never `sigla_uf`/`id_municipio`, which are Brazil-specific |
+| `nome_`, `quantidade_`, `valor_`, `tipo_`, `descricao_` prefixes | natural English snake_case (`name_*`, `quantity_*` / a plain count noun, `value_*`, `type_*`, `description_*`) |
+
+The **partition column is `year` (INT64), not `ano`**, on an English annual/monthly dataset. The rest of this file's examples use Portuguese because the default dataset is Brazilian; translate the column *names* (not just the descriptions) whenever the data language is English. Column descriptions are always written in all three languages (PT/EN/ES) regardless — see [Descriptions](#descriptions).
+
 ## Column naming conventions
 
 - All column names: **snake_case**, lowercase, no accents.
-- Standard prefixes and what they signal:
+- Standard prefixes and what they signal (Portuguese datasets; use the English equivalents above for English data):
 
 | Prefix | Meaning | Example |
 |--------|---------|---------|
@@ -43,10 +59,12 @@ Default language: Portuguese for Brazilian government datasets.
 
 ## Standard partition columns
 
+Names below are Portuguese (Brazilian data). On an **English dataset** substitute `year` for `ano` and `month` for `mes`, and the source country's own geography columns for `sigla_uf`/`id_municipio` (see [Column names follow the data's language](#column-names-follow-the-datas-language-english-data--english-names)).
+
 | Scope | Partition columns |
 |-------|------------------|
-| National, annual | `ano` |
-| National, monthly | `ano`, `mes` |
+| National, annual | `ano` (English: `year`) |
+| National, monthly | `ano`, `mes` (English: `year`, `month`) |
 | State-level | `ano`, `sigla_uf` |
 | Municipal-level | `ano`, `sigla_uf`, `id_municipio` |
 
@@ -61,6 +79,8 @@ Always declare these in the `directory_column` field of architecture tables:
 | `sigla_uf` | `br_bd_diretorios_brasil.uf:sigla_uf` |
 | `id_municipio` | `br_bd_diretorios_brasil.municipio:id_municipio` |
 | `id_pais` | `br_bd_diretorios_mundo.pais:id_pais` |
+
+On an English dataset the temporal columns are named `year`/`month`; the time-directory values are the same integers, so if you link them, map `year` → `br_bd_diretorios_data_tempo.ano:ano` and `month` → `br_bd_diretorios_data_tempo.mes:mes`. Geography links to the source country's own directory (e.g. `br_bd_diretorios_au`), never the Brazilian one.
 
 ### Shared entities get their own directory
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -67,6 +67,9 @@ models:
     br_bcb_sicor:
       +materialized: table
       +schema: br_bcb_sicor
+    au_nsw_bocsar_crime:
+      +materialized: table
+      +schema: au_nsw_bocsar_crime
     br_bcb_taxa_cambio:
       +materialized: table
       +schema: br_bcb_taxa_cambio

--- a/models/au_nsw_bocsar_crime/.gitignore
+++ b/models/au_nsw_bocsar_crime/.gitignore
@@ -1,0 +1,3 @@
+input/
+output/
+*.parquet

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__alleged_offenders.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__alleged_offenders.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="alleged_offenders",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 2010, "end": 2031, "interval": 1},
+        },
+        cluster_by=["offence_category"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(financial_year as string) financial_year,
+    safe_cast(offence_category as string) offence_category,
+    safe_cast(offence_subcategory as string) offence_subcategory,
+    safe_cast(age_group as string) age_group,
+    safe_cast(legal_proceeding as string) legal_proceeding,
+    safe_cast(detailed_legal_proceeding as string) detailed_legal_proceeding,
+    safe_cast(poi_count as int64) poi_count
+from {{ set_datalake_project("au_nsw_bocsar_crime_staging.alleged_offenders") }} as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="criminal_incidents",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1995, "end": 2031, "interval": 1},
+        },
+        cluster_by=["offence_category"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(offence_category as string) offence_category,
+    safe_cast(offence_subcategory as string) offence_subcategory,
+    safe_cast(incidents as int64) incidents
+from {{ set_datalake_project("au_nsw_bocsar_crime_staging.criminal_incidents") }} as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_daily.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_daily.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="criminal_incidents_daily",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 2010, "end": 2031, "interval": 1},
+        },
+        cluster_by=["offence_category"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(date as date) date,
+    safe_cast(offence_category as string) offence_category,
+    safe_cast(offence_subcategory as string) offence_subcategory,
+    safe_cast(incidents as int64) incidents
+from
+    {{ set_datalake_project("au_nsw_bocsar_crime_staging.criminal_incidents_daily") }}
+    as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_lga.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_lga.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="criminal_incidents_lga",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1995, "end": 2031, "interval": 1},
+        },
+        cluster_by=["lga_name", "offence_category"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(lga_name as string) lga_name,
+    safe_cast(offence_category as string) offence_category,
+    safe_cast(offence_subcategory as string) offence_subcategory,
+    safe_cast(incidents as int64) incidents
+from
+    {{ set_datalake_project("au_nsw_bocsar_crime_staging.criminal_incidents_lga") }}
+    as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_postcode.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_postcode.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="criminal_incidents_postcode",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1995, "end": 2031, "interval": 1},
+        },
+        cluster_by=["postcode", "offence_category"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(postcode as string) postcode,
+    safe_cast(offence_category as string) offence_category,
+    safe_cast(offence_subcategory as string) offence_subcategory,
+    safe_cast(incidents as int64) incidents
+from
+    {{
+        set_datalake_project(
+            "au_nsw_bocsar_crime_staging.criminal_incidents_postcode"
+        )
+    }} as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_sa4.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_sa4.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="criminal_incidents_sa4",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1995, "end": 2031, "interval": 1},
+        },
+        cluster_by=["sa4_name", "offence_category"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(sa4_name as string) sa4_name,
+    safe_cast(offence_category as string) offence_category,
+    safe_cast(offence_subcategory as string) offence_subcategory,
+    safe_cast(incidents as int64) incidents
+from
+    {{ set_datalake_project("au_nsw_bocsar_crime_staging.criminal_incidents_sa4") }}
+    as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_suburb.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__criminal_incidents_suburb.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="criminal_incidents_suburb",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1995, "end": 2031, "interval": 1},
+        },
+        cluster_by=["suburb", "offence_category"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(suburb as string) suburb,
+    safe_cast(offence_category as string) offence_category,
+    safe_cast(offence_subcategory as string) offence_subcategory,
+    safe_cast(incidents as int64) incidents
+from
+    {{ set_datalake_project("au_nsw_bocsar_crime_staging.criminal_incidents_suburb") }}
+    as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__custody_discharges.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__custody_discharges.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="custody_discharges",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 2013, "end": 2031, "interval": 1},
+        },
+        cluster_by=["custody_system", "discharge_type"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(custody_system as string) custody_system,
+    safe_cast(discharge_type as string) discharge_type,
+    safe_cast(discharge_type_breakdown as string) discharge_type_breakdown,
+    safe_cast(aboriginality as string) aboriginality,
+    safe_cast(sex as string) sex,
+    safe_cast(discharges as int64) discharges
+from {{ set_datalake_project("au_nsw_bocsar_crime_staging.custody_discharges") }} as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__custody_population.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__custody_population.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="custody_population",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 2013, "end": 2031, "interval": 1},
+        },
+        cluster_by=["custody_system", "most_serious_offence"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(custody_system as string) custody_system,
+    safe_cast(legal_status as string) legal_status,
+    safe_cast(aboriginality as string) aboriginality,
+    safe_cast(sex as string) sex,
+    safe_cast(most_serious_offence as string) most_serious_offence,
+    safe_cast(people as int64) people
+from {{ set_datalake_project("au_nsw_bocsar_crime_staging.custody_population") }} as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__custody_receptions.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__custody_receptions.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="custody_receptions",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 2013, "end": 2031, "interval": 1},
+        },
+        cluster_by=["custody_system"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(custody_system as string) custody_system,
+    safe_cast(reception_status as string) reception_status,
+    safe_cast(aboriginality as string) aboriginality,
+    safe_cast(sex as string) sex,
+    safe_cast(receptions as int64) receptions
+from {{ set_datalake_project("au_nsw_bocsar_crime_staging.custody_receptions") }} as t

--- a/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__custody_remand_to_sentenced.sql
+++ b/models/au_nsw_bocsar_crime/au_nsw_bocsar_crime__custody_remand_to_sentenced.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        schema="au_nsw_bocsar_crime",
+        alias="custody_remand_to_sentenced",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 2013, "end": 2031, "interval": 1},
+        },
+        cluster_by=["custody_system"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(custody_system as string) custody_system,
+    safe_cast(discharge_type as string) discharge_type,
+    safe_cast(aboriginality as string) aboriginality,
+    safe_cast(sex as string) sex,
+    safe_cast(transitions as int64) transitions
+from
+    {{
+        set_datalake_project(
+            "au_nsw_bocsar_crime_staging.custody_remand_to_sentenced"
+        )
+    }} as t

--- a/models/au_nsw_bocsar_crime/code/architecture/alleged_offenders.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/alleged_offenders.csv
@@ -1,0 +1,9 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+financial_year,STRING,"Australian financial year of reference, 1 July to 30 June, e.g. 2010-11",,no,,,no,,
+offence_category,STRING,"BOCSAR offence category, the top level of the offence classification",,no,,,no,,Offence type - main category
+offence_subcategory,STRING,"BOCSAR offence subcategory, the detailed offence type within the category",,no,,,no,,Offence type - subcategory
+age_group,STRING,"Age group of the person of interest (10 to 17 years, or Adult)",,no,,,no,,POIs Age
+legal_proceeding,STRING,Method of legal proceeding (court diversion or proceeded against to court),,no,,,no,,Method of legal proceeding
+detailed_legal_proceeding,STRING,Detailed method of legal proceeding within the broader method,,no,,,no,,Detailed method of legal proceeding
+poi_count,INT64,Number of persons of interest legally proceeded against by the NSW Police Force,,no,,person,no,,

--- a/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,,
+offence_category,STRING,"BOCSAR offence category, the top level of the offence classification",,no,,,no,,Offence category
+offence_subcategory,STRING,"BOCSAR offence subcategory, the detailed offence type within the category",,no,,,no,,Subcategory
+incidents,INT64,Number of criminal incidents recorded by the NSW Police Force,,no,,incident,no,,

--- a/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_daily.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_daily.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+date,DATE,Calendar date of the recorded incidents,,no,,,no,,Date
+offence_category,STRING,BOCSAR offence category mapped from the published offence label,,no,,,no,Mapped from the leaf offence label via the offence hierarchy,
+offence_subcategory,STRING,Offence label as published in the daily file (leaf of the offence hierarchy),,no,,,no,,
+incidents,INT64,Number of criminal incidents recorded by the NSW Police Force,,no,,incident,no,,

--- a/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_lga.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_lga.csv
@@ -1,0 +1,7 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,,
+lga_name,STRING,Name of the Local Government Area in New South Wales,,no,,,no,Identified by name only in the source; intended FK to br_bd_diretorios_au once that directory is live,LGA
+offence_category,STRING,"BOCSAR offence category, the top level of the offence classification",,no,,,no,,Offence category
+offence_subcategory,STRING,"BOCSAR offence subcategory, the detailed offence type within the category",,no,,,no,,Subcategory
+incidents,INT64,Number of criminal incidents recorded by the NSW Police Force,,no,,incident,no,,

--- a/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_postcode.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_postcode.csv
@@ -1,0 +1,7 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,,
+postcode,STRING,Australian postcode of the recorded incidents,,no,,,no,Identified by name only in the source; intended FK to br_bd_diretorios_au once that directory is live,Postcode
+offence_category,STRING,"BOCSAR offence category, the top level of the offence classification",,no,,,no,,Offence category
+offence_subcategory,STRING,"BOCSAR offence subcategory, the detailed offence type within the category",,no,,,no,,Subcategory
+incidents,INT64,Number of criminal incidents recorded by the NSW Police Force,,no,,incident,no,,

--- a/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_sa4.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_sa4.csv
@@ -1,0 +1,7 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,,
+sa4_name,STRING,Name of the Statistical Area Level 4 (ASGS) in New South Wales,,no,,,no,Identified by name only in the source; intended FK to br_bd_diretorios_au once that directory is live,NSW Statistical Area
+offence_category,STRING,"BOCSAR offence category, the top level of the offence classification",,no,,,no,,Offence category
+offence_subcategory,STRING,"BOCSAR offence subcategory, the detailed offence type within the category",,no,,,no,,Subcategory
+incidents,INT64,Number of criminal incidents recorded by the NSW Police Force,,no,,incident,no,,

--- a/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_suburb.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/criminal_incidents_suburb.csv
@@ -1,0 +1,7 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,,
+suburb,STRING,Suburb name in New South Wales,,no,,,no,Identified by name only in the source; intended FK to br_bd_diretorios_au once that directory is live,Suburb
+offence_category,STRING,"BOCSAR offence category, the top level of the offence classification",,no,,,no,,Offence category
+offence_subcategory,STRING,"BOCSAR offence subcategory, the detailed offence type within the category",,no,,,no,,Subcategory
+incidents,INT64,Number of criminal incidents recorded by the NSW Police Force,,no,,incident,no,,

--- a/models/au_nsw_bocsar_crime/code/architecture/custody_discharges.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/custody_discharges.csv
@@ -1,0 +1,9 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,,
+custody_system,STRING,Custody system the record refers to (adult or youth),,no,,,no,Derived from which BOCSAR custody report the row came from,
+discharge_type,STRING,Type of custody the person was discharged from (remand or sentenced),,no,,,no,,Discharge Type
+discharge_type_breakdown,STRING,Detailed discharge destination or reason,,no,,,no,,Discharge Type Breakdown
+aboriginality,STRING,"Aboriginal status of the person (Aboriginal, Non-Aboriginal or Unknown)",,no,,,no,,Aboriginality
+sex,STRING,Sex of the person (Female or Male),,no,,,no,,Gender
+discharges,INT64,Number of discharges from custody during the month,,no,,discharge,no,,Count

--- a/models/au_nsw_bocsar_crime/code/architecture/custody_population.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/custody_population.csv
@@ -1,0 +1,9 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,,
+custody_system,STRING,Custody system the record refers to (adult or youth),,no,,,no,Derived from which BOCSAR custody report the row came from,
+legal_status,STRING,Legal status of the person in custody (remand or sentenced),,no,,,no,,Legal Status
+aboriginality,STRING,"Aboriginal status of the person (Aboriginal, Non-Aboriginal or Unknown)",,no,,,no,,Aboriginality
+sex,STRING,Sex of the person (Female or Male),,no,,,no,,Gender
+most_serious_offence,STRING,Most serious offence associated with the person in custody,,no,,,no,,MSO
+people,INT64,Number of people in custody on the last day of the month,,no,,person,no,,Count

--- a/models/au_nsw_bocsar_crime/code/architecture/custody_receptions.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/custody_receptions.csv
@@ -1,0 +1,8 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,,
+custody_system,STRING,Custody system the record refers to (adult or youth),,no,,,no,Derived from which BOCSAR custody report the row came from,
+reception_status,STRING,"Legal status at reception into custody (remand, sentenced or unknown)",,no,,,no,,Reception Status
+aboriginality,STRING,"Aboriginal status of the person (Aboriginal, Non-Aboriginal or Unknown)",,no,,,no,,Aboriginality
+sex,STRING,Sex of the person (Female or Male),,no,,,no,,Gender
+receptions,INT64,Number of receptions into custody during the month,,no,,reception,no,,Count

--- a/models/au_nsw_bocsar_crime/code/architecture/custody_remand_to_sentenced.csv
+++ b/models/au_nsw_bocsar_crime/code/architecture/custody_remand_to_sentenced.csv
@@ -1,0 +1,8 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,,
+custody_system,STRING,Custody system the record refers to (adult or youth),,no,,,no,Derived from which BOCSAR custody report the row came from,
+discharge_type,STRING,"Transition recorded, remand to sentenced custody",,no,,,no,,Discharge Type
+aboriginality,STRING,"Aboriginal status of the person (Aboriginal, Non-Aboriginal or Unknown)",,no,,,no,,Aboriginality
+sex,STRING,Sex of the person (Female or Male),,no,,,no,,Gender
+transitions,INT64,Number of people who transitioned from remand to sentenced custody during the month,,no,,transition,no,,Count

--- a/models/au_nsw_bocsar_crime/code/build_architecture.py
+++ b/models/au_nsw_bocsar_crime/code/build_architecture.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Emit the au_nsw_bocsar_crime architecture CSVs (one per table).
+
+The architecture CSVs are the source of truth for column names, order, types,
+English descriptions, dictionary/unit flags and directory links. clean_data.py
+reads them for column order; build_columns_json.py reads them for metadata.
+
+English dataset -> English column names (year/month/date), per
+.claude/rules/data-basis-style.md.
+
+Usage: uv run python models/au_nsw_bocsar_crime/code/build_architecture.py
+"""
+
+import csv
+from pathlib import Path
+
+ARCH = Path(__file__).resolve().parent / "architecture"
+FIELDS = [
+    "name",
+    "bigquery_type",
+    "description",
+    "temporal_coverage",
+    "covered_by_dictionary",
+    "directory_column",
+    "measurement_unit",
+    "has_sensitive_data",
+    "observations",
+    "original_name",
+]
+
+# Reusable column definitions: name -> (type, description_en, dir, unit, obs, original)
+YEAR = (
+    "year",
+    "INT64",
+    "Reference year of the observation",
+    "no",
+    "br_bd_diretorios_data_tempo.ano:ano",
+    "year",
+    "no",
+    "Partition column",
+    "",
+)
+MONTH = (
+    "month",
+    "INT64",
+    "Reference month of the observation, from 1 to 12",
+    "no",
+    "br_bd_diretorios_data_tempo.mes:mes",
+    "month",
+    "no",
+    "",
+    "",
+)
+OCAT = (
+    "offence_category",
+    "STRING",
+    "BOCSAR offence category, the top level of the offence classification",
+    "no",
+    "",
+    "",
+    "no",
+    "",
+    "Offence category",
+)
+OSUB = (
+    "offence_subcategory",
+    "STRING",
+    "BOCSAR offence subcategory, the detailed offence type within the category",
+    "no",
+    "",
+    "",
+    "no",
+    "",
+    "Subcategory",
+)
+ABOR = (
+    "aboriginality",
+    "STRING",
+    "Aboriginal status of the person (Aboriginal, Non-Aboriginal or Unknown)",
+    "no",
+    "",
+    "",
+    "no",
+    "",
+    "Aboriginality",
+)
+SEX = (
+    "sex",
+    "STRING",
+    "Sex of the person (Female or Male)",
+    "no",
+    "",
+    "",
+    "no",
+    "",
+    "Gender",
+)
+SYS = (
+    "custody_system",
+    "STRING",
+    "Custody system the record refers to (adult or youth)",
+    "no",
+    "",
+    "",
+    "no",
+    "Derived from which BOCSAR custody report the row came from",
+    "",
+)
+
+
+def col(
+    name,
+    btype,
+    desc,
+    cbd="no",
+    directory="",
+    unit="",
+    sens="no",
+    obs="",
+    orig="",
+):
+    return {
+        "name": name,
+        "bigquery_type": btype,
+        "description": desc,
+        "temporal_coverage": "",
+        "covered_by_dictionary": cbd,
+        "directory_column": directory,
+        "measurement_unit": unit,
+        "has_sensitive_data": sens,
+        "observations": obs,
+        "original_name": orig,
+    }
+
+
+def c(tup):
+    """Expand a reusable tuple into a column dict."""
+    name, btype, desc, cbd, directory, unit, sens, obs, orig = tup
+    return col(name, btype, desc, cbd, directory, unit, sens, obs, orig)
+
+
+GEO_FK_NOTE = (
+    "Identified by name only in the source; intended FK to br_bd_diretorios_au "
+    "once that directory is live"
+)
+
+INC = col(
+    "incidents",
+    "INT64",
+    "Number of criminal incidents recorded by the NSW Police Force",
+    unit="incident",
+    orig="",
+)
+
+TABLES = {
+    # ---- Recorded Criminal Incidents (RCI) ----
+    "criminal_incidents": [c(YEAR), c(MONTH), c(OCAT), c(OSUB), INC],
+    "criminal_incidents_sa4": [
+        c(YEAR),
+        c(MONTH),
+        col(
+            "sa4_name",
+            "STRING",
+            "Name of the Statistical Area Level 4 (ASGS) in New South Wales",
+            obs=GEO_FK_NOTE,
+            orig="NSW Statistical Area",
+        ),
+        c(OCAT),
+        c(OSUB),
+        INC,
+    ],
+    "criminal_incidents_lga": [
+        c(YEAR),
+        c(MONTH),
+        col(
+            "lga_name",
+            "STRING",
+            "Name of the Local Government Area in New South Wales",
+            obs=GEO_FK_NOTE,
+            orig="LGA",
+        ),
+        c(OCAT),
+        c(OSUB),
+        INC,
+    ],
+    "criminal_incidents_postcode": [
+        c(YEAR),
+        c(MONTH),
+        col(
+            "postcode",
+            "STRING",
+            "Australian postcode of the recorded incidents",
+            obs=GEO_FK_NOTE,
+            orig="Postcode",
+        ),
+        c(OCAT),
+        c(OSUB),
+        INC,
+    ],
+    "criminal_incidents_suburb": [
+        c(YEAR),
+        c(MONTH),
+        col(
+            "suburb",
+            "STRING",
+            "Suburb name in New South Wales",
+            obs=GEO_FK_NOTE,
+            orig="Suburb",
+        ),
+        c(OCAT),
+        c(OSUB),
+        INC,
+    ],
+    "criminal_incidents_daily": [
+        c(YEAR),
+        col(
+            "date",
+            "DATE",
+            "Calendar date of the recorded incidents",
+            orig="Date",
+        ),
+        col(
+            "offence_category",
+            "STRING",
+            "BOCSAR offence category mapped from the published offence label",
+            obs="Mapped from the leaf offence label via the offence hierarchy",
+        ),
+        col(
+            "offence_subcategory",
+            "STRING",
+            "Offence label as published in the daily file (leaf of the offence hierarchy)",
+        ),
+        INC,
+    ],
+    # ---- Alleged offenders (financial-year, annual) ----
+    "alleged_offenders": [
+        c(YEAR),
+        col(
+            "financial_year",
+            "STRING",
+            "Australian financial year of reference, 1 July to 30 June, e.g. 2010-11",
+            orig="",
+        ),
+        col(
+            "offence_category",
+            "STRING",
+            "BOCSAR offence category, the top level of the offence classification",
+            orig="Offence type - main category",
+        ),
+        col(
+            "offence_subcategory",
+            "STRING",
+            "BOCSAR offence subcategory, the detailed offence type within the category",
+            orig="Offence type - subcategory",
+        ),
+        col(
+            "age_group",
+            "STRING",
+            "Age group of the person of interest (10 to 17 years, or Adult)",
+            orig="POIs Age",
+        ),
+        col(
+            "legal_proceeding",
+            "STRING",
+            "Method of legal proceeding (court diversion or proceeded against to court)",
+            orig="Method of legal proceeding",
+        ),
+        col(
+            "detailed_legal_proceeding",
+            "STRING",
+            "Detailed method of legal proceeding within the broader method",
+            orig="Detailed method of legal proceeding",
+        ),
+        col(
+            "poi_count",
+            "INT64",
+            "Number of persons of interest legally proceeded against by the NSW Police Force",
+            unit="person",
+        ),
+    ],
+    # ---- Custody (adult + youth combined via custody_system) ----
+    "custody_population": [
+        c(YEAR),
+        c(MONTH),
+        c(SYS),
+        col(
+            "legal_status",
+            "STRING",
+            "Legal status of the person in custody (remand or sentenced)",
+            orig="Legal Status",
+        ),
+        c(ABOR),
+        c(SEX),
+        col(
+            "most_serious_offence",
+            "STRING",
+            "Most serious offence associated with the person in custody",
+            orig="MSO",
+        ),
+        col(
+            "people",
+            "INT64",
+            "Number of people in custody on the last day of the month",
+            unit="person",
+            orig="Count",
+        ),
+    ],
+    "custody_receptions": [
+        c(YEAR),
+        c(MONTH),
+        c(SYS),
+        col(
+            "reception_status",
+            "STRING",
+            "Legal status at reception into custody (remand, sentenced or unknown)",
+            orig="Reception Status",
+        ),
+        c(ABOR),
+        c(SEX),
+        col(
+            "receptions",
+            "INT64",
+            "Number of receptions into custody during the month",
+            unit="reception",
+            orig="Count",
+        ),
+    ],
+    "custody_discharges": [
+        c(YEAR),
+        c(MONTH),
+        c(SYS),
+        col(
+            "discharge_type",
+            "STRING",
+            "Type of custody the person was discharged from (remand or sentenced)",
+            orig="Discharge Type",
+        ),
+        col(
+            "discharge_type_breakdown",
+            "STRING",
+            "Detailed discharge destination or reason",
+            orig="Discharge Type Breakdown",
+        ),
+        c(ABOR),
+        c(SEX),
+        col(
+            "discharges",
+            "INT64",
+            "Number of discharges from custody during the month",
+            unit="discharge",
+            orig="Count",
+        ),
+    ],
+    "custody_remand_to_sentenced": [
+        c(YEAR),
+        c(MONTH),
+        c(SYS),
+        col(
+            "discharge_type",
+            "STRING",
+            "Transition recorded, remand to sentenced custody",
+            orig="Discharge Type",
+        ),
+        c(ABOR),
+        c(SEX),
+        col(
+            "transitions",
+            "INT64",
+            "Number of people who transitioned from remand to sentenced custody during the month",
+            unit="transition",
+            orig="Count",
+        ),
+    ],
+}
+
+
+def main():
+    ARCH.mkdir(parents=True, exist_ok=True)
+    for table, cols in TABLES.items():
+        path = ARCH / f"{table}.csv"
+        with open(path, "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=FIELDS)
+            w.writeheader()
+            w.writerows(cols)
+        print(f"{table}: {len(cols)} columns -> code/architecture/{table}.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_nsw_bocsar_crime/code/build_columns_json.py
+++ b/models/au_nsw_bocsar_crime/code/build_columns_json.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Emit columns_json payloads for mcp__databasis__bulk_upsert_columns, one per table.
+
+Reads the architecture CSVs (English descriptions + type/dictionary/unit flags)
+and attaches Portuguese and Spanish translations from TRANSLATIONS below, so
+columns register without a Google Sheet. Writes code/columns_json/<table>.json.
+
+Usage: uv run python models/au_nsw_bocsar_crime/code/build_columns_json.py
+"""
+
+import csv
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARCH = ROOT / "code" / "architecture"
+OUT = ROOT / "code" / "columns_json"
+
+# name (or name:table) -> (description_pt, description_es). English from the CSV.
+TRANSLATIONS = {
+    "year": (
+        "Ano de referência da observação",
+        "Año de referencia de la observación",
+    ),
+    "month": (
+        "Mês de referência da observação, de 1 a 12",
+        "Mes de referencia de la observación, de 1 a 12",
+    ),
+    "date": (
+        "Data de calendário dos incidentes registrados",
+        "Fecha de calendario de los incidentes registrados",
+    ),
+    "offence_category": (
+        "Categoria de crime do BOCSAR, o nível superior da classificação de crimes",
+        "Categoría de delito del BOCSAR, el nivel superior de la clasificación de delitos",
+    ),
+    "offence_subcategory": (
+        "Subcategoria de crime do BOCSAR, o tipo detalhado de crime dentro da categoria",
+        "Subcategoría de delito del BOCSAR, el tipo detallado de delito dentro de la categoría",
+    ),
+    "offence_category:criminal_incidents_daily": (
+        "Categoria de crime do BOCSAR mapeada a partir do rótulo de crime publicado",
+        "Categoría de delito del BOCSAR asignada a partir de la etiqueta de delito publicada",
+    ),
+    "offence_subcategory:criminal_incidents_daily": (
+        "Rótulo de crime como publicado no arquivo diário, folha da hierarquia de crimes",
+        "Etiqueta de delito según se publica en el archivo diario, hoja de la jerarquía de delitos",
+    ),
+    "incidents": (
+        "Número de incidentes criminais registrados pela Polícia de Nova Gales do Sul",
+        "Número de incidentes delictivos registrados por la Policía de Nueva Gales del Sur",
+    ),
+    "sa4_name": (
+        "Nome da Área Estatística de Nível 4 (ASGS) em Nova Gales do Sul",
+        "Nombre del Área Estadística de Nivel 4 (ASGS) en Nueva Gales del Sur",
+    ),
+    "lga_name": (
+        "Nome da Área de Governo Local (LGA) em Nova Gales do Sul",
+        "Nombre del Área de Gobierno Local (LGA) en Nueva Gales del Sur",
+    ),
+    "postcode": (
+        "Código postal australiano dos incidentes registrados",
+        "Código postal australiano de los incidentes registrados",
+    ),
+    "suburb": (
+        "Nome do subúrbio em Nova Gales do Sul",
+        "Nombre del suburbio en Nueva Gales del Sur",
+    ),
+    "financial_year": (
+        "Ano fiscal australiano de referência, de 1 de julho a 30 de junho, por exemplo 2010-11",
+        "Año fiscal australiano de referencia, del 1 de julio al 30 de junio, por ejemplo 2010-11",
+    ),
+    "age_group": (
+        "Faixa etária da pessoa de interesse (10 a 17 anos, ou adulto)",
+        "Grupo de edad de la persona de interés (10 a 17 años, o adulto)",
+    ),
+    "legal_proceeding": (
+        "Método de procedimento legal (encaminhamento alternativo ou processo judicial)",
+        "Método de procedimiento legal (derivación alternativa o proceso judicial)",
+    ),
+    "detailed_legal_proceeding": (
+        "Método detalhado de procedimento legal dentro do método mais amplo",
+        "Método detallado de procedimiento legal dentro del método más amplio",
+    ),
+    "poi_count": (
+        "Número de pessoas de interesse legalmente processadas pela Polícia de Nova Gales do Sul",
+        "Número de personas de interés legalmente procesadas por la Policía de Nueva Gales del Sur",
+    ),
+    "custody_system": (
+        "Sistema prisional a que o registro se refere (adulto ou juvenil)",
+        "Sistema penitenciario al que se refiere el registro (adulto o juvenil)",
+    ),
+    "legal_status": (
+        "Situação legal da pessoa sob custódia (prisão preventiva ou condenada)",
+        "Situación legal de la persona bajo custodia (prisión preventiva o condenada)",
+    ),
+    "aboriginality": (
+        "Condição indígena da pessoa (aborígene, não aborígene ou desconhecida)",
+        "Condición aborigen de la persona (aborigen, no aborigen o desconocida)",
+    ),
+    "sex": (
+        "Sexo da pessoa (feminino ou masculino)",
+        "Sexo de la persona (femenino o masculino)",
+    ),
+    "most_serious_offence": (
+        "Crime mais grave associado à pessoa sob custódia",
+        "Delito más grave asociado a la persona bajo custodia",
+    ),
+    "people": (
+        "Número de pessoas sob custódia no último dia do mês",
+        "Número de personas bajo custodia el último día del mes",
+    ),
+    "reception_status": (
+        "Situação legal na entrada em custódia (prisão preventiva, condenada ou desconhecida)",
+        "Situación legal al ingreso en custodia (prisión preventiva, condenada o desconocida)",
+    ),
+    "receptions": (
+        "Número de entradas em custódia durante o mês",
+        "Número de ingresos en custodia durante el mes",
+    ),
+    "discharge_type": (
+        "Tipo de custódia da qual a pessoa foi liberada (prisão preventiva ou condenada)",
+        "Tipo de custodia de la que la persona fue liberada (prisión preventiva o condenada)",
+    ),
+    "discharge_type:custody_remand_to_sentenced": (
+        "Transição registrada, de prisão preventiva para custódia condenada",
+        "Transición registrada, de prisión preventiva a custodia condenada",
+    ),
+    "discharge_type_breakdown": (
+        "Destino ou motivo detalhado da liberação",
+        "Destino o motivo detallado de la liberación",
+    ),
+    "discharges": (
+        "Número de liberações de custódia durante o mês",
+        "Número de liberaciones de custodia durante el mes",
+    ),
+    "transitions": (
+        "Número de pessoas que passaram de prisão preventiva para custódia condenada durante o mês",
+        "Número de personas que pasaron de prisión preventiva a custodia condenada durante el mes",
+    ),
+}
+
+
+def tr(name, table):
+    return TRANSLATIONS.get(f"{name}:{table}") or TRANSLATIONS[name]
+
+
+def main():
+    OUT.mkdir(parents=True, exist_ok=True)
+    for csv_path in sorted(ARCH.glob("*.csv")):
+        table = csv_path.stem
+        cols = []
+        with open(csv_path, newline="") as fh:
+            rows = list(csv.DictReader(fh))
+        for r in rows:
+            pt, es = tr(r["name"], table)
+            col = {
+                "name": r["name"],
+                "bigquery_type": r["bigquery_type"],
+                "description_pt": pt,
+                "description_en": r["description"],
+                "description_es": es,
+                "covered_by_dictionary": r["covered_by_dictionary"]
+                .strip()
+                .lower()
+                == "yes",
+                "has_sensitive_data": r["has_sensitive_data"].strip().lower()
+                == "yes",
+            }
+            if r["directory_column"].strip():
+                col["directory_column"] = r["directory_column"].strip()
+            if r["measurement_unit"].strip():
+                col["measurement_unit"] = r["measurement_unit"].strip()
+            cols.append(col)
+        (OUT / f"{table}.json").write_text(
+            json.dumps(cols, ensure_ascii=False, indent=2)
+        )
+        print(
+            f"{table}: {len(cols)} columns -> code/columns_json/{table}.json"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_nsw_bocsar_crime/code/build_dbt.py
+++ b/models/au_nsw_bocsar_crime/code/build_dbt.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Generate the au_nsw_bocsar_crime dbt models (.sql) and schema.yml from the
+architecture CSVs (the column source of truth) plus a per-table config.
+
+Usage: uv run python models/au_nsw_bocsar_crime/code/build_dbt.py
+"""
+
+import csv
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARCH = ROOT / "code" / "architecture"
+DATASET = "au_nsw_bocsar_crime"
+
+CAST = {
+    "INT64": "int64",
+    "FLOAT64": "float64",
+    "STRING": "string",
+    "DATE": "date",
+}
+
+# per-table: partition start year, cluster columns, unique key, model description
+CFG = {
+    "criminal_incidents": dict(
+        start=1995,
+        cluster=["offence_category"],
+        key=["year", "month", "offence_category", "offence_subcategory"],
+        desc="Monthly counts of criminal incidents recorded by the NSW Police Force for the whole state, by offence category and subcategory.",
+    ),
+    "criminal_incidents_sa4": dict(
+        start=1995,
+        cluster=["sa4_name", "offence_category"],
+        key=[
+            "year",
+            "month",
+            "sa4_name",
+            "offence_category",
+            "offence_subcategory",
+        ],
+        desc="Monthly counts of criminal incidents recorded by the NSW Police Force by Statistical Area Level 4 (ASGS), offence category and subcategory.",
+    ),
+    "criminal_incidents_lga": dict(
+        start=1995,
+        cluster=["lga_name", "offence_category"],
+        key=[
+            "year",
+            "month",
+            "lga_name",
+            "offence_category",
+            "offence_subcategory",
+        ],
+        desc="Monthly counts of criminal incidents recorded by the NSW Police Force by Local Government Area, offence category and subcategory.",
+    ),
+    "criminal_incidents_postcode": dict(
+        start=1995,
+        cluster=["postcode", "offence_category"],
+        key=[
+            "year",
+            "month",
+            "postcode",
+            "offence_category",
+            "offence_subcategory",
+        ],
+        desc="Monthly counts of criminal incidents recorded by the NSW Police Force by postcode, offence category and subcategory.",
+    ),
+    "criminal_incidents_suburb": dict(
+        start=1995,
+        cluster=["suburb", "offence_category"],
+        key=[
+            "year",
+            "month",
+            "suburb",
+            "offence_category",
+            "offence_subcategory",
+        ],
+        desc="Monthly counts of criminal incidents recorded by the NSW Police Force by suburb, offence category and subcategory.",
+    ),
+    "criminal_incidents_daily": dict(
+        start=2010,
+        cluster=["offence_category"],
+        key=["date", "offence_subcategory"],
+        desc="Daily counts of criminal incidents recorded by the NSW Police Force for all of New South Wales, by offence type.",
+    ),
+    "alleged_offenders": dict(
+        start=2010,
+        cluster=["offence_category"],
+        key=[
+            "financial_year",
+            "offence_category",
+            "offence_subcategory",
+            "age_group",
+            "legal_proceeding",
+            "detailed_legal_proceeding",
+        ],
+        desc="Number of persons of interest legally proceeded against by the NSW Police Force per financial year, by offence type, age group and method of legal proceeding.",
+    ),
+    "custody_population": dict(
+        start=2013,
+        cluster=["custody_system", "most_serious_offence"],
+        key=[
+            "year",
+            "month",
+            "custody_system",
+            "legal_status",
+            "aboriginality",
+            "sex",
+            "most_serious_offence",
+        ],
+        desc="Monthly custody population (people in custody on the last day of the month) in NSW adult and youth custody, by legal status, Aboriginality, sex and most serious offence.",
+    ),
+    "custody_receptions": dict(
+        start=2013,
+        cluster=["custody_system"],
+        key=[
+            "year",
+            "month",
+            "custody_system",
+            "reception_status",
+            "aboriginality",
+            "sex",
+        ],
+        desc="Monthly receptions into NSW adult and youth custody, by reception status, Aboriginality and sex.",
+    ),
+    "custody_discharges": dict(
+        start=2013,
+        cluster=["custody_system", "discharge_type"],
+        key=[
+            "year",
+            "month",
+            "custody_system",
+            "discharge_type",
+            "discharge_type_breakdown",
+            "aboriginality",
+            "sex",
+        ],
+        desc="Monthly discharges from NSW adult and youth custody, by discharge type and destination, Aboriginality and sex.",
+    ),
+    "custody_remand_to_sentenced": dict(
+        start=2013,
+        cluster=["custody_system"],
+        key=["year", "month", "custody_system", "aboriginality", "sex"],
+        desc="Monthly count of people who transitioned from remand to sentenced status within NSW adult and youth custody, by Aboriginality and sex.",
+    ),
+}
+
+TIME_DIR = {
+    "year": ("br_bd_diretorios_data_tempo__ano", "ano.ano"),
+    "month": ("br_bd_diretorios_data_tempo__mes", "mes.mes"),
+}
+
+
+def read_arch(table):
+    with open(ARCH / f"{table}.csv", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def sql_for(table, cfg):
+    arch = read_arch(table)
+    casts = ",\n".join(
+        f"    safe_cast({a['name']} as {CAST[a['bigquery_type']]}) {a['name']}"
+        for a in arch
+    )
+    cluster = ""
+    if cfg["cluster"]:
+        cols = ", ".join(f'"{c}"' for c in cfg["cluster"])
+        cluster = f"        cluster_by=[{cols}],\n"
+    return f"""{{{{
+    config(
+        schema="{DATASET}",
+        alias="{table}",
+        materialized="table",
+        partition_by={{
+            "field": "year",
+            "data_type": "int64",
+            "range": {{"start": {cfg["start"]}, "end": 2031, "interval": 1}},
+        }},
+{cluster}    )
+}}}}
+
+
+select
+{casts}
+from {{{{ set_datalake_project("{DATASET}_staging.{table}") }}}} as t
+"""
+
+
+def yaml_desc(text, indent):
+    pad = " " * indent
+    return f"{pad}description: >-\n{pad}  {text}\n"
+
+
+def schema_yaml():
+    lines = ["---", "version: 2", "models:"]
+    for table, cfg in CFG.items():
+        arch = read_arch(table)
+        lines.append(f"  - name: {DATASET}__{table}")
+        lines.append("    description: >-")
+        lines.append(f"      {cfg['desc']}")
+        lines.append("    tests:")
+        lines.append("      - dbt_utils.unique_combination_of_columns:")
+        lines.append("          combination_of_columns:")
+        for k in cfg["key"]:
+            lines.append(f"            - {k}")
+        lines.append("      - not_null_proportion_multiple_columns:")
+        lines.append("          at_least: 0.05")
+        lines.append("    columns:")
+        for a in arch:
+            name = a["name"]
+            lines.append(f"      - name: {name}")
+            lines.append(f"        description: {a['description']}")
+            tests = []
+            if name in ("year", "month", "date"):
+                tests.append("not_null")
+            col_tests = list(tests)
+            rel = TIME_DIR.get(name)
+            if col_tests or rel:
+                lines.append("        tests:")
+                for t in col_tests:
+                    lines.append(f"          - {t}")
+                if rel:
+                    lines.append("          - relationships:")
+                    lines.append(f"              to: ref('{rel[0]}')")
+                    lines.append(f"              field: {rel[1]}")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    for table, cfg in CFG.items():
+        (ROOT / f"{DATASET}__{table}.sql").write_text(sql_for(table, cfg))
+        print(f"wrote {DATASET}__{table}.sql")
+    (ROOT / "schema.yml").write_text(schema_yaml())
+    print("wrote schema.yml")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_nsw_bocsar_crime/code/clean_data.py
+++ b/models/au_nsw_bocsar_crime/code/clean_data.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""Clean the BOCSAR NSW crime files in ../input into partitioned parquet in ../output.
+
+One dataset (au_nsw_bocsar_crime), 11 tables. Staging parquet is all-STRING, hive-
+partitioned by year (Data Basis convention: the dbt model safe_casts every
+column; see write_partitioned). English column names per data-basis-style.md.
+
+Usage:
+    uv run --with pandas --with openpyxl --with polars python \
+        models/au_nsw_bocsar_crime/code/clean_data.py [table ...]
+"""
+
+import csv
+import logging
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+ROOT = Path(__file__).resolve().parents[1]
+INPUT = ROOT / "input"
+OUTPUT = ROOT / "output"
+ARCH = ROOT / "code" / "architecture"
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
+)
+log = logging.getLogger("bocsar")
+
+PA_TYPED = {
+    "INT64": pa.int64(),
+    "FLOAT64": pa.float64(),
+    "STRING": pa.string(),
+    "DATE": pa.string(),
+}
+STAR = re.compile(r"[\*\^~]+")
+
+
+def read_arch(table):
+    with open(ARCH / f"{table}.csv", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def clean_label(s):
+    """Strip footnote markers (* ^ ~) and collapse whitespace on a label."""
+    if pd.isna(s):
+        return s
+    return re.sub(r"\s+", " ", STAR.sub("", str(s))).strip()
+
+
+def fill_subcategory(df):
+    """The 13 single-level offence categories carry an empty Subcategory in the
+    source; fill it with the category so offence_subcategory is never null and
+    the RCI tables agree with the daily table (which uses the category as leaf)."""
+    sub = df["offence_subcategory"]
+    df["offence_subcategory"] = sub.where(
+        sub.notna() & (sub.astype(str).str.strip() != ""),
+        df["offence_category"],
+    )
+    return df
+
+
+def write_partitioned(df: pd.DataFrame, table: str) -> Path:
+    """Write df as all-STRING Snappy parquet, hive-partitioned by year."""
+    arch = read_arch(table)
+    order = [a["name"] for a in arch]
+    typed = pa.schema(
+        [pa.field(a["name"], PA_TYPED[a["bigquery_type"]]) for a in arch]
+    )
+    string_schema = pa.schema([pa.field(a["name"], pa.string()) for a in arch])
+    missing = [c for c in order if c not in df.columns]
+    if missing:
+        raise ValueError(f"{table}: missing columns {missing}")
+    out = df[order].copy()
+    # normalise numeric columns to nullable ints/floats so they serialise cleanly
+    for a in arch:
+        if a["bigquery_type"] == "INT64":
+            out[a["name"]] = pd.array(
+                pd.to_numeric(out[a["name"]], errors="coerce"), dtype="Int64"
+            )
+        elif a["bigquery_type"] == "FLOAT64":
+            out[a["name"]] = pd.to_numeric(
+                out[a["name"]], errors="coerce"
+            ).astype("Float64")
+        else:  # STRING / DATE already string-formatted
+            out[a["name"]] = out[a["name"]].astype("object")
+    tdir = OUTPUT / table
+    total = 0
+    for year, g in out.groupby("year", sort=True):
+        pdir = tdir / f"year={int(year)}"
+        pdir.mkdir(parents=True, exist_ok=True)
+        at = pa.Table.from_pandas(g, schema=typed, preserve_index=False).cast(
+            string_schema
+        )
+        pq.write_table(at, pdir / "data.parquet", compression="snappy")
+        total += at.num_rows
+    log.info(
+        "%s: wrote %s rows across %s year-partitions",
+        table,
+        f"{total:,}",
+        out["year"].nunique(),
+    )
+    return tdir
+
+
+# ----------------------------------------------------------------------------- RCI
+def _melt_excel_rci(path, sheet, geo_orig, geo_new, drop_cols, engine=None):
+    df = pd.read_excel(path, sheet_name=sheet, engine=engine)
+    df = df.drop(columns=[c for c in drop_cols if c in df.columns])
+    id_cols = ["Offence category", "Subcategory"] + (
+        [geo_orig] if geo_orig else []
+    )
+    month_cols = [c for c in df.columns if c not in id_cols]
+    long = df.melt(
+        id_vars=id_cols,
+        value_vars=month_cols,
+        var_name="ml",
+        value_name="incidents",
+    )
+    lab = pd.to_datetime(long["ml"], errors="coerce")
+    long = long[lab.notna()].copy()
+    long["year"] = lab[lab.notna()].dt.year
+    long["month"] = lab[lab.notna()].dt.month
+    long["offence_category"] = long["Offence category"].map(clean_label)
+    long["offence_subcategory"] = long["Subcategory"].map(clean_label)
+    long = fill_subcategory(long)
+    if geo_orig:
+        long[geo_new] = long[geo_orig].map(clean_label)
+    return long
+
+
+def clean_nsw():
+    long = _melt_excel_rci(
+        INPUT / "Incident_by_NSW.xlsx",
+        "Data",
+        None,
+        None,
+        drop_cols=["State", "2025 population", "2026 population"],
+    )
+    return long[
+        [
+            "year",
+            "month",
+            "offence_category",
+            "offence_subcategory",
+            "incidents",
+        ]
+    ]
+
+
+def clean_sa4():
+    long = _melt_excel_rci(
+        INPUT / "Statistical_Area_Monthly_Data.xlsx",
+        "SA4",
+        "NSW Statistical Area",
+        "sa4_name",
+        drop_cols=[],
+    )
+    return long[
+        [
+            "year",
+            "month",
+            "sa4_name",
+            "offence_category",
+            "offence_subcategory",
+            "incidents",
+        ]
+    ]
+
+
+def clean_lga():
+    long = _melt_excel_rci(
+        INPUT / "RCI_offencebymonth.xlsm",
+        "Data",
+        "LGA",
+        "lga_name",
+        drop_cols=[],
+        engine="openpyxl",
+    )
+    return long[
+        [
+            "year",
+            "month",
+            "lga_name",
+            "offence_category",
+            "offence_subcategory",
+            "incidents",
+        ]
+    ]
+
+
+def _melt_csv_rci_by_year(path, table, geo_orig, geo_new):
+    """Memory-bounded melt of a wide RCI CSV (postcode/suburb): read once with
+    polars, unpivot one year of month-columns at a time, write each year's parquet."""
+    import polars as pl
+
+    arch = read_arch(table)
+    order = [a["name"] for a in arch]
+    typed = pa.schema(
+        [pa.field(a["name"], PA_TYPED[a["bigquery_type"]]) for a in arch]
+    )
+    string_schema = pa.schema([pa.field(a["name"], pa.string()) for a in arch])
+    ids = [geo_orig, "Offence category", "Subcategory"]
+    df = pl.read_csv(
+        path, schema_overrides={c: pl.Utf8 for c in ids}, infer_schema_length=0
+    )
+    month_cols = [c for c in df.columns if c not in ids]
+    mon_to_num = {
+        "Jan": 1,
+        "Feb": 2,
+        "Mar": 3,
+        "Apr": 4,
+        "May": 5,
+        "Jun": 6,
+        "Jul": 7,
+        "Aug": 8,
+        "Sep": 9,
+        "Oct": 10,
+        "Nov": 11,
+        "Dec": 12,
+    }
+    by_year = {}
+    for c in month_cols:
+        mon, yr = c.split()
+        by_year.setdefault(int(yr), []).append((c, mon_to_num[mon]))
+    tdir = OUTPUT / table
+    total = 0
+    for year in sorted(by_year):
+        cols = by_year[year]
+        sub = df.select(ids + [c for c, _ in cols])
+        long = sub.melt(
+            id_vars=ids,
+            value_vars=[c for c, _ in cols],
+            variable_name="ml",
+            value_name="incidents",
+        ).to_pandas()
+        m = {c: mm for c, mm in cols}
+        long["year"] = year
+        long["month"] = long["ml"].map(m)
+        long[geo_new] = long[geo_orig].map(clean_label)
+        long["offence_category"] = long["Offence category"].map(clean_label)
+        long["offence_subcategory"] = long["Subcategory"].map(clean_label)
+        long = fill_subcategory(long)
+        g = long[order].copy()
+        g["incidents"] = pd.array(
+            pd.to_numeric(g["incidents"], errors="coerce"), dtype="Int64"
+        )
+        for col in [geo_new, "offence_category", "offence_subcategory"]:
+            g[col] = g[col].astype("object")
+        pdir = tdir / f"year={year}"
+        pdir.mkdir(parents=True, exist_ok=True)
+        at = pa.Table.from_pandas(g, schema=typed, preserve_index=False).cast(
+            string_schema
+        )
+        pq.write_table(at, pdir / "data.parquet", compression="snappy")
+        total += at.num_rows
+        log.info("  %s year=%s: %s rows", table, year, f"{at.num_rows:,}")
+    log.info(
+        "%s: wrote %s rows across %s year-partitions",
+        table,
+        f"{total:,}",
+        len(by_year),
+    )
+    return total
+
+
+def clean_postcode():
+    return _melt_csv_rci_by_year(
+        INPUT / "PostcodeData.csv",
+        "criminal_incidents_postcode",
+        "Postcode",
+        "postcode",
+    )
+
+
+def clean_suburb():
+    csvs = list(INPUT.glob("SuburbData*.csv"))
+    if not csvs:
+        raise FileNotFoundError("SuburbData*.csv not found in input/")
+    return _melt_csv_rci_by_year(
+        csvs[0], "criminal_incidents_suburb", "Suburb", "suburb"
+    )
+
+
+# ----------------------------------------------------------------------------- daily
+def _offence_category_map():
+    nsw = pd.read_excel(INPUT / "Incident_by_NSW.xlsx", sheet_name="Data")
+    cat = nsw["Offence category"].map(clean_label)
+    sub = nsw["Subcategory"].map(clean_label)
+    sub_to_cats = {}
+    for cc, ss in zip(cat, sub, strict=False):
+        sub_to_cats.setdefault(ss, set()).add(cc)
+    cats = set(cat)
+
+    def m(leaf):
+        leaf = clean_label(leaf)
+        if leaf in sub_to_cats and len(sub_to_cats[leaf]) == 1:
+            return next(iter(sub_to_cats[leaf])), leaf
+        if leaf in cats:
+            return leaf, leaf
+        return None, leaf
+
+    return m
+
+
+def clean_daily():
+    df = pd.read_excel(
+        INPUT / "NSW_criminal_incidents_daily.xlsx",
+        sheet_name="Offence daily",
+        header=3,
+    )
+    df = df.rename(columns={df.columns[0]: "Date"})
+    date = pd.to_datetime(df["Date"], format="%d%b%Y", errors="coerce")
+    df = df[date.notna()].copy()
+    df["date"] = date[date.notna()]
+    off_cols = [c for c in df.columns if c not in ("Date", "date")]
+    long = df.melt(
+        id_vars=["date"],
+        value_vars=off_cols,
+        var_name="offence",
+        value_name="incidents",
+    )
+    mp = _offence_category_map()
+    mapped = long["offence"].map(mp)
+    long["offence_category"] = [x[0] for x in mapped]
+    long["offence_subcategory"] = [x[1] for x in mapped]
+    n_null = long["offence_category"].isna().sum()
+    if n_null:
+        log.warning(
+            "daily: %s rows with unmapped offence_category (%s distinct leaves)",
+            f"{n_null:,}",
+            long.loc[long["offence_category"].isna(), "offence"].nunique(),
+        )
+    long["year"] = long["date"].dt.year
+    long["date"] = long["date"].dt.strftime("%Y-%m-%d")
+    return long[
+        [
+            "year",
+            "date",
+            "offence_category",
+            "offence_subcategory",
+            "incidents",
+        ]
+    ]
+
+
+# ----------------------------------------------------------------------------- alleged offenders
+def clean_alleged():
+    df = pd.read_excel(
+        INPUT / "NSW_Alleged_offender_data.xlsx",
+        sheet_name="Table 1 ",
+        header=6,
+    )
+    df = df.rename(
+        columns={
+            df.columns[0]: "cat",
+            df.columns[1]: "sub",
+            df.columns[2]: "age",
+            df.columns[3]: "method",
+            df.columns[4]: "detmethod",
+        }
+    )
+    fy_cols = [
+        c
+        for c in df.columns
+        if isinstance(c, str) and re.match(r"Jul \d{4} - Jun \d{4}", c)
+    ]
+    df = df[df["cat"].notna()].copy()
+    df = df[df["method"].astype(str).str.strip().str.lower() != "total"]
+    long = df.melt(
+        id_vars=["cat", "sub", "age", "method", "detmethod"],
+        value_vars=fy_cols,
+        var_name="financial_year",
+        value_name="poi_count",
+    )
+    long = long[long["poi_count"].notna()].copy()
+    long["year"] = (
+        long["financial_year"].str.extract(r"Jul (\d{4})").astype(int)
+    )
+    long["financial_year"] = long["financial_year"].str.replace(
+        r"Jul (\d{4}) - Jun (\d{2})(\d{2})", r"\1-\3", regex=True
+    )
+    long["offence_category"] = long["cat"].map(clean_label)
+    long["offence_subcategory"] = long["sub"].map(clean_label)
+    long["age_group"] = long["age"].map(clean_label)
+    long["legal_proceeding"] = long["method"].map(clean_label)
+    long["detailed_legal_proceeding"] = long["detmethod"].map(clean_label)
+    return long[
+        [
+            "year",
+            "financial_year",
+            "offence_category",
+            "offence_subcategory",
+            "age_group",
+            "legal_proceeding",
+            "detailed_legal_proceeding",
+            "poi_count",
+        ]
+    ]
+
+
+# ----------------------------------------------------------------------------- custody
+def _custody(sheet, rename, value_col):
+    frames = []
+    for system, fname in [
+        ("adult", "Adult_Custody_Report.xlsx"),
+        ("youth", "Youth_Custody_Report.xlsx"),
+    ]:
+        d = pd.read_excel(INPUT / fname, sheet_name=sheet)
+        d = d.rename(columns=rename)
+        d["custody_system"] = system
+        d["Month"] = pd.to_datetime(d["Month"], errors="coerce")
+        d = d[d["Month"].notna()].copy()
+        d["year"] = d["Month"].dt.year
+        d["month"] = d["Month"].dt.month
+        d["sex"] = d["sex"].map(clean_label)
+        d["aboriginality"] = d["aboriginality"].map(clean_label)
+        frames.append(d)
+    return pd.concat(frames, ignore_index=True)
+
+
+def clean_custody_population():
+    d = _custody(
+        "stock_data",
+        {
+            "Legal Status": "legal_status",
+            "Aboriginality": "aboriginality",
+            "Gender": "sex",
+            "MSO": "most_serious_offence",
+            "Count": "people",
+        },
+        "people",
+    )
+    return d[
+        [
+            "year",
+            "month",
+            "custody_system",
+            "legal_status",
+            "aboriginality",
+            "sex",
+            "most_serious_offence",
+            "people",
+        ]
+    ]
+
+
+def clean_custody_receptions():
+    d = _custody(
+        "reception_data",
+        {
+            "Reception Status": "reception_status",
+            "Aboriginality": "aboriginality",
+            "Gender": "sex",
+            "Count": "receptions",
+        },
+        "receptions",
+    )
+    return d[
+        [
+            "year",
+            "month",
+            "custody_system",
+            "reception_status",
+            "aboriginality",
+            "sex",
+            "receptions",
+        ]
+    ]
+
+
+def clean_custody_discharges():
+    d = _custody(
+        "discharge_data",
+        {
+            "Discharge Type": "discharge_type",
+            "Discharge Type Breakdown": "discharge_type_breakdown",
+            "Aboriginality": "aboriginality",
+            "Gender": "sex",
+            "Count": "discharges",
+        },
+        "discharges",
+    )
+    return d[
+        [
+            "year",
+            "month",
+            "custody_system",
+            "discharge_type",
+            "discharge_type_breakdown",
+            "aboriginality",
+            "sex",
+            "discharges",
+        ]
+    ]
+
+
+def clean_custody_remand_to_sentenced():
+    d = _custody(
+        "remand_to_sentenced_data",
+        {
+            "Discharge Type": "discharge_type",
+            "Aboriginality": "aboriginality",
+            "Gender": "sex",
+            "Count": "transitions",
+        },
+        "transitions",
+    )
+    return d[
+        [
+            "year",
+            "month",
+            "custody_system",
+            "discharge_type",
+            "aboriginality",
+            "sex",
+            "transitions",
+        ]
+    ]
+
+
+# ----------------------------------------------------------------------------- driver
+BUILDERS = {
+    "criminal_incidents": clean_nsw,
+    "criminal_incidents_sa4": clean_sa4,
+    "criminal_incidents_lga": clean_lga,
+    "criminal_incidents_daily": clean_daily,
+    "alleged_offenders": clean_alleged,
+    "custody_population": clean_custody_population,
+    "custody_receptions": clean_custody_receptions,
+    "custody_discharges": clean_custody_discharges,
+    "custody_remand_to_sentenced": clean_custody_remand_to_sentenced,
+}
+# these write their own parquet (memory-bounded) and are not in BUILDERS
+SELF_WRITERS = {
+    "criminal_incidents_postcode": clean_postcode,
+    "criminal_incidents_suburb": clean_suburb,
+}
+
+
+def main():
+    OUTPUT.mkdir(parents=True, exist_ok=True)
+    only = set(sys.argv[1:])
+    tables = list(BUILDERS) + list(SELF_WRITERS)
+    if only:
+        tables = [t for t in tables if t in only]
+    for t in tables:
+        log.info("=== %s ===", t)
+        if t in SELF_WRITERS:
+            SELF_WRITERS[t]()
+        else:
+            write_partitioned(BUILDERS[t](), t)
+    log.info("DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_nsw_bocsar_crime/code/upload.py
+++ b/models/au_nsw_bocsar_crime/code/upload.py
@@ -1,0 +1,126 @@
+"""Upload cleaned au_nsw_bocsar_crime parquet tables to BigQuery.
+
+Usage:
+    uv run python models/au_nsw_bocsar_crime/code/upload.py [--env dev|prod] [table ...]
+
+--env dev (default) -> basedosdados-dev; --env prod -> basedosdados. Point
+GOOGLE_APPLICATION_CREDENTIALS at the matching service account. Uploads
+smallest-first, verifies BQ row count against the local parquet, stops on first
+failure.
+"""
+
+import glob
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+import basedosdados as bd  # noqa: E402
+import google.cloud.storage as gcs  # noqa: E402
+import pyarrow.parquet as pq  # noqa: E402
+from google.cloud import bigquery  # noqa: E402
+
+_argv = sys.argv[1:]
+if "--env" in _argv:
+    _i = _argv.index("--env")
+    ENV = _argv[_i + 1]
+    _argv = _argv[:_i] + _argv[_i + 2 :]
+else:
+    ENV = "dev"
+BILLING_PROJECT = "basedosdados" if ENV == "prod" else "basedosdados-dev"
+DATASET_ID = "au_nsw_bocsar_crime"
+OUTPUT_ROOT = Path(__file__).resolve().parent.parent / "output"
+
+# smallest-first
+TABLES = [
+    "custody_remand_to_sentenced",
+    "custody_receptions",
+    "alleged_offenders",
+    "custody_discharges",
+    "criminal_incidents",
+    "custody_population",
+    "criminal_incidents_daily",
+    "criminal_incidents_sa4",
+    "criminal_incidents_lga",
+    "criminal_incidents_postcode",
+    "criminal_incidents_suburb",
+]
+
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+
+def local_rows(slug: str) -> int:
+    return sum(
+        pq.ParquetFile(f).metadata.num_rows
+        for f in glob.glob(str(OUTPUT_ROOT / slug / "year=*" / "*.parquet"))
+    )
+
+
+def upload_table(slug: str) -> int:
+    path = OUTPUT_ROOT / slug
+    if not path.exists():
+        raise FileNotFoundError(f"Missing output path: {path}")
+    expected = local_rows(slug)
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=slug)
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=slug)
+    try:
+        st.delete_table(mode="staging", not_found_ok=True)
+    except Exception as e:
+        print(f"  [warn] staging prefix cleanup: {e}")
+
+    tb.create(
+        path=str(path),
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    # Count verification is best-effort: it needs bigquery.jobs.create on the
+    # billing project, which the ambient credentials may lack. The bd upload
+    # above already confirms the staging table was created; dbt run/test verifies
+    # row counts downstream.
+    try:
+        client = bigquery.Client(project=BILLING_PROJECT)
+        q = f"select count(*) as n from `{BILLING_PROJECT}.{DATASET_ID}_staging.{slug}`"
+        n = next(iter(client.query(q).result())).n
+        status = "OK" if n == expected else "ROW MISMATCH"
+        print(f"  {slug}: uploaded {n:,} rows (local {expected:,}) — {status}")
+        if n != expected:
+            raise ValueError(f"{slug}: BQ {n:,} != local {expected:,}")
+        return n
+    except ValueError:
+        raise
+    except Exception as e:
+        print(
+            f"  {slug}: staging table created; local parquet has {expected:,} rows "
+            f"(BQ count unverified: {type(e).__name__})"
+        )
+        return expected
+
+
+def main():
+    only = set(_argv)
+    tables = [t for t in TABLES if not only or t in only]
+    print(f"=== uploading to {BILLING_PROJECT} (env={ENV}) ===", flush=True)
+    for slug in tables:
+        print(f"=== {slug} ===", flush=True)
+        try:
+            upload_table(slug)
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+            sys.exit(1)
+    print("ALL TABLES UPLOADED")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_nsw_bocsar_crime/schema.yml
+++ b/models/au_nsw_bocsar_crime/schema.yml
@@ -1,0 +1,430 @@
+---
+version: 2
+models:
+  - name: au_nsw_bocsar_crime__criminal_incidents
+    description: >-
+      Monthly counts of criminal incidents recorded by the NSW Police Force for the
+      whole state, by offence category and subcategory.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - offence_category
+            - offence_subcategory
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: offence_category
+        description: BOCSAR offence category, the top level of the offence classification
+      - name: offence_subcategory
+        description: BOCSAR offence subcategory, the detailed offence type within
+          the category
+      - name: incidents
+        description: Number of criminal incidents recorded by the NSW Police Force
+  - name: au_nsw_bocsar_crime__criminal_incidents_sa4
+    description: >-
+      Monthly counts of criminal incidents recorded by the NSW Police Force by Statistical
+      Area Level 4 (ASGS), offence category and subcategory.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - sa4_name
+            - offence_category
+            - offence_subcategory
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: sa4_name
+        description: Name of the Statistical Area Level 4 (ASGS) in New South Wales
+      - name: offence_category
+        description: BOCSAR offence category, the top level of the offence classification
+      - name: offence_subcategory
+        description: BOCSAR offence subcategory, the detailed offence type within
+          the category
+      - name: incidents
+        description: Number of criminal incidents recorded by the NSW Police Force
+  - name: au_nsw_bocsar_crime__criminal_incidents_lga
+    description: >-
+      Monthly counts of criminal incidents recorded by the NSW Police Force by Local
+      Government Area, offence category and subcategory.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - lga_name
+            - offence_category
+            - offence_subcategory
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: lga_name
+        description: Name of the Local Government Area in New South Wales
+      - name: offence_category
+        description: BOCSAR offence category, the top level of the offence classification
+      - name: offence_subcategory
+        description: BOCSAR offence subcategory, the detailed offence type within
+          the category
+      - name: incidents
+        description: Number of criminal incidents recorded by the NSW Police Force
+  - name: au_nsw_bocsar_crime__criminal_incidents_postcode
+    description: >-
+      Monthly counts of criminal incidents recorded by the NSW Police Force by postcode,
+      offence category and subcategory.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - postcode
+            - offence_category
+            - offence_subcategory
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: postcode
+        description: Australian postcode of the recorded incidents
+      - name: offence_category
+        description: BOCSAR offence category, the top level of the offence classification
+      - name: offence_subcategory
+        description: BOCSAR offence subcategory, the detailed offence type within
+          the category
+      - name: incidents
+        description: Number of criminal incidents recorded by the NSW Police Force
+  - name: au_nsw_bocsar_crime__criminal_incidents_suburb
+    description: >-
+      Monthly counts of criminal incidents recorded by the NSW Police Force by suburb,
+      offence category and subcategory.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - suburb
+            - offence_category
+            - offence_subcategory
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: suburb
+        description: Suburb name in New South Wales
+      - name: offence_category
+        description: BOCSAR offence category, the top level of the offence classification
+      - name: offence_subcategory
+        description: BOCSAR offence subcategory, the detailed offence type within
+          the category
+      - name: incidents
+        description: Number of criminal incidents recorded by the NSW Police Force
+  - name: au_nsw_bocsar_crime__criminal_incidents_daily
+    description: >-
+      Daily counts of criminal incidents recorded by the NSW Police Force for all
+      of New South Wales, by offence type.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [date, offence_subcategory]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: date
+        description: Calendar date of the recorded incidents
+        tests: [not_null]
+      - name: offence_category
+        description: BOCSAR offence category mapped from the published offence label
+      - name: offence_subcategory
+        description: Offence label as published in the daily file (leaf of the offence
+          hierarchy)
+      - name: incidents
+        description: Number of criminal incidents recorded by the NSW Police Force
+  - name: au_nsw_bocsar_crime__alleged_offenders
+    description: >-
+      Number of persons of interest legally proceeded against by the NSW Police Force
+      per financial year, by offence type, age group and method of legal proceeding.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - financial_year
+            - offence_category
+            - offence_subcategory
+            - age_group
+            - legal_proceeding
+            - detailed_legal_proceeding
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: financial_year
+        description: Australian financial year of reference, 1 July to 30 June, e.g.
+          2010-11
+      - name: offence_category
+        description: BOCSAR offence category, the top level of the offence classification
+      - name: offence_subcategory
+        description: BOCSAR offence subcategory, the detailed offence type within
+          the category
+      - name: age_group
+        description: Age group of the person of interest (10 to 17 years, or Adult)
+      - name: legal_proceeding
+        description: Method of legal proceeding (court diversion or proceeded against
+          to court)
+      - name: detailed_legal_proceeding
+        description: Detailed method of legal proceeding within the broader method
+      - name: poi_count
+        description: Number of persons of interest legally proceeded against by the
+          NSW Police Force
+  - name: au_nsw_bocsar_crime__custody_population
+    description: >-
+      Monthly custody population (people in custody on the last day of the month)
+      in NSW adult and youth custody, by legal status, Aboriginality, sex and most
+      serious offence.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - custody_system
+            - legal_status
+            - aboriginality
+            - sex
+            - most_serious_offence
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: custody_system
+        description: Custody system the record refers to (adult or youth)
+      - name: legal_status
+        description: Legal status of the person in custody (remand or sentenced)
+      - name: aboriginality
+        description: Aboriginal status of the person (Aboriginal, Non-Aboriginal or
+          Unknown)
+      - name: sex
+        description: Sex of the person (Female or Male)
+      - name: most_serious_offence
+        description: Most serious offence associated with the person in custody
+      - name: people
+        description: Number of people in custody on the last day of the month
+  - name: au_nsw_bocsar_crime__custody_receptions
+    description: >-
+      Monthly receptions into NSW adult and youth custody, by reception status, Aboriginality
+      and sex.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - custody_system
+            - reception_status
+            - aboriginality
+            - sex
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: custody_system
+        description: Custody system the record refers to (adult or youth)
+      - name: reception_status
+        description: Legal status at reception into custody (remand, sentenced or
+          unknown)
+      - name: aboriginality
+        description: Aboriginal status of the person (Aboriginal, Non-Aboriginal or
+          Unknown)
+      - name: sex
+        description: Sex of the person (Female or Male)
+      - name: receptions
+        description: Number of receptions into custody during the month
+  - name: au_nsw_bocsar_crime__custody_discharges
+    description: >-
+      Monthly discharges from NSW adult and youth custody, by discharge type and destination,
+      Aboriginality and sex.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - custody_system
+            - discharge_type
+            - discharge_type_breakdown
+            - aboriginality
+            - sex
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: custody_system
+        description: Custody system the record refers to (adult or youth)
+      - name: discharge_type
+        description: Type of custody the person was discharged from (remand or sentenced)
+      - name: discharge_type_breakdown
+        description: Detailed discharge destination or reason
+      - name: aboriginality
+        description: Aboriginal status of the person (Aboriginal, Non-Aboriginal or
+          Unknown)
+      - name: sex
+        description: Sex of the person (Female or Male)
+      - name: discharges
+        description: Number of discharges from custody during the month
+  - name: au_nsw_bocsar_crime__custody_remand_to_sentenced
+    description: >-
+      Monthly count of people who transitioned from remand to sentenced status within
+      NSW adult and youth custody, by Aboriginality and sex.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - custody_system
+            - aboriginality
+            - sex
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: custody_system
+        description: Custody system the record refers to (adult or youth)
+      - name: discharge_type
+        description: Transition recorded, remand to sentenced custody
+      - name: aboriginality
+        description: Aboriginal status of the person (Aboriginal, Non-Aboriginal or
+          Unknown)
+      - name: sex
+        description: Sex of the person (Female or Male)
+      - name: transitions
+        description: Number of people who transitioned from remand to sentenced custody
+          during the month


### PR DESCRIPTION
## Dataset
`au_nsw_bocsar_crime` — **Crime in New South Wales (BOCSAR)**. Source: NSW Bureau of Crime Statistics and Research (part of DCJ). Licence: **CC BY**. Coverage: New South Wales (`au_nsw`), 1995–2026. English column names; quarterly refresh (no BD Pro paywall).

## Tables (11)
**Recorded criminal incidents** — counts by offence category/subcategory:
- `criminal_incidents` — all of NSW, monthly
- `criminal_incidents_sa4` — by Statistical Area Level 4, monthly
- `criminal_incidents_lga` — by Local Government Area, monthly
- `criminal_incidents_postcode` — by postcode, monthly (annual refresh)
- `criminal_incidents_suburb` — by suburb, monthly (annual refresh)
- `criminal_incidents_daily` — all of NSW, daily (2010–)

**Other units:**
- `alleged_offenders` — persons of interest proceeded against, by offence × age × method, per financial year
- `custody_population`, `custody_receptions`, `custody_discharges`, `custody_remand_to_sentenced` — adult + youth, monthly (2013–)

## Notes
- English column names (`year`/`month`/`date`).
- Geography carried as published names (SA4 / LGA / postcode / suburb); FK to `br_bd_diretorios_au` deferred until that directory is live. Observation levels use generic geographic entities (region / municipality / neighborhood / zip_code).
- **dbt build: 74/74 pass** in dev (11 models + 63 tests: unique keys, not-null, time-directory relationships, null-proportion). NSW incident total matches the source file exactly (21,194,009).
- Also codifies a rules change: English-language datasets use English column names (`.claude/rules/data-basis-style.md`).

## Checklist
- [x] Cleaning validated against source
- [x] Uploaded to dev staging; dbt run + tests pass
- [x] Metadata registered (staging backend)
- [ ] Merge → table-approve materialises `basedosdados.au_nsw_bocsar_crime.*`
- [ ] Verify prod, then flip dataset `under_review` → `published`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NSW crime and custody datasets covering incidents, daily activity, alleged offenders, postcode, suburb, LGA, and regional statistics.
  * Added custody population, receptions, discharges, and remand-to-sentenced transition data.
  * Included English field names, descriptions, geographic and time-based metadata, and multilingual column information.
* **Data Quality**
  * Added validation checks for required fields, uniqueness, missing values, and time relationships.
  * Improved yearly partitioning and category-based organization for faster data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->