### PR TITLE
fix(br_bcb_sicor): adequação de teste à coluna nova

### DIFF
--- a/models/br_bcb_sicor/schema.yml
+++ b/models/br_bcb_sicor/schema.yml
@@ -235,6 +235,7 @@ models:
             where: __most_recent_year_month_sicor__
       - not_null_proportion_multiple_columns:
           at_least: 1
+          ignore_values: [indicador_renegociacao]
       - custom_dictionary_coverage:
           columns_covered_by_dictionary: [id_situacao_operacao]
           dictionary_model: ref('br_bcb_sicor__dicionario')
@@ -271,7 +272,11 @@ models:
       - name: indicador_renegociacao
         description: >-
           Indicador de operação renegociada (1 = renegociada, 0 = não
-          renegociada)
+          renegociada). Disponível a partir de fevereiro de 2026
+        tests:
+          - not_null:
+              config:
+                where: (ano > 2026 or (ano = 2026 and mes>=2))
       - name: valor_medio_diario
         description: Saldo médio diário
       - name: valor_medio_diario_vincendo

--- a/pipelines/datasets/br_bcb_sicor/README.md
+++ b/pipelines/datasets/br_bcb_sicor/README.md
@@ -192,6 +192,25 @@ with validation_errors as (
 select * from validation_errors;
 ```
 
+**Coluna `indicador_renegociacao` (nula em quase todo o histórico):**
+
+O BCB só publica `IB_RENEGOCIADA` a partir do arquivo de base 2026-02. De fevereiro de 2026 em diante a coluna é 100% preenchida (`0`/`1`); janeiro de 2026 tem 49.688 preenchidas em 4,52 milhões de linhas; 2013 a 2025 é toda nula, com uma única linha de exceção em 2025. Não é artefato do `dump_mode="append"`: das 5,9 milhões de chaves de 2026 em dev, nenhuma tem uma versão nula e outra preenchida (verificado em 04/08/2026).
+
+Duas consequências no `schema.yml`:
+
+- a coluna entra em `ignore_values` do `not_null_proportion_multiple_columns`, que cobra `at_least: 1` das outras dez. Sem isso o teste é impossível e derruba o flow — foi o que aconteceu em 03/08/2026, quando o full-refresh materializou a coluna e o run que reaplicaria as row access policies falhou no teste;
+- em troca, ela ganha um `not_null` próprio com escopo `(ano > 2026 or (ano = 2026 and mes >= 2))`.
+
+O `where` tem duas escolhas que parecem redundantes e não são:
+
+| Alternativa | Custo por execução | Em 2027 |
+|---|---|---|
+| `ano = 2026 and mes >= 2` | 98 MB | congela em 2026 — passa verde sem cobrir dado novo |
+| `(ano > 2026 or (ano = 2026 and mes >= 2))` | 98 MB | acompanha os anos seguintes |
+| `date(ano, mes, 1) >= '2026-02-01'` | 10,26 GB | acompanha, mas envolver `ano` numa função desliga o partition pruning |
+
+Pendências de metadado, pelo manual de estilo: falta declarar a cobertura temporal da coluna (`2026-02(1)`) na planilha de arquitetura e no backend — deixar vazio significa "igual à tabela", o que é falso. Isso não é código: o `create_update_coverage` do MCP só aceita `table_id`, então vai por planilha ou GraphQL. O manual também define `indicador_` como booleano `int64` preenchido com 0/1, enquanto aqui a coluna é `STRING`, seguindo a regra do repo para flags 0/1 — divergência conhecida, cuja troca exigiria full-refresh em prod e mudança de `bigquery_type`.
+
 ---
 
 ### br_bcb_sicor__recurso_publico_mutuario

--- a/pipelines/datasets/br_bcb_sicor/flows.py
+++ b/pipelines/datasets/br_bcb_sicor/flows.py
@@ -64,7 +64,8 @@ def _sicor_flow(
 # recriado nos runs seguintes. Quando o BCB adiciona uma coluna (como o
 # `IB_RENEGOCIADA` em 2026), `_sync_staging_schema` a acrescenta à definição da
 # tabela externa durante o upload. Registrar a coluna em `constants.py`, no
-# `.sql` e no `schema.yml` continua sendo manual.
+# `.sql` e no `schema.yml` continua sendo manual — ver a seção
+# `br_bcb_sicor__saldo` do README para a cobertura da coluna e seus testes.
 br_bcb_sicor__operacao = _sicor_flow(
     table_id="operacao",
     cron="5 2 * * 1-5",


### PR DESCRIPTION
O BCB só publica `IB_RENEGOCIADA` a partir do arquivo de base 2026-02, então
`indicador_renegociacao` é nula em todo o histórico anterior.

- `models/br_bcb_sicor/schema.yml`: a coluna entra em `ignore_values` do
  `not_null_proportion_multiple_columns`; as outras dez seguem cobradas em `at_least: 1`.
- `models/br_bcb_sicor/schema.yml`: a coluna ganha um `not_null` próprio, com escopo
  `(ano > 2026 or (ano = 2026 and mes >= 2))`, e a descrição registra que ela está
  disponível a partir de fevereiro de 2026.
- `pipelines/datasets/br_bcb_sicor/README.md`: nova seção na parte do `saldo` com a
  cobertura da coluna e o motivo das duas escolhas do `where`.
- `pipelines/datasets/br_bcb_sicor/flows.py`: o comentário sobre o `IB_RENEGOCIADA`
  passa a apontar para essa seção do README.

- Teste em dev da tabela saldo: https://prefect3.basedosdados.org/runs/flow-run/66986f9c-708e-4832-ac97-300403199932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation for the `indicador_renegociacao` field to account for its availability beginning in February 2026.
  * Historical records are no longer incorrectly required to contain values for this field.

* **Documentation**
  * Added coverage, validation, and data-quality details for the field.
  * Clarified the steps for documenting future columns added to SICOR datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->