### PR TITLE
fix: corrige crash no check_metadata para colunas que existem na API mas não no BigQuery

### DIFF
--- a/.github/workflows/scripts/check_metadata.py
+++ b/.github/workflows/scripts/check_metadata.py
@@ -165,9 +165,11 @@ def get_column_errors(row: pd.Series) -> ColumnResult:
                 )
             )
 
-    column_name = row.get("column_name", row.get("name", ""))
+    bq_name = row.get("column_name")
+    api_name = row.get("name")
+    column_name = bq_name if pd.notna(bq_name) else api_name
 
-    if column_name is None or not isinstance(column_name, str):
+    if not isinstance(column_name, str):
         raise Exception(f"Failed to get column_name for pandas series {row}")
 
     return ColumnResult(column_name=column_name, errors=errors)
@@ -263,8 +265,8 @@ def raise_if_metadata_errors(
                                 print(f"     BQ: `{bq}`")
                                 print(f"    API: `{api}`\n")
                             case TypeError(lhs, rhs):
-                                print(f"     BQ: `{lhs}`")
-                                print(f"    API: `{rhs}`\n")
+                                print(f"     BQ Datatype: `{lhs}`")
+                                print(f"    API Datatype: `{rhs}`\n")
 
     if error_exists:
         print("⚠️ Metadata discrepancies found. See the output")


### PR DESCRIPTION
# fix: corrige crash e melhora output do check_metadata para colunas right_only

# Contexto

O script `.github/workflows/scripts/check_metadata.py` valida se as colunas declaradas na API estão presentes e consistentes no BigQuery. O merge entre as duas fontes é feito com `how="outer"`, produzindo três tipos de linha:

- `both` — coluna existe nos dois lados
- `left_only` — coluna existe só no BigQuery
- `right_only` — coluna existe só na API (não está no BigQuery)

Para linhas `right_only`, a função `get_column_errors()` tentava recuperar o nome da coluna com:

```python
column_name = row.get("column_name", row.get("name", ""))
```

O problema: `pandas.Series.get(key, default)` retorna `NaN` quando a chave existe mas o valor é `NaN` — o `default` é ignorado. Para linhas `right_only`, `column_name` vem como `NaN` do lado do BigQuery. O `.get()` encontra a chave, retorna `NaN`, e nunca cai no fallback `row.get("name", "")`. O `isinstance(column_name, str)` falha e a função lança uma exceção genérica em vez de retornar um `ColumnResult` com `NotFoundError`.

Além disso, o output de erros de tipo usava os mesmos prefixos `BQ:` / `API:` que os erros de descrição, tornando ambíguo quando os dois apareciam juntos para a mesma coluna.

---

## Organização de arquivos

```
.github/workflows/scripts/
└── check_metadata.py   # get_column_errors: fix do crash right_only + label do TypeError
```

---

## Estrutura do código

### Crash fix — `get_column_errors()`

Substituído o `.get()` encadeado por uma leitura explícita com `pd.notna()`:

```python
# Antes (buggy)
column_name = row.get("column_name", row.get("name", ""))

# Depois
bq_name = row.get("column_name")
api_name = row.get("name")
column_name = bq_name if pd.notna(bq_name) else api_name
```

Para linhas `right_only`: `bq_name` é `NaN` → `pd.notna()` é `False` → usa `api_name`, que é a string correta da API.
Para linhas `left_only`: `bq_name` é a string do BigQuery → `pd.notna()` é `True` → usa `bq_name`. Sem regressão.

### Output fix — `raise_if_metadata_errors()`

Label do bloco `TypeError` diferenciado para evitar ambiguidade com o bloco `DescriptionError`:

```python
# Antes
print(f"     BQ: `{lhs}`")
print(f"    API: `{rhs}`")

# Depois
print(f"     BQ Datatype: `{lhs}`")
print(f"    API Datatype: `{rhs}`")
```

---

## Testes realizados

**Simulação local com pandas** — cenários cobertos:

| Cenário | Antes | Depois |
|---|---|---|
| `right_only` (coluna só na API) | crash `Failed to get column_name` | `ColumnResult(column_name='...', errors=[NotFoundError(...)])` |
| `left_only` (coluna só no BQ) | ok | ok (sem regressão) |
| `both` | ok | ok (sem regressão) |

**Action com models reais do `br_rf_cnpj` e `br_ms_sinan`** (que geraram o crash na action original):
- https://github.com/basedosdados/pipelines/actions/runs/30938799316/job/92091607100?pr=1745

O crash foi identificado na action: https://github.com/basedosdados/pipelines/actions/runs/30773811135/job/91565440576?pr=1723