### PR TITLE
[Feature] au_abs_labour_force

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -115,6 +115,9 @@ models:
     us_bls_cpi:
       +materialized: table
       +schema: us_bls_cpi
+    au_abs_labour_force:
+      +materialized: table
+      +schema: au_abs_labour_force
     us_bls_qcew:
       +materialized: table
       +schema: us_bls_qcew

--- a/models/au_abs_labour_force/ONBOARDING_PLAN.md
+++ b/models/au_abs_labour_force/ONBOARDING_PLAN.md
@@ -1,0 +1,192 @@
+# Onboarding Plan — `au_abs_labour_force`
+
+**Dataset:** `au_abs_labour_force` (org `au_abs`) — Labour Force, Australia (ABS cat. 6202.0)
+**Source:** https://www.abs.gov.au/statistics/labour/employment-and-unemployment/labour-force-australia/latest-release
+**License:** CC BY 4.0 (ABS)
+**Frequency:** Monthly (reference month released ~2 weeks later, Thursday 11:30 AEST)
+**Scope (decided):** Tier 1 + Tier 2 = the full 6202.0 headline release. The separate
+*Detailed* release (6291.0.55.001: industry/occupation/duration cubes) is a deferred phase 2.
+**Source mechanism (decided):** ABS Data API (SDMX) first; Excel pivot cubes for grains the
+API does not serve.
+
+---
+
+## 1. The core architectural insight
+
+The release page lists ~30 downloadable files, but they are the **same measures sliced
+many ways**, not 30 datasets. We slice by **grain**, not by ABS spreadsheet:
+
+- **Tables 1–16** (national / each state / youth / working-age age bands) are *one cube*:
+  `month × region × sex × age × adjustment-type → measures`. ABS exposes exactly this as the
+  SDMX **`LF`** dataflow (MEASURE ×31, SEX ×3, AGE ~27, REGION = AUS + 8 states, TSEST =
+  original/seasonally-adjusted/trend, FREQ = M, from Feb 1978). → **one Data Basis table**.
+- The **pivot cubes** (LMS1–5, HRS1–2, SEM1, MLF1, X28–X29) are genuinely different grains →
+  one table each.
+
+`GM1`/`RM1` etc. are Excel **data-cube codes, not SDMX dataflow ids** (they 404 on the API).
+ABS has *ceased* the SA4 direct-survey cubes (RM1/RQ); our `region_sa4` uses **MLF1
+(modelled)**, which is in the main release and still published.
+
+---
+
+## 2. Table architecture (8 data tables + `dicionario`)
+
+Shape: **wide-by-measure** for the status-type cubes (matches the source; each measure column
+carries its own `measurement_unit` — persons `'000`, rates `%`, hours `'000 hours`);
+**long** for gross flows. Column names in **English** (`year`, `month`, not `ano`/`mes`).
+
+### Tier 1 — core (monthly)
+
+| Table | Grain | Key measures | Source |
+|---|---|---|---|
+| `labour_force_status` | month × adjustment_type × geography × sex × age_group | employed_total/full_time/part_time, unemployed, labour_force, unemployment_rate, participation_rate, employment_to_population_ratio, monthly_hours_worked | SDMX `LF` |
+| `hours_worked` | month × geography × sex × hours_band | employed persons (`'000`) | Excel HRS1/HRS2 (Table 18) |
+| `status_in_employment` | month × geography × sex × status_in_employment | persons (`'000`) | Excel SEM1 (Table 19) |
+| `underutilisation` | month × adjustment_type × geography × sex × age_group | underemployed, underemployment_rate, underutilisation_rate, unemployed | Excel X28/X29 (has SA/trend) |
+
+### Tier 2 — regional & flows (monthly; the large pivots)
+
+| Table | Grain | Key measures | Source |
+|---|---|---|---|
+| `gross_flows` | month × geography × sex × age_group × lfs_current × lfs_previous | matched-sample persons (`'000`) — **long** | Excel LMS1 |
+| `region_sa4` | month × id_sa4 × sex × age_group | employed, unemployed, labour_force, unemployment_rate, participation_rate | Excel MLF1 (modelled) |
+| `capital_city` | month × gccsa (greater capital city / rest of state) × sex × age_group | labour force status | Excel LMS2/LMS3 |
+| `country_of_birth` | month × geography × sex × age_group × birth_country_group × years_since_arrival | labour force status (`'000`) | Excel LMS4/LMS5 |
+
+`dicionario` — coded dimensions: `adjustment_type`, `hours_band`, `status_in_employment`,
+`lfs_current`/`lfs_previous`, `birth_country_group`, `years_since_arrival`, age_group codes.
+
+Notes:
+- `adjustment_type ∈ {original, seasonally_adjusted, trend}` exists only for
+  `labour_force_status` and `underutilisation`; the pivots are Original-only (column omitted).
+- Sensitivity upper/lower (TSEST 40/50) dropped.
+- LMS2+LMS3 consolidate into `capital_city`, LMS4+LMS5 into `country_of_birth`, at the finest
+  consistent grain; split only if the grains genuinely conflict (resolved at architecture step).
+
+---
+
+## 3. Geography modelling & directory FK (open design point → resolved at architecture step)
+
+- **states/territories:** `labour_force_status`, `hours_worked`, `status_in_employment`,
+  `underutilisation`, `gross_flows`, `country_of_birth` carry a geography dimension =
+  **Australia + 8 states/territories**. National ("AUS") is an aggregate, not a state, so it
+  cannot FK a state directory. Decision: state code column FK-linked to `br_bd_diretorios_au`
+  for state rows; handle the national aggregate per BD's national-total convention (confirm the
+  AU directory has/handles a national entry, else sentinel + `covered_by_dictionary`).
+- **`region_sa4`** → `id_sa4` FK to `br_bd_diretorios_au` (SA4).
+- **`capital_city`** → GCCSA FK to `br_bd_diretorios_au` (GCCSA) if present.
+
+**Dependency/risk:** `br_bd_diretorios_au` (ASGS 2016+2021) must be **live in prod** for these
+FK dbt tests. It is in progress. If not live at metadata time: onboard the geo columns as
+STRING `covered_by_dictionary=no` with `directory_column` noted, and defer the FK
+`relationships` tests (re-enable once the directory lands) rather than block the whole dataset.
+
+---
+
+## 4. Recurring monthly pipeline (`pipelines/datasets/au_abs_labour_force/`)
+
+Reference implementation: `us_bls_cpi`. Because both sources ship **full history each release**,
+use `dump_mode="overwrite"`; staging parquet **all-STRING via arrow** (dump_header bug), real
+types applied first. Poll guard on the release month (SDMX `LF` latest period + Excel release
+month), so a scheduled run no-ops until ABS publishes. One raw source per table (multi-raw-source
+client bug): core tables → the `LF` API source; pivots → the 6202.0 Excel release source.
+
+**BD Pro rolling window:** every table refreshes monthly → **`PartBdpro(free_lag=6 months)`** per
+house rule; `dicionario` takes no coverage. Requires a pro Coverage (`is_closed=True`) created
+**before** the first pipeline run (else `assert_coverage_topology` hard-fails).
+
+---
+
+## 5. Step sequence
+
+**A. Design**
+1. `context` — confirm org `au_abs`, license CC BY 4.0, coverage (Feb 1978–present), Drive folder.
+2. `architecture` — 9 Google Sheets (one per table) with English column names, PT/EN/ES
+   descriptions, types by arithmetic meaning, directory FKs. **← architecture reviewed here.**
+
+**B. Build (dev)**
+3. `download` — SDMX `LF` (full history) + the 6202.0 Excel pivot cubes (LMS1–5, HRS1–2, SEM1,
+   MLF1, X28–X29). Verify per-grain API coverage; fall back to Excel where absent.
+4. `clean` — reshape to the architecture schema → partitioned parquet (`year=` partition).
+5. `upload` — BigQuery `basedosdados-dev` staging.
+6. `dbt` — 9 models + `schema.yml` (safe_cast, FK relationships, unique-combination tests).
+7. `validate` — dbt tests + row-count / coverage checks.
+
+**C. Metadata**
+8. `discover` + `metadata` (dev, status `under_review`) → **verification checkpoint (pause)**.
+9. `metadata --env prod` (`under_review`) after approval.
+10. `pr` — open PR (add **`deploy-flow`** label for the pipeline dev run).
+
+**D. Pipeline**
+11. Build `pipelines/datasets/au_abs_labour_force/` (constants/utils/tasks/flows), reusing the
+    cleaning transform from step 4. Dev run with
+    `{materialize_to_prod:false, update_metadata:false, force_run:true}`; confirm `dbt run OK` +
+    `dbt test OK` per table. Create the pro Coverage + source `Update`/`Poll` records.
+
+**E. Post-merge**
+12. After merge → table-approve materialises prod → verify row counts / cloud tables → **publish**
+    (`status.published`). Arm the schedule (Django admin `is_schedule_active`) deliberately.
+
+---
+
+## 5b. Tier-1 as-built architecture (2026-08-05)
+
+Phasing decided: **Tier 1 (4 tables) first; Tier 2 = phase 2.** Columns registered via
+`bulk_upsert_columns` from `code/columns_json/*.json` (built by `build_columns_json.py` from
+`code/architecture/*.csv`) — **not** a Google Sheet, which drops `description_en` for
+English-source datasets. All categories decoded to readable English labels ⇒
+`covered_by_dictionary=false` everywhere ⇒ **no `dicionario` table**. All ABS counts converted
+from thousands → absolute persons (`person`) / hours (`hour`); rates are `percent`.
+
+| Table | Cols | Grain | Source | Adj. type |
+|---|---|---|---|---|
+| `labour_force_status` | 20 | year·month·geography·sex·age_group·adjustment_type → 14 measures | SDMX `LF` | Orig/SA/Trend |
+| `hours_worked` | 8 | year·month·geography·sex·hours_band → employed_persons, hours_worked, hours_per_person | Table 18 (national) | Original only |
+| `status_in_employment` | 8 | year·month·geography·sex·status_in_employment → employed_total/full_time/part_time | Table 19 (national) + SEM1 (states) | Original only |
+| `underutilisation` | 10 | year·month·geography·sex·age_group·adjustment_type → underemployed_total, underemployment_ratio, underemployment_rate, underutilisation_rate | X28 (states) + X29 (age) | Orig/SA/Trend |
+
+Deliberate scoping calls (documented for review):
+- **`hours_worked` is national-only in Tier-1.** ABS fragments hours across incompatible cuts:
+  Table 18 (national, sex, 3 measures incl. hours-per-person), HRS1 (states, no sex, FT/PT
+  split), HRS2 (age×sex, national). Table 18 is the cleanest headline distribution; state hours
+  (HRS1/SEM1) are phase 2. `geography` column kept (= Australia) for schema continuity.
+- **`underutilisation` carries only the four underutilisation-specific measures.** Employment /
+  unemployment / labour-force levels live in `labour_force_status` on the same keys (joinable),
+  avoiding duplication.
+- **`geography`** = Australia + 8 states/territories as readable names; no `directory_column`
+  yet (br_bd_diretorios_au unpublished + national aggregate has no state-directory row). FK noted.
+- National (Persons + national totals) sourced from the time-series spreadsheets; state
+  disaggregation (Males/Females only) from the pivots — ABS benchmarks national separately, so
+  national is **never** derived by summing states.
+
+## 5c. Build status (2026-08-05)
+
+Done through dbt, all in dev:
+- **Sourcing finalised (API-heavy):** `labour_force_status` <- SDMX `LF` + `LF_AGES`;
+  `underutilisation` <- SDMX `LF_UNDER`; `hours_worked` <- Excel Table 18;
+  `status_in_employment` <- Excel Table 19 + SEM1. (`not_in_labour_force` /
+  `civilian_population_15_over` kept — national via `LF_AGES`; NULL for states, which the
+  `LF` flow does not carry.)
+- **Cleaning** in `pipelines/datasets/au_abs_labour_force/utils.py` (shared, no Prefect).
+  Row counts: labour_force_status 83,664 (1978–2026), underutilisation 85,407 (1978–2026),
+  hours_worked 19,170 (1991–2026), status_in_employment 68,754 (1991–2026). Staging parquet
+  all-STRING, `year` as `'2026'`, NULLs preserved.
+- **Uploaded** to `basedosdados-dev` staging (row counts exact).
+- **dbt** run OK (4/4) + test OK (38/38): unique-combination, not_null, not_null_proportion,
+  and year/month relationships to `br_bd_diretorios_data_tempo`. Ran with
+  `--profiles-dir ~/.dbt` (repo `profiles.yml` uses the CI-only `/credentials-dev/dev.json`).
+
+Verify in dev BigQuery, e.g.:
+```sql
+select geography, unemployment_rate from `basedosdados-dev.au_abs_labour_force.labour_force_status`
+where year=2026 and month=6 and sex='persons' and age_group='total' and adjustment_type='seasonally_adjusted'
+order by geography
+```
+
+Not yet done: metadata registration (dev → prod), commit, PR, monthly pipeline. Nothing committed.
+
+## 6. Open items to confirm during build
+- Exact SDMX dataflow ids for hours / status-in-employment / underutilisation (else Excel).
+- LMS2/3 and LMS4/5 grain consolidation.
+- `br_bd_diretorios_au` prod availability (FK dependency above).
+- Whether `au_abs` org already exists in the backend (community-profiles onboarding) or needs creating.

--- a/models/au_abs_labour_force/au_abs_labour_force__hours_worked.sql
+++ b/models/au_abs_labour_force/au_abs_labour_force__hours_worked.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        schema="au_abs_labour_force",
+        alias="hours_worked",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1991, "end": 2031, "interval": 1},
+        },
+        cluster_by=["geography"],
+    )
+}}
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(geography as string) geography,
+    safe_cast(sex as string) sex,
+    safe_cast(hours_band as string) hours_band,
+    safe_cast(employed_persons as float64) employed_persons,
+    safe_cast(hours_worked as float64) hours_worked,
+    safe_cast(hours_per_person as float64) hours_per_person
+from {{ set_datalake_project("au_abs_labour_force_staging.hours_worked") }} as t

--- a/models/au_abs_labour_force/au_abs_labour_force__labour_force_status.sql
+++ b/models/au_abs_labour_force/au_abs_labour_force__labour_force_status.sql
@@ -1,0 +1,44 @@
+{{
+    config(
+        schema="au_abs_labour_force",
+        alias="labour_force_status",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1978, "end": 2031, "interval": 1},
+        },
+        cluster_by=["geography", "adjustment_type"],
+    )
+}}
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(geography as string) geography,
+    safe_cast(sex as string) sex,
+    safe_cast(age_group as string) age_group,
+    safe_cast(adjustment_type as string) adjustment_type,
+    safe_cast(employed_total as float64) employed_total,
+    safe_cast(employed_full_time as float64) employed_full_time,
+    safe_cast(employed_part_time as float64) employed_part_time,
+    safe_cast(unemployed_total as float64) unemployed_total,
+    safe_cast(
+        unemployed_looked_for_full_time as float64
+    ) unemployed_looked_for_full_time,
+    safe_cast(
+        unemployed_looked_for_part_time as float64
+    ) unemployed_looked_for_part_time,
+    safe_cast(labour_force_total as float64) labour_force_total,
+    safe_cast(not_in_labour_force as float64) not_in_labour_force,
+    safe_cast(civilian_population_15_over as float64) civilian_population_15_over,
+    safe_cast(unemployment_rate as float64) unemployment_rate,
+    safe_cast(
+        unemployment_rate_looked_for_full_time as float64
+    ) unemployment_rate_looked_for_full_time,
+    safe_cast(
+        unemployment_rate_looked_for_part_time as float64
+    ) unemployment_rate_looked_for_part_time,
+    safe_cast(participation_rate as float64) participation_rate,
+    safe_cast(employment_to_population_ratio as float64) employment_to_population_ratio
+from {{ set_datalake_project("au_abs_labour_force_staging.labour_force_status") }} as t

--- a/models/au_abs_labour_force/au_abs_labour_force__status_in_employment.sql
+++ b/models/au_abs_labour_force/au_abs_labour_force__status_in_employment.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        schema="au_abs_labour_force",
+        alias="status_in_employment",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1991, "end": 2031, "interval": 1},
+        },
+        cluster_by=["geography"],
+    )
+}}
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(geography as string) geography,
+    safe_cast(sex as string) sex,
+    safe_cast(status_in_employment as string) status_in_employment,
+    safe_cast(employed_total as float64) employed_total,
+    safe_cast(employed_full_time as float64) employed_full_time,
+    safe_cast(employed_part_time as float64) employed_part_time
+from {{ set_datalake_project("au_abs_labour_force_staging.status_in_employment") }} as t

--- a/models/au_abs_labour_force/au_abs_labour_force__underutilisation.sql
+++ b/models/au_abs_labour_force/au_abs_labour_force__underutilisation.sql
@@ -1,0 +1,26 @@
+{{
+    config(
+        schema="au_abs_labour_force",
+        alias="underutilisation",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1978, "end": 2031, "interval": 1},
+        },
+        cluster_by=["geography", "adjustment_type"],
+    )
+}}
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(month as int64) month,
+    safe_cast(geography as string) geography,
+    safe_cast(sex as string) sex,
+    safe_cast(age_group as string) age_group,
+    safe_cast(adjustment_type as string) adjustment_type,
+    safe_cast(underemployed_total as float64) underemployed_total,
+    safe_cast(underemployment_ratio as float64) underemployment_ratio,
+    safe_cast(underemployment_rate as float64) underemployment_rate,
+    safe_cast(underutilisation_rate as float64) underutilisation_rate
+from {{ set_datalake_project("au_abs_labour_force_staging.underutilisation") }} as t

--- a/models/au_abs_labour_force/code/architecture/hours_worked.csv
+++ b/models/au_abs_labour_force/code/architecture/hours_worked.csv
@@ -1,0 +1,9 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,TIME_PERIOD
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,Derived from the monthly reference period,TIME_PERIOD
+geography,STRING,Geographic area: Australia (national) or one of the eight states and territories,,no,,,no,Australia is the national aggregate; states and territories follow the ASGS. To be linked to br_bd_diretorios_au once that directory is published,REGION
+sex,STRING,"Sex: persons (all), males or females",,no,,,no,Persons is the total across males and females,SEX
+hours_band,STRING,Range of hours actually worked in all jobs during the reference week,,no,,,no,Includes aggregate bands such as worked fewer than 35 hours and worked 35 hours or more,Hours actually worked in all jobs
+employed_persons,FLOAT64,Number of employed persons in the hours-worked band,,no,,person,no,Converted from ABS thousands to absolute persons,Employed total
+hours_worked,FLOAT64,Total hours actually worked in all jobs,,no,,hour,no,Converted from ABS thousands of hours to hours,Number of hours actually worked in all jobs
+hours_per_person,FLOAT64,Average hours actually worked per employed person,,no,,hour,no,Converted from ABS thousands of hours to hours,Hours actually worked in all jobs per employed person

--- a/models/au_abs_labour_force/code/architecture/labour_force_status.csv
+++ b/models/au_abs_labour_force/code/architecture/labour_force_status.csv
@@ -1,0 +1,21 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,TIME_PERIOD
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,Derived from the monthly reference period,TIME_PERIOD
+geography,STRING,Geographic area: Australia (national) or one of the eight states and territories,,no,,,no,Australia is the national aggregate; states and territories follow the ASGS. To be linked to br_bd_diretorios_au once that directory is published,REGION
+sex,STRING,"Sex: persons (all), males or females",,no,,,no,Persons is the total across males and females,SEX
+age_group,STRING,Age group in years; total covers persons aged 15 years and over,,no,,,no,ABS standard age groupings; the set of groups available varies by geography,AGE
+adjustment_type,STRING,"Time series adjustment: original, seasonally adjusted or trend",,no,,,no,,TSEST
+employed_total,FLOAT64,Number of employed persons,,no,,person,no,Converted from ABS thousands to absolute persons,Employed total
+employed_full_time,FLOAT64,Number of persons employed full-time,,no,,person,no,Converted from ABS thousands to absolute persons,Employed full-time
+employed_part_time,FLOAT64,Number of persons employed part-time,,no,,person,no,Converted from ABS thousands to absolute persons,Employed part-time
+unemployed_total,FLOAT64,Number of unemployed persons,,no,,person,no,Converted from ABS thousands to absolute persons,Unemployed total
+unemployed_looked_for_full_time,FLOAT64,Number of unemployed persons who looked for full-time work,,no,,person,no,Converted from ABS thousands to absolute persons,Unemployed looked for full-time work
+unemployed_looked_for_part_time,FLOAT64,Number of unemployed persons who looked for only part-time work,,no,,person,no,Converted from ABS thousands to absolute persons,Unemployed looked for only part-time work
+labour_force_total,FLOAT64,"Total labour force, employed plus unemployed",,no,,person,no,Converted from ABS thousands to absolute persons,Labour force total
+not_in_labour_force,FLOAT64,Number of persons not in the labour force,,no,,person,no,Converted from ABS thousands to absolute persons,Not in the labour force (NILF)
+civilian_population_15_over,FLOAT64,Civilian population aged 15 years and over,,no,,person,no,Converted from ABS thousands to absolute persons,Civilian population aged 15 years and over
+unemployment_rate,FLOAT64,Unemployed persons as a percentage of the labour force,,no,,percent,no,,Unemployment rate
+unemployment_rate_looked_for_full_time,FLOAT64,Unemployment rate among those who looked for full-time work,,no,,percent,no,,Unemployment rate looked for full-time work
+unemployment_rate_looked_for_part_time,FLOAT64,Unemployment rate among those who looked for only part-time work,,no,,percent,no,,Unemployment rate looked for only part-time work
+participation_rate,FLOAT64,Labour force as a percentage of the civilian population aged 15 years and over,,no,,percent,no,,Participation rate
+employment_to_population_ratio,FLOAT64,Employed persons as a percentage of the civilian population aged 15 years and over,,no,,percent,no,,Employment to population ratio

--- a/models/au_abs_labour_force/code/architecture/status_in_employment.csv
+++ b/models/au_abs_labour_force/code/architecture/status_in_employment.csv
@@ -1,0 +1,9 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,TIME_PERIOD
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,Derived from the monthly reference period,TIME_PERIOD
+geography,STRING,Geographic area: Australia (national) or one of the eight states and territories,,no,,,no,Australia is the national aggregate; states and territories follow the ASGS. To be linked to br_bd_diretorios_au once that directory is published,REGION
+sex,STRING,"Sex: persons (all), males or females",,no,,,no,Persons is the total across males and females,SEX
+status_in_employment,STRING,"Status in employment of the main job, such as employee, owner manager or contributing family worker",,no,,,no,,Status in employment of main job
+employed_total,FLOAT64,Number of employed persons with this status in employment,,no,,person,no,Converted from ABS thousands to absolute persons,Employed total
+employed_full_time,FLOAT64,Number employed full-time with this status in employment,,no,,person,no,Converted from ABS thousands to absolute persons,Employed full-time
+employed_part_time,FLOAT64,Number employed part-time with this status in employment,,no,,person,no,Converted from ABS thousands to absolute persons,Employed part-time

--- a/models/au_abs_labour_force/code/architecture/underutilisation.csv
+++ b/models/au_abs_labour_force/code/architecture/underutilisation.csv
@@ -1,0 +1,11 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Reference year of the observation,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column,TIME_PERIOD
+month,INT64,"Reference month of the observation, from 1 to 12",,no,br_bd_diretorios_data_tempo.mes:mes,month,no,Derived from the monthly reference period,TIME_PERIOD
+geography,STRING,Geographic area: Australia (national) or one of the eight states and territories,,no,,,no,Australia is the national aggregate; states and territories follow the ASGS. To be linked to br_bd_diretorios_au once that directory is published,REGION
+sex,STRING,"Sex: persons (all), males or females",,no,,,no,Persons is the total across males and females,SEX
+age_group,STRING,Age group in years; total covers persons aged 15 years and over,,no,,,no,ABS standard age groupings; the set of groups available varies by geography,AGE
+adjustment_type,STRING,"Time series adjustment: original, seasonally adjusted or trend",,no,,,no,,TSEST
+underemployed_total,FLOAT64,Number of underemployed persons,,no,,person,no,Converted from ABS thousands to absolute persons,Underemployed total
+underemployment_ratio,FLOAT64,Underemployed persons as a percentage of employed persons,,no,,percent,no,,Underemployment ratio (proportion of employed)
+underemployment_rate,FLOAT64,Underemployed persons as a percentage of the labour force,,no,,percent,no,,Underemployment rate (proportion of labour force)
+underutilisation_rate,FLOAT64,Sum of the unemployment rate and the underemployment rate,,no,,percent,no,,Underutilisation rate

--- a/models/au_abs_labour_force/code/build_architecture.py
+++ b/models/au_abs_labour_force/code/build_architecture.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""
+Emit the architecture CSVs for au_abs_labour_force (Tier 1: 4 tables).
+
+The architecture CSV is the single source of truth for column order, BigQuery
+types, dictionary/directory flags, and measurement units. English descriptions
+live here; Portuguese and Spanish are attached by build_columns_json.py.
+
+Column names are English (English-language dataset). All ABS counts are converted
+from thousands to absolute persons/hours at clean time, so count columns carry the
+unit `person` and hours columns `hour`; rates carry `percent`.
+
+Categorical dimensions (sex, age_group, adjustment_type, hours_band,
+status_in_employment) are decoded to readable English labels, so
+covered_by_dictionary is false throughout and there is no dicionario table.
+
+`geography` is Australia (national) plus the eight states/territories. It is left
+without a directory_column for now: br_bd_diretorios_au is not yet published, and
+the national aggregate does not map to a state directory row. The FK is noted in
+observations and can be added in a later PR.
+
+Usage:
+    python models/au_abs_labour_force/code/build_architecture.py
+"""
+
+import csv
+from pathlib import Path
+
+OUT = Path(__file__).resolve().parent / "architecture"
+OUT.mkdir(parents=True, exist_ok=True)
+
+HEADER = [
+    "name",
+    "bigquery_type",
+    "description",
+    "temporal_coverage",
+    "covered_by_dictionary",
+    "directory_column",
+    "measurement_unit",
+    "has_sensitive_data",
+    "observations",
+    "original_name",
+]
+
+# Shared dimension rows -------------------------------------------------------
+YEAR = [
+    "year",
+    "INT64",
+    "Reference year of the observation",
+    "",
+    "no",
+    "br_bd_diretorios_data_tempo.ano:ano",
+    "year",
+    "no",
+    "Partition column",
+    "TIME_PERIOD",
+]
+MONTH = [
+    "month",
+    "INT64",
+    "Reference month of the observation, from 1 to 12",
+    "",
+    "no",
+    "br_bd_diretorios_data_tempo.mes:mes",
+    "month",
+    "no",
+    "Derived from the monthly reference period",
+    "TIME_PERIOD",
+]
+GEOGRAPHY = [
+    "geography",
+    "STRING",
+    "Geographic area: Australia (national) or one of the eight states and territories",
+    "",
+    "no",
+    "",
+    "",
+    "no",
+    "Australia is the national aggregate; states and territories follow the ASGS. To be linked to br_bd_diretorios_au once that directory is published",
+    "REGION",
+]
+SEX = [
+    "sex",
+    "STRING",
+    "Sex: persons (all), males or females",
+    "",
+    "no",
+    "",
+    "",
+    "no",
+    "Persons is the total across males and females",
+    "SEX",
+]
+AGE_GROUP = [
+    "age_group",
+    "STRING",
+    "Age group in years; total covers persons aged 15 years and over",
+    "",
+    "no",
+    "",
+    "",
+    "no",
+    "ABS standard age groupings; the set of groups available varies by geography",
+    "AGE",
+]
+ADJUSTMENT = [
+    "adjustment_type",
+    "STRING",
+    "Time series adjustment: original, seasonally adjusted or trend",
+    "",
+    "no",
+    "",
+    "",
+    "no",
+    "",
+    "TSEST",
+]
+
+
+def count(name, desc, original):
+    return [
+        name,
+        "FLOAT64",
+        desc,
+        "",
+        "no",
+        "",
+        "person",
+        "no",
+        "Converted from ABS thousands to absolute persons",
+        original,
+    ]
+
+
+def rate(name, desc, original):
+    return [name, "FLOAT64", desc, "", "no", "", "percent", "no", "", original]
+
+
+def hours(name, desc, original):
+    return [
+        name,
+        "FLOAT64",
+        desc,
+        "",
+        "no",
+        "",
+        "hour",
+        "no",
+        "Converted from ABS thousands of hours to hours",
+        original,
+    ]
+
+
+TABLES = {}
+
+# 1. labour_force_status (SDMX LF) -------------------------------------------
+TABLES["labour_force_status"] = [
+    YEAR,
+    MONTH,
+    GEOGRAPHY,
+    SEX,
+    AGE_GROUP,
+    ADJUSTMENT,
+    count("employed_total", "Number of employed persons", "Employed total"),
+    count(
+        "employed_full_time",
+        "Number of persons employed full-time",
+        "Employed full-time",
+    ),
+    count(
+        "employed_part_time",
+        "Number of persons employed part-time",
+        "Employed part-time",
+    ),
+    count(
+        "unemployed_total", "Number of unemployed persons", "Unemployed total"
+    ),
+    count(
+        "unemployed_looked_for_full_time",
+        "Number of unemployed persons who looked for full-time work",
+        "Unemployed looked for full-time work",
+    ),
+    count(
+        "unemployed_looked_for_part_time",
+        "Number of unemployed persons who looked for only part-time work",
+        "Unemployed looked for only part-time work",
+    ),
+    count(
+        "labour_force_total",
+        "Total labour force, employed plus unemployed",
+        "Labour force total",
+    ),
+    count(
+        "not_in_labour_force",
+        "Number of persons not in the labour force",
+        "Not in the labour force (NILF)",
+    ),
+    count(
+        "civilian_population_15_over",
+        "Civilian population aged 15 years and over",
+        "Civilian population aged 15 years and over",
+    ),
+    rate(
+        "unemployment_rate",
+        "Unemployed persons as a percentage of the labour force",
+        "Unemployment rate",
+    ),
+    rate(
+        "unemployment_rate_looked_for_full_time",
+        "Unemployment rate among those who looked for full-time work",
+        "Unemployment rate looked for full-time work",
+    ),
+    rate(
+        "unemployment_rate_looked_for_part_time",
+        "Unemployment rate among those who looked for only part-time work",
+        "Unemployment rate looked for only part-time work",
+    ),
+    rate(
+        "participation_rate",
+        "Labour force as a percentage of the civilian population aged 15 years and over",
+        "Participation rate",
+    ),
+    rate(
+        "employment_to_population_ratio",
+        "Employed persons as a percentage of the civilian population aged 15 years and over",
+        "Employment to population ratio",
+    ),
+]
+
+# 2. hours_worked (Table 18, national) ---------------------------------------
+HOURS_BAND = [
+    "hours_band",
+    "STRING",
+    "Range of hours actually worked in all jobs during the reference week",
+    "",
+    "no",
+    "",
+    "",
+    "no",
+    "Includes aggregate bands such as worked fewer than 35 hours and worked 35 hours or more",
+    "Hours actually worked in all jobs",
+]
+TABLES["hours_worked"] = [
+    YEAR,
+    MONTH,
+    GEOGRAPHY,
+    SEX,
+    HOURS_BAND,
+    count(
+        "employed_persons",
+        "Number of employed persons in the hours-worked band",
+        "Employed total",
+    ),
+    hours(
+        "hours_worked",
+        "Total hours actually worked in all jobs",
+        "Number of hours actually worked in all jobs",
+    ),
+    hours(
+        "hours_per_person",
+        "Average hours actually worked per employed person",
+        "Hours actually worked in all jobs per employed person",
+    ),
+]
+
+# 3. status_in_employment (Table 19 national + SEM1 states) ------------------
+STATUS = [
+    "status_in_employment",
+    "STRING",
+    "Status in employment of the main job, such as employee, owner manager or contributing family worker",
+    "",
+    "no",
+    "",
+    "",
+    "no",
+    "",
+    "Status in employment of main job",
+]
+TABLES["status_in_employment"] = [
+    YEAR,
+    MONTH,
+    GEOGRAPHY,
+    SEX,
+    STATUS,
+    count(
+        "employed_total",
+        "Number of employed persons with this status in employment",
+        "Employed total",
+    ),
+    count(
+        "employed_full_time",
+        "Number employed full-time with this status in employment",
+        "Employed full-time",
+    ),
+    count(
+        "employed_part_time",
+        "Number employed part-time with this status in employment",
+        "Employed part-time",
+    ),
+]
+
+# 4. underutilisation (X28 states + X29 age) ---------------------------------
+TABLES["underutilisation"] = [
+    YEAR,
+    MONTH,
+    GEOGRAPHY,
+    SEX,
+    AGE_GROUP,
+    ADJUSTMENT,
+    count(
+        "underemployed_total",
+        "Number of underemployed persons",
+        "Underemployed total",
+    ),
+    rate(
+        "underemployment_ratio",
+        "Underemployed persons as a percentage of employed persons",
+        "Underemployment ratio (proportion of employed)",
+    ),
+    rate(
+        "underemployment_rate",
+        "Underemployed persons as a percentage of the labour force",
+        "Underemployment rate (proportion of labour force)",
+    ),
+    rate(
+        "underutilisation_rate",
+        "Sum of the unemployment rate and the underemployment rate",
+        "Underutilisation rate",
+    ),
+]
+
+
+def main():
+    for table, rows in TABLES.items():
+        path = OUT / f"{table}.csv"
+        with path.open("w", newline="") as fh:
+            w = csv.writer(fh)
+            w.writerow(HEADER)
+            w.writerows(rows)
+        print(f"wrote {path}  ({len(rows)} columns)")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_abs_labour_force/code/build_columns_json.py
+++ b/models/au_abs_labour_force/code/build_columns_json.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Emit columns_json payloads for mcp__databasis__bulk_upsert_columns, one per table.
+
+Reads the architecture CSVs (English descriptions + type/dictionary/unit flags)
+and attaches Portuguese and Spanish translations from TRANSLATIONS below, so
+columns register directly with all three languages (no Google Sheet — the sheet
+path drops description_en for English-source datasets). Writes
+code/columns_json/<table>.json.
+
+Keys in TRANSLATIONS are the column name, or "name:table" when the same column
+name carries a different meaning across tables.
+
+Usage:
+    python models/au_abs_labour_force/code/build_columns_json.py
+"""
+
+import csv
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARCH = ROOT / "code" / "architecture"
+OUT = ROOT / "code" / "columns_json"
+
+# name (or name:table) -> (description_pt, description_es). English from the CSV.
+TRANSLATIONS = {
+    "year": (
+        "Ano de referência da observação",
+        "Año de referencia de la observación",
+    ),
+    "month": (
+        "Mês de referência da observação, de 1 a 12",
+        "Mes de referencia de la observación, de 1 a 12",
+    ),
+    "geography": (
+        "Área geográfica: Austrália (nacional) ou um dos oito estados e territórios",
+        "Área geográfica: Australia (nacional) o uno de los ocho estados y territorios",
+    ),
+    "sex": (
+        "Sexo: pessoas (total), homens ou mulheres",
+        "Sexo: personas (total), hombres o mujeres",
+    ),
+    "age_group": (
+        "Faixa etária em anos; total abrange pessoas com 15 anos ou mais",
+        "Grupo de edad en años; total abarca personas de 15 años o más",
+    ),
+    "adjustment_type": (
+        "Ajuste da série temporal: original, ajustada sazonalmente ou tendência",
+        "Ajuste de la serie temporal: original, ajustada estacionalmente o tendencia",
+    ),
+    # labour_force_status measures
+    "employed_total": (
+        "Número de pessoas ocupadas",
+        "Número de personas ocupadas",
+    ),
+    "employed_full_time": (
+        "Número de pessoas ocupadas em tempo integral",
+        "Número de personas ocupadas a tiempo completo",
+    ),
+    "employed_part_time": (
+        "Número de pessoas ocupadas em tempo parcial",
+        "Número de personas ocupadas a tiempo parcial",
+    ),
+    "unemployed_total": (
+        "Número de pessoas desempregadas",
+        "Número de personas desempleadas",
+    ),
+    "unemployed_looked_for_full_time": (
+        "Número de pessoas desempregadas que procuraram trabalho em tempo integral",
+        "Número de personas desempleadas que buscaron trabajo a tiempo completo",
+    ),
+    "unemployed_looked_for_part_time": (
+        "Número de pessoas desempregadas que procuraram apenas trabalho em tempo parcial",
+        "Número de personas desempleadas que buscaron solo trabajo a tiempo parcial",
+    ),
+    "labour_force_total": (
+        "Força de trabalho total, ocupados mais desempregados",
+        "Fuerza laboral total, ocupados más desempleados",
+    ),
+    "not_in_labour_force": (
+        "Número de pessoas fora da força de trabalho",
+        "Número de personas fuera de la fuerza laboral",
+    ),
+    "civilian_population_15_over": (
+        "População civil com 15 anos ou mais",
+        "Población civil de 15 años o más",
+    ),
+    "unemployment_rate": (
+        "Pessoas desempregadas como porcentagem da força de trabalho",
+        "Personas desempleadas como porcentaje de la fuerza laboral",
+    ),
+    "unemployment_rate_looked_for_full_time": (
+        "Taxa de desemprego entre quem procurou trabalho em tempo integral",
+        "Tasa de desempleo entre quienes buscaron trabajo a tiempo completo",
+    ),
+    "unemployment_rate_looked_for_part_time": (
+        "Taxa de desemprego entre quem procurou apenas trabalho em tempo parcial",
+        "Tasa de desempleo entre quienes buscaron solo trabajo a tiempo parcial",
+    ),
+    "participation_rate": (
+        "Força de trabalho como porcentagem da população civil com 15 anos ou mais",
+        "Fuerza laboral como porcentaje de la población civil de 15 años o más",
+    ),
+    "employment_to_population_ratio": (
+        "Pessoas ocupadas como porcentagem da população civil com 15 anos ou mais",
+        "Personas ocupadas como porcentaje de la población civil de 15 años o más",
+    ),
+    # hours_worked
+    "hours_band": (
+        "Faixa de horas efetivamente trabalhadas em todos os empregos na semana de referência",
+        "Rango de horas efectivamente trabajadas en todos los empleos en la semana de referencia",
+    ),
+    "employed_persons": (
+        "Número de pessoas ocupadas na faixa de horas trabalhadas",
+        "Número de personas ocupadas en el rango de horas trabajadas",
+    ),
+    "hours_worked": (
+        "Total de horas efetivamente trabalhadas em todos os empregos",
+        "Total de horas efectivamente trabajadas en todos los empleos",
+    ),
+    "hours_per_person": (
+        "Média de horas efetivamente trabalhadas por pessoa ocupada",
+        "Promedio de horas efectivamente trabajadas por persona ocupada",
+    ),
+    # status_in_employment
+    "status_in_employment": (
+        "Posição na ocupação do trabalho principal, como empregado, empregador ou trabalhador familiar auxiliar",
+        "Situación en el empleo del trabajo principal, como asalariado, empleador o trabajador familiar auxiliar",
+    ),
+    "employed_total:status_in_employment": (
+        "Número de pessoas ocupadas com esta posição na ocupação",
+        "Número de personas ocupadas con esta situación en el empleo",
+    ),
+    "employed_full_time:status_in_employment": (
+        "Número de pessoas ocupadas em tempo integral com esta posição na ocupação",
+        "Número de personas ocupadas a tiempo completo con esta situación en el empleo",
+    ),
+    "employed_part_time:status_in_employment": (
+        "Número de pessoas ocupadas em tempo parcial com esta posição na ocupação",
+        "Número de personas ocupadas a tiempo parcial con esta situación en el empleo",
+    ),
+    # underutilisation
+    "underemployed_total": (
+        "Número de pessoas subocupadas",
+        "Número de personas subempleadas",
+    ),
+    "underemployment_ratio": (
+        "Pessoas subocupadas como porcentagem das pessoas ocupadas",
+        "Personas subempleadas como porcentaje de las personas ocupadas",
+    ),
+    "underemployment_rate": (
+        "Pessoas subocupadas como porcentagem da força de trabalho",
+        "Personas subempleadas como porcentaje de la fuerza laboral",
+    ),
+    "underutilisation_rate": (
+        "Soma da taxa de desemprego e da taxa de subocupação",
+        "Suma de la tasa de desempleo y la tasa de subempleo",
+    ),
+}
+
+
+def tr(name, table):
+    if f"{name}:{table}" in TRANSLATIONS:
+        return TRANSLATIONS[f"{name}:{table}"]
+    if name not in TRANSLATIONS:
+        raise KeyError(f"missing translation for {name!r} (table {table})")
+    return TRANSLATIONS[name]
+
+
+def main():
+    OUT.mkdir(parents=True, exist_ok=True)
+    for csv_path in sorted(ARCH.glob("*.csv")):
+        table = csv_path.stem
+        cols = []
+        with csv_path.open() as fh:
+            for r in csv.DictReader(fh):
+                pt, es = tr(r["name"], table)
+                col = {
+                    "name": r["name"],
+                    "bigquery_type": r["bigquery_type"],
+                    "description_pt": pt,
+                    "description_en": r["description"],
+                    "description_es": es,
+                    "covered_by_dictionary": r["covered_by_dictionary"]
+                    .strip()
+                    .lower()
+                    == "yes",
+                    "has_sensitive_data": r["has_sensitive_data"]
+                    .strip()
+                    .lower()
+                    == "yes",
+                }
+                if r["directory_column"].strip():
+                    col["directory_column"] = r["directory_column"].strip()
+                if r["measurement_unit"].strip():
+                    col["measurement_unit"] = r["measurement_unit"].strip()
+                cols.append(col)
+        out_path = OUT / f"{table}.json"
+        out_path.write_text(json.dumps(cols, ensure_ascii=False, indent=2))
+        print(f"wrote {out_path}  ({len(cols)} columns)")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_abs_labour_force/code/clean_data.py
+++ b/models/au_abs_labour_force/code/clean_data.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Bootstrap: clean the ABS sources already in ../input into partitioned parquet
+in ../output.
+
+The cleaning transform lives in `pipelines.datasets.au_abs_labour_force.utils` so
+the one-shot bootstrap and the recurring Prefect pipeline share one
+implementation. This CLI is just the initial-load entry point; it assumes the
+SDMX CSVs (LF.csv, LF_AGES.csv, LF_UNDER.csv) and the Excel spreadsheets
+(62020018.xlsx, 62020019.xlsx, SEM1.xlsx) are already in ../input.
+
+Usage:
+    uv run python models/au_abs_labour_force/code/clean_data.py [table ...]
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+from pipelines.datasets.au_abs_labour_force.constants import constants
+from pipelines.datasets.au_abs_labour_force.utils import (
+    clean_all,
+    write_partitioned,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main():
+    """Rebuild the requested tables from ``input/`` into ``output/``."""
+    want = set(sys.argv[1:]) or set(constants.DATA_TABLES.value)
+    tables = clean_all(ROOT / "input")
+    for name, df in tables.items():
+        if name in want:
+            write_partitioned(df, name, ROOT / "output")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_abs_labour_force/code/columns_json/hours_worked.json
+++ b/models/au_abs_labour_force/code/columns_json/hours_worked.json
@@ -1,0 +1,81 @@
+[
+  {
+    "name": "year",
+    "bigquery_type": "INT64",
+    "description_pt": "Ano de referência da observação",
+    "description_en": "Reference year of the observation",
+    "description_es": "Año de referencia de la observación",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.ano:ano",
+    "measurement_unit": "year"
+  },
+  {
+    "name": "month",
+    "bigquery_type": "INT64",
+    "description_pt": "Mês de referência da observação, de 1 a 12",
+    "description_en": "Reference month of the observation, from 1 to 12",
+    "description_es": "Mes de referencia de la observación, de 1 a 12",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.mes:mes",
+    "measurement_unit": "month"
+  },
+  {
+    "name": "geography",
+    "bigquery_type": "STRING",
+    "description_pt": "Área geográfica: Austrália (nacional) ou um dos oito estados e territórios",
+    "description_en": "Geographic area: Australia (national) or one of the eight states and territories",
+    "description_es": "Área geográfica: Australia (nacional) o uno de los ocho estados y territorios",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "sex",
+    "bigquery_type": "STRING",
+    "description_pt": "Sexo: pessoas (total), homens ou mulheres",
+    "description_en": "Sex: persons (all), males or females",
+    "description_es": "Sexo: personas (total), hombres o mujeres",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "hours_band",
+    "bigquery_type": "STRING",
+    "description_pt": "Faixa de horas efetivamente trabalhadas em todos os empregos na semana de referência",
+    "description_en": "Range of hours actually worked in all jobs during the reference week",
+    "description_es": "Rango de horas efectivamente trabajadas en todos los empleos en la semana de referencia",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "employed_persons",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas ocupadas na faixa de horas trabalhadas",
+    "description_en": "Number of employed persons in the hours-worked band",
+    "description_es": "Número de personas ocupadas en el rango de horas trabajadas",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "hours_worked",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Total de horas efetivamente trabalhadas em todos os empregos",
+    "description_en": "Total hours actually worked in all jobs",
+    "description_es": "Total de horas efectivamente trabajadas en todos los empleos",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "hour"
+  },
+  {
+    "name": "hours_per_person",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Média de horas efetivamente trabalhadas por pessoa ocupada",
+    "description_en": "Average hours actually worked per employed person",
+    "description_es": "Promedio de horas efectivamente trabajadas por persona ocupada",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "hour"
+  }
+]

--- a/models/au_abs_labour_force/code/columns_json/labour_force_status.json
+++ b/models/au_abs_labour_force/code/columns_json/labour_force_status.json
@@ -1,0 +1,200 @@
+[
+  {
+    "name": "year",
+    "bigquery_type": "INT64",
+    "description_pt": "Ano de referência da observação",
+    "description_en": "Reference year of the observation",
+    "description_es": "Año de referencia de la observación",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.ano:ano",
+    "measurement_unit": "year"
+  },
+  {
+    "name": "month",
+    "bigquery_type": "INT64",
+    "description_pt": "Mês de referência da observação, de 1 a 12",
+    "description_en": "Reference month of the observation, from 1 to 12",
+    "description_es": "Mes de referencia de la observación, de 1 a 12",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.mes:mes",
+    "measurement_unit": "month"
+  },
+  {
+    "name": "geography",
+    "bigquery_type": "STRING",
+    "description_pt": "Área geográfica: Austrália (nacional) ou um dos oito estados e territórios",
+    "description_en": "Geographic area: Australia (national) or one of the eight states and territories",
+    "description_es": "Área geográfica: Australia (nacional) o uno de los ocho estados y territorios",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "sex",
+    "bigquery_type": "STRING",
+    "description_pt": "Sexo: pessoas (total), homens ou mulheres",
+    "description_en": "Sex: persons (all), males or females",
+    "description_es": "Sexo: personas (total), hombres o mujeres",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "age_group",
+    "bigquery_type": "STRING",
+    "description_pt": "Faixa etária em anos; total abrange pessoas com 15 anos ou mais",
+    "description_en": "Age group in years; total covers persons aged 15 years and over",
+    "description_es": "Grupo de edad en años; total abarca personas de 15 años o más",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "adjustment_type",
+    "bigquery_type": "STRING",
+    "description_pt": "Ajuste da série temporal: original, ajustada sazonalmente ou tendência",
+    "description_en": "Time series adjustment: original, seasonally adjusted or trend",
+    "description_es": "Ajuste de la serie temporal: original, ajustada estacionalmente o tendencia",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "employed_total",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas ocupadas",
+    "description_en": "Number of employed persons",
+    "description_es": "Número de personas ocupadas",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "employed_full_time",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas ocupadas em tempo integral",
+    "description_en": "Number of persons employed full-time",
+    "description_es": "Número de personas ocupadas a tiempo completo",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "employed_part_time",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas ocupadas em tempo parcial",
+    "description_en": "Number of persons employed part-time",
+    "description_es": "Número de personas ocupadas a tiempo parcial",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "unemployed_total",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas desempregadas",
+    "description_en": "Number of unemployed persons",
+    "description_es": "Número de personas desempleadas",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "unemployed_looked_for_full_time",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas desempregadas que procuraram trabalho em tempo integral",
+    "description_en": "Number of unemployed persons who looked for full-time work",
+    "description_es": "Número de personas desempleadas que buscaron trabajo a tiempo completo",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "unemployed_looked_for_part_time",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas desempregadas que procuraram apenas trabalho em tempo parcial",
+    "description_en": "Number of unemployed persons who looked for only part-time work",
+    "description_es": "Número de personas desempleadas que buscaron solo trabajo a tiempo parcial",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "labour_force_total",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Força de trabalho total, ocupados mais desempregados",
+    "description_en": "Total labour force, employed plus unemployed",
+    "description_es": "Fuerza laboral total, ocupados más desempleados",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "not_in_labour_force",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas fora da força de trabalho",
+    "description_en": "Number of persons not in the labour force",
+    "description_es": "Número de personas fuera de la fuerza laboral",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "civilian_population_15_over",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "População civil com 15 anos ou mais",
+    "description_en": "Civilian population aged 15 years and over",
+    "description_es": "Población civil de 15 años o más",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "unemployment_rate",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Pessoas desempregadas como porcentagem da força de trabalho",
+    "description_en": "Unemployed persons as a percentage of the labour force",
+    "description_es": "Personas desempleadas como porcentaje de la fuerza laboral",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  },
+  {
+    "name": "unemployment_rate_looked_for_full_time",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Taxa de desemprego entre quem procurou trabalho em tempo integral",
+    "description_en": "Unemployment rate among those who looked for full-time work",
+    "description_es": "Tasa de desempleo entre quienes buscaron trabajo a tiempo completo",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  },
+  {
+    "name": "unemployment_rate_looked_for_part_time",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Taxa de desemprego entre quem procurou apenas trabalho em tempo parcial",
+    "description_en": "Unemployment rate among those who looked for only part-time work",
+    "description_es": "Tasa de desempleo entre quienes buscaron solo trabajo a tiempo parcial",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  },
+  {
+    "name": "participation_rate",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Força de trabalho como porcentagem da população civil com 15 anos ou mais",
+    "description_en": "Labour force as a percentage of the civilian population aged 15 years and over",
+    "description_es": "Fuerza laboral como porcentaje de la población civil de 15 años o más",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  },
+  {
+    "name": "employment_to_population_ratio",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Pessoas ocupadas como porcentagem da população civil com 15 anos ou mais",
+    "description_en": "Employed persons as a percentage of the civilian population aged 15 years and over",
+    "description_es": "Personas ocupadas como porcentaje de la población civil de 15 años o más",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  }
+]

--- a/models/au_abs_labour_force/code/columns_json/status_in_employment.json
+++ b/models/au_abs_labour_force/code/columns_json/status_in_employment.json
@@ -1,0 +1,81 @@
+[
+  {
+    "name": "year",
+    "bigquery_type": "INT64",
+    "description_pt": "Ano de referência da observação",
+    "description_en": "Reference year of the observation",
+    "description_es": "Año de referencia de la observación",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.ano:ano",
+    "measurement_unit": "year"
+  },
+  {
+    "name": "month",
+    "bigquery_type": "INT64",
+    "description_pt": "Mês de referência da observação, de 1 a 12",
+    "description_en": "Reference month of the observation, from 1 to 12",
+    "description_es": "Mes de referencia de la observación, de 1 a 12",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.mes:mes",
+    "measurement_unit": "month"
+  },
+  {
+    "name": "geography",
+    "bigquery_type": "STRING",
+    "description_pt": "Área geográfica: Austrália (nacional) ou um dos oito estados e territórios",
+    "description_en": "Geographic area: Australia (national) or one of the eight states and territories",
+    "description_es": "Área geográfica: Australia (nacional) o uno de los ocho estados y territorios",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "sex",
+    "bigquery_type": "STRING",
+    "description_pt": "Sexo: pessoas (total), homens ou mulheres",
+    "description_en": "Sex: persons (all), males or females",
+    "description_es": "Sexo: personas (total), hombres o mujeres",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "status_in_employment",
+    "bigquery_type": "STRING",
+    "description_pt": "Posição na ocupação do trabalho principal, como empregado, empregador ou trabalhador familiar auxiliar",
+    "description_en": "Status in employment of the main job, such as employee, owner manager or contributing family worker",
+    "description_es": "Situación en el empleo del trabajo principal, como asalariado, empleador o trabajador familiar auxiliar",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "employed_total",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas ocupadas com esta posição na ocupação",
+    "description_en": "Number of employed persons with this status in employment",
+    "description_es": "Número de personas ocupadas con esta situación en el empleo",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "employed_full_time",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas ocupadas em tempo integral com esta posição na ocupação",
+    "description_en": "Number employed full-time with this status in employment",
+    "description_es": "Número de personas ocupadas a tiempo completo con esta situación en el empleo",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "employed_part_time",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas ocupadas em tempo parcial com esta posição na ocupação",
+    "description_en": "Number employed part-time with this status in employment",
+    "description_es": "Número de personas ocupadas a tiempo parcial con esta situación en el empleo",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  }
+]

--- a/models/au_abs_labour_force/code/columns_json/underutilisation.json
+++ b/models/au_abs_labour_force/code/columns_json/underutilisation.json
@@ -1,0 +1,100 @@
+[
+  {
+    "name": "year",
+    "bigquery_type": "INT64",
+    "description_pt": "Ano de referência da observação",
+    "description_en": "Reference year of the observation",
+    "description_es": "Año de referencia de la observación",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.ano:ano",
+    "measurement_unit": "year"
+  },
+  {
+    "name": "month",
+    "bigquery_type": "INT64",
+    "description_pt": "Mês de referência da observação, de 1 a 12",
+    "description_en": "Reference month of the observation, from 1 to 12",
+    "description_es": "Mes de referencia de la observación, de 1 a 12",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "directory_column": "br_bd_diretorios_data_tempo.mes:mes",
+    "measurement_unit": "month"
+  },
+  {
+    "name": "geography",
+    "bigquery_type": "STRING",
+    "description_pt": "Área geográfica: Austrália (nacional) ou um dos oito estados e territórios",
+    "description_en": "Geographic area: Australia (national) or one of the eight states and territories",
+    "description_es": "Área geográfica: Australia (nacional) o uno de los ocho estados y territorios",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "sex",
+    "bigquery_type": "STRING",
+    "description_pt": "Sexo: pessoas (total), homens ou mulheres",
+    "description_en": "Sex: persons (all), males or females",
+    "description_es": "Sexo: personas (total), hombres o mujeres",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "age_group",
+    "bigquery_type": "STRING",
+    "description_pt": "Faixa etária em anos; total abrange pessoas com 15 anos ou mais",
+    "description_en": "Age group in years; total covers persons aged 15 years and over",
+    "description_es": "Grupo de edad en años; total abarca personas de 15 años o más",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "adjustment_type",
+    "bigquery_type": "STRING",
+    "description_pt": "Ajuste da série temporal: original, ajustada sazonalmente ou tendência",
+    "description_en": "Time series adjustment: original, seasonally adjusted or trend",
+    "description_es": "Ajuste de la serie temporal: original, ajustada estacionalmente o tendencia",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false
+  },
+  {
+    "name": "underemployed_total",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Número de pessoas subocupadas",
+    "description_en": "Number of underemployed persons",
+    "description_es": "Número de personas subempleadas",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "person"
+  },
+  {
+    "name": "underemployment_ratio",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Pessoas subocupadas como porcentagem das pessoas ocupadas",
+    "description_en": "Underemployed persons as a percentage of employed persons",
+    "description_es": "Personas subempleadas como porcentaje de las personas ocupadas",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  },
+  {
+    "name": "underemployment_rate",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Pessoas subocupadas como porcentagem da força de trabalho",
+    "description_en": "Underemployed persons as a percentage of the labour force",
+    "description_es": "Personas subempleadas como porcentaje de la fuerza laboral",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  },
+  {
+    "name": "underutilisation_rate",
+    "bigquery_type": "FLOAT64",
+    "description_pt": "Soma da taxa de desemprego e da taxa de subocupação",
+    "description_en": "Sum of the unemployment rate and the underemployment rate",
+    "description_es": "Suma de la tasa de desempleo y la tasa de subempleo",
+    "covered_by_dictionary": false,
+    "has_sensitive_data": false,
+    "measurement_unit": "percent"
+  }
+]

--- a/models/au_abs_labour_force/code/upload.py
+++ b/models/au_abs_labour_force/code/upload.py
@@ -1,0 +1,104 @@
+"""Upload cleaned au_abs_labour_force parquet tables to BigQuery.
+
+Usage:
+    uv run python models/au_abs_labour_force/code/upload.py [--env dev|prod] [table ...]
+
+--env dev (default) -> basedosdados-dev; --env prod -> basedosdados. Point
+GOOGLE_APPLICATION_CREDENTIALS at the matching service account (this machine's
+config.toml is dev-only). Uploads sequentially (smallest first) and stops on the
+first failure.
+"""
+
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+import basedosdados as bd  # noqa: E402
+import google.cloud.storage as gcs  # noqa: E402
+from google.cloud import bigquery  # noqa: E402
+
+_argv = sys.argv[1:]
+if "--env" in _argv:
+    _i = _argv.index("--env")
+    ENV = _argv[_i + 1]
+    _argv = _argv[:_i] + _argv[_i + 2 :]
+else:
+    ENV = "dev"
+BILLING_PROJECT = "basedosdados" if ENV == "prod" else "basedosdados-dev"
+DATASET_ID = "au_abs_labour_force"
+OUTPUT_ROOT = Path(__file__).resolve().parent.parent / "output"
+
+# Monkey-patch for the requester-pays staging bucket.
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+# (table_slug, expected_rows) — smallest first.
+TABLES = [
+    ("hours_worked", 19_170),
+    ("status_in_employment", 68_754),
+    ("labour_force_status", 83_664),
+    ("underutilisation", 85_407),
+]
+
+
+def upload_table(slug: str, expected_rows: int) -> int:
+    path = OUTPUT_ROOT / slug
+    if not path.exists():
+        raise FileNotFoundError(f"Missing output path: {path}")
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=slug)
+
+    # Delete stale GCS staging prefix (avoids BQ partition key conflicts).
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=slug)
+    try:
+        st.delete_table(mode="staging", not_found_ok=True)
+    except Exception as e:
+        print(f"  [warn] staging prefix cleanup: {e}")
+
+    tb.create(
+        path=str(path),
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    client = bigquery.Client(project=BILLING_PROJECT)
+    q = f"select count(*) as n from `{BILLING_PROJECT}.{DATASET_ID}_staging.{slug}`"
+    n = next(iter(client.query(q).result())).n
+
+    status = "OK" if n == expected_rows else "ROW MISMATCH"
+    print(
+        f"  {slug}: uploaded {n:,} rows (expected {expected_rows:,}) — {status}"
+    )
+    if n != expected_rows:
+        raise ValueError(
+            f"{slug}: row count {n:,} != expected {expected_rows:,}"
+        )
+    return n
+
+
+def main():
+    only = set(_argv)
+    tables = [(s, r) for s, r in TABLES if not only or s in only]
+    print(f"=== uploading to {BILLING_PROJECT} (env={ENV}) ===", flush=True)
+    for slug, expected in tables:
+        print(f"=== {slug} ===", flush=True)
+        try:
+            upload_table(slug, expected)
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+            sys.exit(1)
+    print("ALL TABLES UPLOADED")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_abs_labour_force/schema.yml
+++ b/models/au_abs_labour_force/schema.yml
@@ -1,0 +1,258 @@
+---
+version: 2
+models:
+  - name: au_abs_labour_force__labour_force_status
+    description: >-
+      Monthly labour force status for Australia and the states and territories by
+      sex, age group and time series adjustment, covering employment, unemployment,
+      the labour force, participation and unemployment rates and related measures.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - geography
+            - sex
+            - age_group
+            - adjustment_type
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: >-
+          Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: >-
+          Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: geography
+        description: >-
+          Geographic area: Australia (national) or one of the eight states and territories
+        tests: [not_null]
+      - name: sex
+        description: >-
+          Sex: persons (all), males or females
+        tests: [not_null]
+      - name: age_group
+        description: >-
+          Age group in years; total covers persons aged 15 years and over
+        tests: [not_null]
+      - name: adjustment_type
+        description: >-
+          Time series adjustment: original, seasonally adjusted or trend
+        tests: [not_null]
+      - name: employed_total
+        description: >-
+          Number of employed persons
+      - name: employed_full_time
+        description: >-
+          Number of persons employed full-time
+      - name: employed_part_time
+        description: >-
+          Number of persons employed part-time
+      - name: unemployed_total
+        description: >-
+          Number of unemployed persons
+      - name: unemployed_looked_for_full_time
+        description: >-
+          Number of unemployed persons who looked for full-time work
+      - name: unemployed_looked_for_part_time
+        description: >-
+          Number of unemployed persons who looked for only part-time work
+      - name: labour_force_total
+        description: >-
+          Total labour force, employed plus unemployed
+      - name: not_in_labour_force
+        description: >-
+          Number of persons not in the labour force
+      - name: civilian_population_15_over
+        description: >-
+          Civilian population aged 15 years and over
+      - name: unemployment_rate
+        description: >-
+          Unemployed persons as a percentage of the labour force
+      - name: unemployment_rate_looked_for_full_time
+        description: >-
+          Unemployment rate among those who looked for full-time work
+      - name: unemployment_rate_looked_for_part_time
+        description: >-
+          Unemployment rate among those who looked for only part-time work
+      - name: participation_rate
+        description: >-
+          Labour force as a percentage of the civilian population aged 15 years and
+          over
+      - name: employment_to_population_ratio
+        description: >-
+          Employed persons as a percentage of the civilian population aged 15 years
+          and over
+  - name: au_abs_labour_force__hours_worked
+    description: >-
+      Monthly distribution of employed persons in Australia by hours actually worked
+      in all jobs and sex, with total hours worked and average hours per employed
+      person.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [year, month, geography, sex, hours_band]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: >-
+          Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: >-
+          Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: geography
+        description: >-
+          Geographic area: Australia (national) or one of the eight states and territories
+        tests: [not_null]
+      - name: sex
+        description: >-
+          Sex: persons (all), males or females
+        tests: [not_null]
+      - name: hours_band
+        description: >-
+          Range of hours actually worked in all jobs during the reference week
+        tests: [not_null]
+      - name: employed_persons
+        description: >-
+          Number of employed persons in the hours-worked band
+      - name: hours_worked
+        description: >-
+          Total hours actually worked in all jobs
+      - name: hours_per_person
+        description: >-
+          Average hours actually worked per employed person
+  - name: au_abs_labour_force__status_in_employment
+    description: >-
+      Monthly employed persons by status in employment of the main job, sex and full-time
+      or part-time, for Australia and the states and territories.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - geography
+            - sex
+            - status_in_employment
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: >-
+          Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: >-
+          Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: geography
+        description: >-
+          Geographic area: Australia (national) or one of the eight states and territories
+        tests: [not_null]
+      - name: sex
+        description: >-
+          Sex: persons (all), males or females
+        tests: [not_null]
+      - name: status_in_employment
+        description: >-
+          Status in employment of the main job, such as employee, owner manager or
+          contributing family worker
+        tests: [not_null]
+      - name: employed_total
+        description: >-
+          Number of employed persons with this status in employment
+      - name: employed_full_time
+        description: >-
+          Number employed full-time with this status in employment
+      - name: employed_part_time
+        description: >-
+          Number employed part-time with this status in employment
+  - name: au_abs_labour_force__underutilisation
+    description: >-
+      Monthly labour underutilisation for Australia and the states and territories
+      by sex, age group and time series adjustment, covering underemployment and the
+      underutilisation rate.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - year
+            - month
+            - geography
+            - sex
+            - age_group
+            - adjustment_type
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: >-
+          Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: month
+        description: >-
+          Reference month of the observation, from 1 to 12
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
+      - name: geography
+        description: >-
+          Geographic area: Australia (national) or one of the eight states and territories
+        tests: [not_null]
+      - name: sex
+        description: >-
+          Sex: persons (all), males or females
+        tests: [not_null]
+      - name: age_group
+        description: >-
+          Age group in years; total covers persons aged 15 years and over
+        tests: [not_null]
+      - name: adjustment_type
+        description: >-
+          Time series adjustment: original, seasonally adjusted or trend
+        tests: [not_null]
+      - name: underemployed_total
+        description: >-
+          Number of underemployed persons
+      - name: underemployment_ratio
+        description: >-
+          Underemployed persons as a percentage of employed persons
+      - name: underemployment_rate
+        description: >-
+          Underemployed persons as a percentage of the labour force
+      - name: underutilisation_rate
+        description: >-
+          Sum of the unemployment rate and the underemployment rate

--- a/pipelines/datasets/au_abs_labour_force/constants.py
+++ b/pipelines/datasets/au_abs_labour_force/constants.py
@@ -1,0 +1,71 @@
+"""Constants for the au_abs_labour_force pipeline (Prefect 3).
+
+Labour Force, Australia (ABS cat. 6202.0), monthly. Two source mechanisms:
+
+- the ABS Data API (SDMX-CSV) for the status and underutilisation cubes — one
+  ``all`` query returns the full monthly history, so the pipeline query is
+  month-agnostic;
+- the ABS time-series Excel spreadsheets for the hours-worked distribution and
+  status-in-employment, which the curated API does not serve; these live under a
+  month-stamped release path.
+
+See models/au_abs_labour_force/ONBOARDING_PLAN.md for the full design.
+"""
+
+from enum import Enum
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class constants(Enum):
+    """Constants for the au_abs_labour_force pipeline.
+
+    Lowercase class name follows the repo-wide convention for dataset constant
+    enums. ``ARCHITECTURE_DIR`` points at the architecture CSVs under
+    ``models/au_abs_labour_force/code/`` — the schema source of truth for both
+    this pipeline and the one-shot bootstrap.
+    """
+
+    DATASET_ID = "au_abs_labour_force"
+
+    # ── ABS Data API (SDMX-CSV) ──────────────────────────────────────────────
+    API_BASE = "https://data.api.abs.gov.au/rest/data"
+    # SDMX-CSV with both code and label in each cell (e.g. "M1: Employed - full-time").
+    SDMX_ACCEPT = "application/vnd.sdmx.data+csv;labels=both"
+    USER_AGENT = (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120 Safari/537.36 rdahis@basedosdados.org"
+    )
+    # SDMX dataflows used. LF = status by state (age total); LF_AGES = national by
+    # age (adds Not-in-labour-force + Civilian population); LF_UNDER = under-
+    # utilisation by state and age.
+    SDMX_FLOWS = ["LF", "LF_AGES", "LF_UNDER"]
+
+    # ── ABS time-series Excel spreadsheets ───────────────────────────────────
+    # Month-stamped release path, e.g. .../labour-force-australia/jun-2026/62020018.xlsx
+    EXCEL_BASE = (
+        "https://www.abs.gov.au/statistics/labour/employment-and-unemployment/"
+        "labour-force-australia/{month}"
+    )
+    # slug -> filename. Table 18 = hours-worked distribution (national, by sex);
+    # Table 19 = status in employment (national); SEM1 = status in employment by
+    # state (pivot).
+    EXCEL_FILES = {
+        "hours_worked": "62020018.xlsx",
+        "status_national": "62020019.xlsx",
+        "status_states": "SEM1.xlsx",
+    }
+
+    # Data tables (partitioned parquet). No dicionario — all categories are
+    # decoded to readable English labels.
+    DATA_TABLES = [
+        "labour_force_status",
+        "hours_worked",
+        "status_in_employment",
+        "underutilisation",
+    ]
+
+    ARCHITECTURE_DIR = (
+        _REPO_ROOT / "models" / "au_abs_labour_force" / "code" / "architecture"
+    )

--- a/pipelines/datasets/au_abs_labour_force/flows.py
+++ b/pipelines/datasets/au_abs_labour_force/flows.py
@@ -1,0 +1,192 @@
+"""Flows for au_abs_labour_force — Prefect 3.
+
+Labour Force, Australia (ABS cat. 6202.0), monthly. Both sources ship the full
+history every release — the SDMX ``all`` query returns every period, and each ABS
+Excel spreadsheet carries the whole series — so every run is a **full replace**
+(``dump_mode="overwrite"``), not an incremental append. A single flow downloads
+once and rebuilds all four tables. The source poll short-circuits the run until
+the ABS publishes a newer reference month, so a scheduled run is a cheap no-op
+between releases.
+
+Every table refreshes monthly, so each carries the BD Pro rolling window
+(``PartBdpro``): the most recent six months are pro-only, older data is free, and
+the window rolls forward on its own each run.
+
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``au_abs_labour_force_flow``;
+the dev pool ignores the schedule, the prod pool activates it (paused until armed).
+"""
+
+import shutil
+import tempfile
+
+from prefect import flow
+
+from pipelines.datasets.au_abs_labour_force.constants import constants
+from pipelines.datasets.au_abs_labour_force.tasks import (
+    clean_and_write_task,
+    download_excel_task,
+    download_sdmx_task,
+    latest_month_task,
+)
+from pipelines.utils.metadata.domain import (
+    DateFormat,
+    FreeLag,
+    PartBdpro,
+    YearMonth,
+)
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+TABLES = constants.DATA_TABLES.value
+
+# Every table is monthly, so every table gets the BD Pro rolling window: the most
+# recent 6 months are pro-only, everything older is free. Each run recomputes
+# free_end = source_end - 6 months, rewrites both DateTimeRanges, and re-issues the
+# BigQuery Row Access Policies, so the window slides forward on its own.
+#
+# part_bdpro requires BOTH a free (is_closed=False) and a pro (is_closed=True)
+# Coverage to already exist on the table, or assert_coverage_topology raises before
+# anything is written. Onboarding created only the free Coverage, so the pro
+# Coverage must be created by hand before the first armed (update_metadata) run.
+_COVERAGE = {
+    table: PartBdpro(
+        date_column=YearMonth(year="year", month="month"),
+        date_format=DateFormat.YEAR_MONTH,
+        free_lag=FreeLag(unit="months", value=6),
+    )
+    for table in TABLES
+}
+
+# Each table is linked to exactly one raw source (the poll/commit client raises on
+# a multi-source table). labour_force_status -> the SDMX API source, which drives
+# the poll; hours_worked -> the Excel source. Committing the source update for one
+# representative table per source writes both RawDataSource.Update records. Both
+# sources release the same reference month together, so one poll gate suffices.
+_POLL_TABLE = "labour_force_status"
+_SOURCE_COMMIT_TABLES = ["labour_force_status", "hours_worked"]
+
+
+@flow(name="au_abs_labour_force", log_prints=True)
+def au_abs_labour_force_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+) -> None:
+    """Download the ABS labour-force sources, rebuild all four tables, materialize.
+
+    Both sources ship the full history on every release, so each run is a full
+    replace (``dump_mode="overwrite"``). The source poll no-ops the run when the
+    ABS has not published a newer month, making a scheduled run cheap between
+    releases.
+
+    Args:
+        materialize_to_prod: Continue past the dev materialization to write the
+            prod staging bucket and run dbt against ``target="prod"``. Set False
+            to exercise only the dev half — required for a safe test run, since the
+            default writes production.
+        update_metadata: After a successful prod materialization, register table
+            coverage (the rolling window) and commit the source update. Has no
+            effect when ``materialize_to_prod`` is False.
+        force_run: Materialize even when the source poll reports no new month.
+    """
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id=_POLL_TABLE
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="au_abs_labour_force_")
+    try:
+        # SDMX first (small, and it carries the latest reference month).
+        input_dir = download_sdmx_task(work_dir=work_dir)
+        max_ym = latest_month_task(input_dir=input_dir)
+
+        # Skip when the ABS has not published a newer month (unless forced).
+        has_new_data = poll_source_for_update_task(
+            dataset_id=DATASET_ID,
+            table_id=_POLL_TABLE,
+            source_max_date=max_ym,
+            env="prod",
+            date_format="%Y-%m",
+        )
+        if not has_new_data and not force_run:
+            return
+
+        # Only now fetch the heavy Excel spreadsheets and rebuild.
+        download_excel_task(input_dir=input_dir, source_max_date=max_ym)
+        result = clean_and_write_task(work_dir=work_dir, input_dir=input_dir)
+
+        # Dev: upload staging + materialize/test.
+        for table in TABLES:
+            upload_to_gcs(
+                data_path=result[table],
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados-dev",
+                dump_mode="overwrite",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="dev",
+            )
+
+        if not materialize_to_prod:
+            return
+
+        # Prod: upload staging + materialize/test.
+        for table in TABLES:
+            upload_to_gcs(
+                data_path=result[table],
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados",
+                dump_mode="overwrite",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="prod",
+            )
+
+        if update_metadata:
+            for table, coverage in _COVERAGE.items():
+                register_table_materialization_task(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    coverage=coverage,
+                    env="prod",
+                    bq_project="basedosdados",
+                )
+            for table in _SOURCE_COMMIT_TABLES:
+                commit_source_update_task(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    source_max_date=max_ym,
+                    env="prod",
+                    date_format="%Y-%m",
+                )
+    finally:
+        # Covers both early returns (no new data, dev-only) and any exception.
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# ABS releases Labour Force monthly, on a Thursday roughly the 3rd-4th week, at
+# 11:30 Canberra time. Poll daily across that window at 06:00 BRT (= evening AEST,
+# after the morning release); the source-poll guard no-ops until a new month lands.
+au_abs_labour_force_flow.deploy_schedules = [
+    {"cron": "0 6 14-27 * *", "timezone": "America/Sao_Paulo"}
+]
+# openpyxl reads the ~38 MB SEM1 pivot; give the worker headroom.
+au_abs_labour_force_flow.job_variables = {"memory": "6Gi"}

--- a/pipelines/datasets/au_abs_labour_force/flows.py
+++ b/pipelines/datasets/au_abs_labour_force/flows.py
@@ -108,16 +108,21 @@ def au_abs_labour_force_flow(
         input_dir = download_sdmx_task(work_dir=work_dir)
         max_ym = latest_month_task(input_dir=input_dir)
 
-        # Skip when the ABS has not published a newer month (unless forced).
-        has_new_data = poll_source_for_update_task(
-            dataset_id=DATASET_ID,
-            table_id=_POLL_TABLE,
-            source_max_date=max_ym,
-            env="prod",
-            date_format="%Y-%m",
-        )
-        if not has_new_data and not force_run:
-            return
+        # A scheduled run polls prod and no-ops until the ABS publishes a newer
+        # month. force_run bypasses the poll entirely (not just its early return)
+        # — the dev test sets it, and the poll is env="prod", so a dev-only test
+        # must never reach it (prod metadata may not exist yet, and a test must
+        # not write a prod Poll record).
+        if not force_run:
+            has_new_data = poll_source_for_update_task(
+                dataset_id=DATASET_ID,
+                table_id=_POLL_TABLE,
+                source_max_date=max_ym,
+                env="prod",
+                date_format="%Y-%m",
+            )
+            if not has_new_data:
+                return
 
         # Only now fetch the heavy Excel spreadsheets and rebuild.
         download_excel_task(input_dir=input_dir, source_max_date=max_ym)

--- a/pipelines/datasets/au_abs_labour_force/tasks.py
+++ b/pipelines/datasets/au_abs_labour_force/tasks.py
@@ -1,0 +1,123 @@
+"""Prefect 3 tasks for au_abs_labour_force — thin wrappers over utils.py.
+
+The download splits in two so the source poll can gate the expensive half: the
+SDMX extracts (small, and they carry the latest reference month) come first, then
+the poll decides whether to fetch the month-stamped Excel spreadsheets (SEM1 is
+~38 MB) and rebuild. On a no-op run only the SDMX pull happens.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+from prefect import task
+
+from pipelines.datasets.au_abs_labour_force.constants import constants
+from pipelines.datasets.au_abs_labour_force.utils import (
+    clean_all,
+    download_excel,
+    download_sdmx,
+    write_partitioned,
+)
+
+# Release-period helpers — pipeline-only (resolve the source-poll key + the
+# month-stamped Excel URL), so they live here rather than in the shared transform.
+_MONTHS = [
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "may",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec",
+]
+
+
+def latest_period(input_dir: Path) -> str:
+    """Latest reference month in the LF SDMX extract, as ``"YYYY-MM"``.
+
+    Zero-padded ``"YYYY-MM"`` sorts lexicographically in calendar order, so the
+    max string is the newest month. Drives both the source-update poll and the
+    month-stamped Excel URL. Read from ``LF.csv`` — the ABS API and the Excel
+    spreadsheets release the same reference month together.
+    """
+    df = pd.read_csv(input_dir / "LF.csv", dtype=str, na_filter=False)
+    tcol = next(
+        c for c in df.columns if c.split(":")[0].strip() == "TIME_PERIOD"
+    )
+    return max(v[:7] for v in df[tcol] if v)
+
+
+def month_slug(period: str) -> str:
+    """Map ``"YYYY-MM"`` to the ABS release slug, e.g. ``"2026-06" -> "jun-2026"``.
+
+    A fixed English abbreviation table (not ``strftime("%b")``) keeps the slug
+    locale-independent on the worker.
+    """
+    y, m = period.split("-")
+    return f"{_MONTHS[int(m) - 1]}-{y}"
+
+
+@task(retries=2, retry_delay_seconds=30)
+def download_sdmx_task(work_dir: str) -> str:
+    """Download the SDMX full-history extracts (LF, LF_AGES, LF_UNDER).
+
+    Retries twice: the ABS Data API occasionally times out on the full-history
+    ``all`` query.
+
+    Args:
+        work_dir: Directory to download into; files land in ``<work_dir>/input``.
+
+    Returns:
+        The input directory path, as a string (Prefect serializes task results).
+    """
+    input_dir = Path(work_dir) / "input"
+    for flow in constants.SDMX_FLOWS.value:
+        download_sdmx(flow, input_dir)
+    return str(input_dir)
+
+
+@task
+def latest_month_task(input_dir: str) -> str:
+    """Latest reference month in the LF extract, as ``"YYYY-MM"`` — the poll key."""
+    return latest_period(Path(input_dir))
+
+
+@task(retries=2, retry_delay_seconds=30)
+def download_excel_task(input_dir: str, source_max_date: str) -> str:
+    """Download the release-month Excel spreadsheets (Table 18/19, SEM1).
+
+    Args:
+        input_dir: Directory holding the SDMX extracts, from
+            :func:`download_sdmx_task`; the Excel files land beside them.
+        source_max_date: Latest reference month ``"YYYY-MM"``; maps to the ABS
+            month-stamped release path (e.g. ``jun-2026``).
+
+    Returns:
+        The input directory path.
+    """
+    download_excel(month_slug(source_max_date), Path(input_dir))
+    return input_dir
+
+
+@task
+def clean_and_write_task(work_dir: str, input_dir: str) -> dict:
+    """Build the four tables and write each as all-STRING partitioned parquet.
+
+    Args:
+        work_dir: Directory to write into; tables land under ``<work_dir>/output``.
+        input_dir: Directory holding the downloaded SDMX + Excel sources.
+
+    Returns:
+        A mapping of table slug to its partitioned output directory (as a string).
+    """
+    output_dir = Path(work_dir) / "output"
+    tables = clean_all(Path(input_dir))
+    return {
+        table: str(write_partitioned(df, table, output_dir))
+        for table, df in tables.items()
+    }

--- a/pipelines/datasets/au_abs_labour_force/utils.py
+++ b/pipelines/datasets/au_abs_labour_force/utils.py
@@ -1,0 +1,626 @@
+"""Download + cleaning transform for au_abs_labour_force (shared by the pipeline
+and the one-shot bootstrap in models/au_abs_labour_force/code/).
+
+Pure functions (no Prefect) so they are importable and unit-testable. Schema and
+column order come from the architecture CSVs (the single source of truth).
+
+Sources
+-------
+- SDMX-CSV (ABS Data API), ``labels=both`` so each cell is ``"code: label"``:
+    * ``labour_force_status`` <- ``LF`` (states, age total) + ``LF_AGES``
+      (national, all ages, adds Not-in-labour-force + Civilian population).
+    * ``underutilisation``    <- ``LF_UNDER`` (state and age).
+- ABS time-series Excel spreadsheets (curated API does not serve these):
+    * ``hours_worked``          <- Table 18 (national, by sex).
+    * ``status_in_employment``  <- Table 19 (national) + SEM1 (states pivot).
+
+ABS reports counts in thousands and hours in thousands of hours; every value is
+scaled by ``10 ** UNIT_MULT`` (SDMX) or by the Index unit (Excel) to absolute
+persons / hours, so the ``person`` / ``hour`` measurement units are truthful.
+Rates are left untouched. National totals come from the national sources; states
+from the state sources — ABS benchmarks national separately, so national is never
+derived by summing states.
+"""
+
+import csv
+import logging
+from pathlib import Path
+
+import openpyxl
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+
+from pipelines.datasets.au_abs_labour_force.constants import constants
+
+log = logging.getLogger("au_abs_labour_force")
+
+PA = {"STRING": pa.string(), "INT64": pa.int64(), "FLOAT64": pa.float64()}
+_ARCH = constants.ARCHITECTURE_DIR.value
+
+# ── label normalisation ──────────────────────────────────────────────────────
+SEX = {"males": "males", "females": "females", "persons": "persons"}
+TSEST = {
+    "original": "original",
+    "seasonally adjusted": "seasonally_adjusted",
+    "trend": "trend",
+}
+
+# SDMX MEASURE / PARM_ITEM code -> architecture column.
+LFS_MEASURE = {
+    "M3": "employed_total",
+    "M1": "employed_full_time",
+    "M2": "employed_part_time",
+    "M6": "unemployed_total",
+    "M4": "unemployed_looked_for_full_time",
+    "M5": "unemployed_looked_for_part_time",
+    "M9": "labour_force_total",
+    "M10": "not_in_labour_force",
+    "M11": "civilian_population_15_over",
+    "M13": "unemployment_rate",
+    "M14": "unemployment_rate_looked_for_full_time",
+    "M15": "unemployment_rate_looked_for_part_time",
+    "M12": "participation_rate",
+    "M16": "employment_to_population_ratio",
+}
+UNDER_MEASURE = {
+    "M21": "underemployed_total",
+    "M22": "underemployment_ratio",
+    "M23": "underemployment_rate",
+    "M24": "underutilisation_rate",
+}
+
+# Status in employment (Excel labels) -> normalised label.
+STATUS = {
+    "employee": "employee",
+    "owner manager of incorporated enterprise with employees": "owner manager of incorporated enterprise with employees",
+    "owner manager of incorporated enterprise without employees": "owner manager of incorporated enterprise without employees",
+    "owner manager of unincorporated enterprise with employees": "owner manager of unincorporated enterprise with employees",
+    "owner manager of unincorporated enterprise without employees": "owner manager of unincorporated enterprise without employees",
+    "contributing family worker": "contributing family worker",
+    "contributing family worker or payment in kind": "contributing family worker",
+}
+
+
+def _norm_age(label: str) -> str:
+    """Normalise an ABS age label, e.g. '15 - 24 years' -> '15-24 years'."""
+    label = label.strip()
+    if label.lower().startswith("total"):
+        return "total"
+    return label.replace(" - ", "-")
+
+
+def _norm_hours_band(label: str) -> str:
+    """Strip the ABS '>' / '>>' hierarchy markers from an hours-band label."""
+    return label.lstrip("> ").strip()
+
+
+def _year_month(period: str) -> tuple[int, int]:
+    """Split an SDMX 'YYYY-MM' (or a pandas Timestamp) into (year, month)."""
+    s = str(period)[:7]
+    y, m = s.split("-")
+    return int(y), int(m)
+
+
+# ── schema ───────────────────────────────────────────────────────────────────
+def read_arch(table: str) -> list[dict]:
+    """Read a table's architecture CSV — the schema source of truth."""
+    with open(_ARCH / f"{table}.csv", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+# ── SDMX download + parse ─────────────────────────────────────────────────────
+def download_sdmx(flow: str, dest: Path) -> Path:
+    """Download a full-history SDMX-CSV extract for one dataflow.
+
+    ``/all`` returns every series and period, so the query is month-agnostic and
+    the pipeline re-pulls the complete history each run (dump_mode overwrite).
+
+    Args:
+        flow: Dataflow id (``LF``, ``LF_AGES``, ``LF_UNDER``).
+        dest: Directory to write ``<flow>.csv`` into; created if absent.
+
+    Returns:
+        Path to the written CSV.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    url = f"{constants.API_BASE.value}/{flow}/all"
+    r = requests.get(
+        url,
+        headers={
+            "User-Agent": constants.USER_AGENT.value,
+            "Accept": constants.SDMX_ACCEPT.value,
+        },
+        timeout=600,
+    )
+    r.raise_for_status()
+    out = dest / f"{flow}.csv"
+    out.write_bytes(r.content)
+    log.info(f"{flow}: {len(r.content):,} bytes -> {out}")
+    return out
+
+
+def _split_code(series: pd.Series) -> pd.Series:
+    """From a 'code: label' SDMX-CSV cell, return the code (before ': ')."""
+    return series.str.split(": ", n=1).str[0].str.strip()
+
+
+def _split_label(series: pd.Series) -> pd.Series:
+    """From a 'code: label' SDMX-CSV cell, return the label (after ': ')."""
+    return series.str.split(": ", n=1).str[1].str.strip()
+
+
+def load_sdmx(path: Path) -> pd.DataFrame:
+    """Read one SDMX-CSV extract into a tidy long frame.
+
+    Splits every ``code: label`` cell, scales OBS_VALUE by ``10 ** UNIT_MULT`` so
+    counts become absolute persons and rates are untouched, and normalises the
+    dimension labels.
+
+    Returns:
+        Columns: measure_code, sex, age_group, adjustment_type, region,
+        year, month, value.
+    """
+    df = pd.read_csv(path, dtype=str, na_filter=False)
+    # the measure dimension is MEASURE for LF/LF_AGES, PARM_ITEM for LF_UNDER.
+    mcol = next(
+        c for c in df.columns if c.split(":")[0] in ("MEASURE", "PARM_ITEM")
+    )
+
+    def col(prefix):
+        return next(c for c in df.columns if c.split(":")[0] == prefix)
+
+    out = pd.DataFrame(
+        {
+            "measure_code": _split_code(df[mcol]),
+            "sex": _split_label(df[col("SEX")]).str.lower().map(SEX),
+            "age_group": _split_label(df[col("AGE")]).map(_norm_age),
+            "adjustment_type": _split_label(df[col("TSEST")])
+            .str.lower()
+            .map(TSEST),
+            "region": _split_label(df[col("REGION")]),
+        }
+    )
+    ym = df[col("TIME_PERIOD")].map(_year_month)
+    out["year"] = ym.str[0]
+    out["month"] = ym.str[1]
+    mult = _split_code(df[col("UNIT_MULT")]).astype(int)
+    out["value"] = pd.to_numeric(df["OBS_VALUE"], errors="coerce") * (
+        10.0**mult
+    )
+    return out
+
+
+def _pivot_measures(
+    long: pd.DataFrame,
+    measure_map: dict,
+    keys: list[str],
+    arch_cols: list[str],
+) -> pd.DataFrame:
+    """Pivot a long SDMX frame (measure_code -> value) to wide measure columns."""
+    long = long[long["measure_code"].isin(measure_map)].copy()
+    long["measure"] = long["measure_code"].map(measure_map)
+    wide = long.pivot_table(
+        index=keys, columns="measure", values="value", aggfunc="first"
+    ).reset_index()
+    wide.columns.name = None
+    for c in arch_cols:
+        if c not in wide.columns:
+            wide[c] = pd.NA
+    return wide[arch_cols]
+
+
+def clean_labour_force_status(input_dir: Path) -> pd.DataFrame:
+    """Build labour_force_status from LF + LF_AGES.
+
+    LF carries the headline series for all nine regions at age total, in all
+    three adjustments (Original/Seasonally Adjusted/Trend), but only 12 measures.
+    LF_AGES adds the national age breakdown and the two measures LF omits
+    (Not-in-labour-force, Civilian population) — but its total-age series is
+    Original only. So both are needed: national SA/Trend at total age comes from
+    LF, the age breakdown and M10/M11 from LF_AGES. The pivot merges the rows
+    that overlap at (Australia, total age, Original), filling each measure once.
+    """
+    arch_cols = [a["name"] for a in read_arch("labour_force_status")]
+    keys = [
+        "year",
+        "month",
+        "geography",
+        "sex",
+        "age_group",
+        "adjustment_type",
+    ]
+
+    lf = load_sdmx(input_dir / "LF.csv")  # all regions, age total, 3 adj
+    lf["geography"] = lf["region"]
+
+    national = load_sdmx(
+        input_dir / "LF_AGES.csv"
+    )  # national, all ages, +M10/M11
+    national = national[national["region"] == "Australia"].copy()
+    national["geography"] = "Australia"
+
+    long = pd.concat([lf, national], ignore_index=True)
+    return _pivot_measures(long, LFS_MEASURE, keys, arch_cols)
+
+
+def clean_underutilisation(input_dir: Path) -> pd.DataFrame:
+    """Build underutilisation from LF_UNDER (state and age, Orig/SA/Trend)."""
+    arch_cols = [a["name"] for a in read_arch("underutilisation")]
+    keys = [
+        "year",
+        "month",
+        "geography",
+        "sex",
+        "age_group",
+        "adjustment_type",
+    ]
+    long = load_sdmx(input_dir / "LF_UNDER.csv")
+    long["geography"] = long["region"]
+    return _pivot_measures(long, UNDER_MEASURE, keys, arch_cols)
+
+
+# ── Excel time-series download + parse ────────────────────────────────────────
+def download_excel(month: str, dest: Path) -> dict[str, Path]:
+    """Download the Table 18 / Table 19 / SEM1 spreadsheets for a release month.
+
+    Args:
+        month: Release month slug, e.g. ``"jun-2026"``.
+        dest: Directory to write into; created if absent.
+
+    Returns:
+        Mapping slug -> written path.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    base = constants.EXCEL_BASE.value.format(month=month)
+    headers = {"User-Agent": constants.USER_AGENT.value}
+    out = {}
+    for slug, fname in constants.EXCEL_FILES.value.items():
+        r = requests.get(f"{base}/{fname}", headers=headers, timeout=600)
+        r.raise_for_status()
+        p = dest / fname
+        p.write_bytes(r.content)
+        out[slug] = p
+        log.info(f"{slug}: {len(r.content):,} bytes -> {p}")
+    return out
+
+
+def _index_meta(path: Path) -> pd.DataFrame:
+    """Read an ABS time-series 'Index' sheet -> one row per series.
+
+    Returns:
+        Columns: series_id, description, unit, series_type.
+    """
+    wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    ws = wb["Index"]
+    rows = list(ws.iter_rows(values_only=True))
+    hdr = next(
+        i
+        for i, r in enumerate(rows)
+        if r
+        and any(isinstance(c, str) and c.strip() == "Series ID" for c in r)
+    )
+    header = [str(c).strip() if c is not None else "" for c in rows[hdr]]
+    di = header.index("Data Item Description")
+    si = header.index("Series ID")
+    ui = header.index("Unit")
+    ti = header.index("Series Type")
+    recs = []
+    for r in rows[hdr + 1 :]:
+        if not r or si >= len(r) or r[si] is None:
+            continue
+        sid = str(r[si]).strip()
+        if not sid or sid.startswith("©"):
+            continue
+        recs.append(
+            {
+                "series_id": sid,
+                "description": str(r[di]).strip()
+                if di < len(r) and r[di] is not None
+                else "",
+                "unit": str(r[ui]).strip()
+                if ui < len(r) and r[ui] is not None
+                else "",
+                "series_type": str(r[ti]).strip()
+                if ti < len(r) and r[ti] is not None
+                else "",
+            }
+        )
+    wb.close()
+    return pd.DataFrame(recs)
+
+
+def _timeseries_long(path: Path) -> pd.DataFrame:
+    """Read all 'Data*' sheets of an ABS time-series spreadsheet -> long frame.
+
+    Returns:
+        Columns: series_id, year, month, value (value raw, unscaled).
+    """
+    wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    frames = []
+    for sheet in [s for s in wb.sheetnames if s.startswith("Data")]:
+        ws = wb[sheet]
+        rows = list(ws.iter_rows(values_only=True))
+        hdr = next(
+            i
+            for i, r in enumerate(rows)
+            if r and isinstance(r[0], str) and r[0].strip() == "Series ID"
+        )
+        ids = [str(c).strip() if c is not None else "" for c in rows[hdr]]
+        for r in rows[hdr + 1 :]:
+            if not r or r[0] is None:
+                continue
+            y, m = _year_month(pd.Timestamp(r[0]).strftime("%Y-%m"))
+            for j in range(1, len(ids)):
+                sid = ids[j]
+                if not sid or j >= len(r) or r[j] is None:
+                    continue
+                frames.append((sid, y, m, r[j]))
+    wb.close()
+    df = pd.DataFrame(frames, columns=["series_id", "year", "month", "value"])
+    df["value"] = pd.to_numeric(df["value"], errors="coerce")
+    return df
+
+
+def _apply_unit(df: pd.DataFrame) -> pd.DataFrame:
+    """Scale values to absolute units from the Index 'unit': thousands -> x1000."""
+    mult = (
+        df["unit"]
+        .str.strip()
+        .str.lower()
+        .map(lambda u: 1000.0 if u in ("000", "000 hours") else 1.0)
+    )
+    df = df.copy()
+    df["value"] = df["value"] * mult
+    return df
+
+
+def clean_hours_worked(input_dir: Path) -> pd.DataFrame:
+    """Build hours_worked from Table 18 (national, by sex and hours band)."""
+    path = input_dir / constants.EXCEL_FILES.value["hours_worked"]
+    arch_cols = [a["name"] for a in read_arch("hours_worked")]
+    meta = _index_meta(path)
+    data = _timeseries_long(path).merge(meta, on="series_id", how="left")
+    data = _apply_unit(data)
+
+    top = {
+        "employed total": "employed_persons",
+        "number of hours actually worked in all jobs": "hours_worked",
+        "hours actually worked in all jobs per employed person": "hours_per_person",
+    }
+    recs = []
+    for _, r in data.iterrows():
+        segs = [s.strip() for s in r["description"].split(";") if s.strip()]
+        if len(segs) < 2:
+            continue
+        if segs[0].lower() in top:  # band-less grand total
+            band, measure, sex = "total", segs[0], segs[1]
+        else:  # <band> ; <measure> ; <sex>
+            if len(segs) < 3:
+                continue
+            band, measure, sex = segs[0], segs[1], segs[2]
+        mcol = top.get(measure.lower())
+        if mcol is None:
+            continue
+        recs.append(
+            {
+                "year": r["year"],
+                "month": r["month"],
+                "geography": "Australia",
+                "sex": SEX.get(_norm_hours_band(sex).lower()),
+                "hours_band": _norm_hours_band(band).lower()
+                if band == "total"
+                else _norm_hours_band(band),
+                "measure": mcol,
+                "value": r["value"],
+            }
+        )
+    long = pd.DataFrame(recs)
+    keys = ["year", "month", "geography", "sex", "hours_band"]
+    wide = long.pivot_table(
+        index=keys, columns="measure", values="value", aggfunc="first"
+    ).reset_index()
+    wide.columns.name = None
+    for c in arch_cols:
+        if c not in wide.columns:
+            wide[c] = pd.NA
+    return wide[arch_cols]
+
+
+def clean_status_in_employment(input_dir: Path) -> pd.DataFrame:
+    """Build status_in_employment from Table 19 (national) + SEM1 (states).
+
+    National (persons, males, females) comes from Table 19; the eight states
+    (males, females) come from SEM1 aggregated over hours bands, with persons
+    derived as males + females within each state.
+    """
+    arch_cols = [a["name"] for a in read_arch("status_in_employment")]
+    keys = ["year", "month", "geography", "sex", "status_in_employment"]
+
+    # National — Table 19 time-series spreadsheet.
+    path19 = input_dir / constants.EXCEL_FILES.value["status_national"]
+    meta = _index_meta(path19)
+    d19 = _apply_unit(
+        _timeseries_long(path19).merge(meta, on="series_id", how="left")
+    )
+    emp_type = {
+        "employed total": "employed_total",
+        "employed full-time": "employed_full_time",
+        "employed part-time": "employed_part_time",
+    }
+    recs = []
+    for _, r in d19.iterrows():
+        segs = [s.strip() for s in r["description"].split(";") if s.strip()]
+        if len(segs) < 3:
+            continue
+        status = STATUS.get(segs[0].lower())
+        etype = emp_type.get(_norm_hours_band(segs[1]).lower())
+        sex = SEX.get(_norm_hours_band(segs[2]).lower())
+        if status is None or etype is None or sex is None:
+            continue
+        recs.append(
+            {
+                "year": r["year"],
+                "month": r["month"],
+                "geography": "Australia",
+                "sex": sex,
+                "status_in_employment": status,
+                "measure": etype,
+                "value": r["value"],
+            }
+        )
+    national = pd.DataFrame(recs)
+
+    # States — SEM1 pivot (Data 1 sheet), aggregate over hours bands.
+    sem = _read_sem1(input_dir / constants.EXCEL_FILES.value["status_states"])
+    states = []
+    for (y, m, geo, status), g in sem.groupby(
+        ["year", "month", "geography", "status_in_employment"]
+    ):
+        ft = {
+            sx: sub["employed_full_time"].sum() for sx, sub in g.groupby("sex")
+        }
+        pt = {
+            sx: sub["employed_part_time"].sum() for sx, sub in g.groupby("sex")
+        }
+        for sx in ("males", "females"):
+            states.append(
+                {
+                    "year": y,
+                    "month": m,
+                    "geography": geo,
+                    "sex": sx,
+                    "status_in_employment": status,
+                    "employed_full_time": ft.get(sx, 0.0),
+                    "employed_part_time": pt.get(sx, 0.0),
+                }
+            )
+        states.append(
+            {
+                "year": y,
+                "month": m,
+                "geography": geo,
+                "sex": "persons",
+                "status_in_employment": status,
+                "employed_full_time": sum(ft.values()),
+                "employed_part_time": sum(pt.values()),
+            }
+        )
+    st = pd.DataFrame(states)
+    st["employed_total"] = st["employed_full_time"] + st["employed_part_time"]
+
+    nat_wide = national.pivot_table(
+        index=keys, columns="measure", values="value", aggfunc="first"
+    ).reset_index()
+    nat_wide.columns.name = None
+    out = pd.concat([nat_wide, st], ignore_index=True)
+    for c in arch_cols:
+        if c not in out.columns:
+            out[c] = pd.NA
+    return out[arch_cols]
+
+
+def _read_sem1(path: Path) -> pd.DataFrame:
+    """Read SEM1's 'Data 1' pivot sheet -> long by state/sex/status/hours band.
+
+    Returns:
+        Columns: year, month, geography, sex, status_in_employment,
+        employed_full_time, employed_part_time (absolute persons).
+    """
+    wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    ws = wb[next(s for s in wb.sheetnames if s.lower().startswith("data"))]
+    it = ws.iter_rows(values_only=True)
+    header = None
+    for r in it:
+        nn = [c for c in r if c is not None]
+        if len(nn) >= 5 and any(
+            isinstance(c, str) and str(c).strip() == "Month" for c in r
+        ):
+            header = [str(c).strip() if c is not None else "" for c in r]
+            break
+    idx = {h: i for i, h in enumerate(header)}
+    ci_month = idx["Month"]
+    ci_sex = idx["Sex"]
+    ci_state = next(
+        i for h, i in idx.items() if h.startswith("State and territory")
+    )
+    ci_status = idx["Status in employment of main job"]
+    ci_ft = next(
+        i for h, i in idx.items() if h.startswith("Employed full-time")
+    )
+    ci_pt = next(
+        i for h, i in idx.items() if h.startswith("Employed part-time")
+    )
+    recs = []
+    for r in it:
+        if not r or ci_month >= len(r) or r[ci_month] is None:
+            continue
+        y, m = _year_month(pd.Timestamp(r[ci_month]).strftime("%Y-%m"))
+        status = STATUS.get(str(r[ci_status]).strip().lower())
+        sex = SEX.get(str(r[ci_sex]).strip().lower())
+        if status is None or sex is None:
+            continue
+        ft = (
+            pd.to_numeric(r[ci_ft], errors="coerce")
+            if ci_ft < len(r)
+            else None
+        )
+        pt = (
+            pd.to_numeric(r[ci_pt], errors="coerce")
+            if ci_pt < len(r)
+            else None
+        )
+        recs.append(
+            {
+                "year": y,
+                "month": m,
+                "geography": str(r[ci_state]).strip(),
+                "sex": sex,
+                "status_in_employment": status,
+                "employed_full_time": (ft or 0.0) * 1000.0,
+                "employed_part_time": (pt or 0.0) * 1000.0,
+            }
+        )
+    wb.close()
+    return pd.DataFrame(recs)
+
+
+# ── write ─────────────────────────────────────────────────────────────────────
+def write_partitioned(df: pd.DataFrame, table: str, output_dir: Path) -> Path:
+    """Write a table as all-STRING Snappy Parquet, hive-partitioned by year.
+
+    Staging is all-STRING by Data Basis convention (dump_header stringifies the
+    header BigQuery infers the staging schema from). Values pass through the
+    architecture's real types first — so year serialises as "1978" not "1978.0"
+    — then cast to string via arrow (never astype(str), which renders NULL as
+    "nan" and defeats the dbt safe_cast). See [[project_dump_header_parquet_bug]].
+    """
+    arch = read_arch(table)
+    order = [a["name"] for a in arch]
+    typed = pa.schema(
+        [pa.field(a["name"], PA[a["bigquery_type"]]) for a in arch]
+    )
+    string_schema = pa.schema([pa.field(a["name"], pa.string()) for a in arch])
+    out = df[order].copy()
+    tdir = output_dir / table
+    total = 0
+    for year, g in out.groupby("year", sort=True):
+        pdir = tdir / f"year={int(year)}"
+        pdir.mkdir(parents=True, exist_ok=True)
+        at = pa.Table.from_pandas(g, schema=typed, preserve_index=False)
+        at = at.cast(string_schema)
+        pq.write_table(at, pdir / "data.parquet", compression="snappy")
+        total += len(g)
+    log.info(f"{table}: {total:,} rows -> {tdir}")
+    return tdir
+
+
+def clean_all(input_dir: Path) -> dict[str, pd.DataFrame]:
+    """Build all four Tier-1 tables from downloaded sources in ``input_dir``."""
+    return {
+        "labour_force_status": clean_labour_force_status(input_dir),
+        "underutilisation": clean_underutilisation(input_dir),
+        "hours_worked": clean_hours_worked(input_dir),
+        "status_in_employment": clean_status_in_employment(input_dir),
+    }


### PR DESCRIPTION
## Descrição do PR

Onboarding do dataset **`au_abs_labour_force`** — *Labour Force, Australia* (ABS, catálogo 6202.0), estatísticas mensais da força de trabalho australiana, de fevereiro de 1978 em diante. Licença CC BY 4.0.

**Motivação/Contexto:** dataset de referência para o mercado de trabalho australiano (emprego, desemprego, participação, horas, subutilização), amplamente usado em pesquisa. A publicação da ABS espalha os mesmos indicadores por ~30 planilhas; aqui eles são reorganizados por **grão** em poucas tabelas tidy.

Este PR entrega o **Tier 1** (4 tabelas). O Tier 2 (fluxos brutos, SA4 modelado, capital vs. resto do estado, país de nascimento) e a **pipeline mensal** do Prefect vêm em PRs seguintes.

## Detalhes Técnicos

**Tabelas (grão, não a planilha da ABS):**
| Tabela | Grão | Fonte |
|---|---|---|
| `labour_force_status` | mês × ajuste × geografia × sexo × idade, 14 medidas | SDMX `LF` + `LF_AGES` |
| `underutilisation` | mês × ajuste × geografia × sexo × idade | SDMX `LF_UNDER` |
| `hours_worked` | mês × geografia × sexo × faixa de horas | Excel Tabela 18 |
| `status_in_employment` | mês × geografia × sexo × posição na ocupação | Excel Tabela 19 + SEM1 |

- **Nomes de colunas em inglês** (dataset em inglês): `year`/`month`, geografia = Austrália + 8 estados/territórios.
- Metadados de coluna **trilíngues** (PT/EN/ES) via `columns_json` (`bulk_upsert_columns`).
- Contagens convertidas para **pessoas/horas absolutas** (SDMX `UNIT_MULT` / unidade do índice); taxas intactas. Nacional vem das séries nacionais da ABS, nunca somando estados.
- Transformação de limpeza colocada em `pipelines/datasets/au_abs_labour_force/` (pura, sem Prefect) para ser **reusada** pela pipeline recorrente; o bootstrap em `models/.../code/` importa dela.

**Mudanças nos dados e no schema:** novo dataset e 4 modelos dbt + `schema.yml` (safe_cast em todas as colunas, testes de unicidade e proporção de não-nulos). Sem chaves primárias no backend (convenção de tabelas não-diretório).

## Teste e Validações
- [x] Testado localmente — `dbt run` + `dbt test`: **4 modelos, 38 testes** verdes; contagens e valores conferidos contra a release de junho/2026 da ABS.
- [ ] Testado na Cloud — metadados registrados em **staging** (`under_review`); dados em `basedosdados-dev`. As tabelas de produção materializam no merge (table-approve), e a publicação (`published`) é ação pós-merge após verificação.

## Riscos e Mitigações
- Riscos conhecidos: baixo — dataset estático neste PR, sem pipeline agendada. FKs de geografia (SA4/GCCSA para `br_bd_diretorios_au`) só entram no Tier 2.
- Planos de rollback: reverter o commit; nenhum dado de produção é tocado antes do merge.

## Dependencias
- [x] Nenhuma dependencia adicional

## Revisadores
- Recomendado: basedosdados/dados

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Australian Bureau of Statistics labour-force data covering labour-force status, hours worked, employment status, and underutilisation.
  * Added monthly and geographic breakdowns for employment, unemployment, participation, hours worked, and underutilisation measures.
  * Added multilingual metadata, measurement units, directory mappings, and data-quality validations.
  * Added automated data preparation and publication workflows for reliable table updates.

* **Documentation**
  * Added onboarding documentation covering data sources, table structures, processing stages, and publication steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->