### PR TITLE
feat(au_abs_national_accounts): onboard ABS Australian System of National Accounts

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,6 +40,9 @@ models:
     af_afrobarometer_survey:
       +materialized: table
       +schema: af_afrobarometer_survey
+    au_abs_national_accounts:
+      +materialized: table
+      +schema: au_abs_national_accounts
     au_alexander_politicians:
       +materialized: table
       +schema: au_alexander_politicians

--- a/models/au_abs_national_accounts/.gitignore
+++ b/models/au_abs_national_accounts/.gitignore
@@ -1,0 +1,2 @@
+input/
+output/

--- a/models/au_abs_national_accounts/ONBOARDING_PLAN.md
+++ b/models/au_abs_national_accounts/ONBOARDING_PLAN.md
@@ -1,0 +1,78 @@
+# au_abs_national_accounts — onboarding plan & status
+
+**Dataset:** Australian System of National Accounts (ABS catalogue **5204.0**)
+**Source:** https://www.abs.gov.au/statistics/economy/national-accounts/australian-system-national-accounts/latest-release
+**Org:** `au_abs` · **Licence:** CC BY 4.0 · **GCP dataset id / slug:** `au_abs_national_accounts`
+
+## Shape (locked)
+
+Long two-table design keyed on the ABS **Series ID** (mirrors FRED's series +
+observations, and the `au_abs_community_profiles` precedent). Every one of the 72
+ASNA workbooks shares one machine layout, so a single universal parser ingests
+all of them.
+
+| Table | Grain | Rows | Notes |
+|---|---|---|---|
+| `series` | one row per `series_id` | 4,454 | dictionary: description, unit, source_table_no/name, series_start/end |
+| `observations` | `year` × `series_id` | 233,873 | long fact, partitioned by `year`; `value` FLOAT64, unit lives in `series` |
+
+- **Frequency:** annual (each late October; next 2026-10-23). All tables `AllFree`
+  (annual → no BD Pro rolling window).
+- **Coverage:** FY 1959-60 → 2024-25 (`year` = period-**end** calendar year, e.g.
+  FY2024-25 → 2025; plus `financial_year` STRING "2024-25").
+- **Scope:** all 71 standard tables. **Table 14** (Market Sector Productivity)
+  dropped — it is a growth-cycle summary with no Series IDs.
+- **Dropped constant columns:** Series Type (Original), Data Type (DERIVED),
+  Frequency (Annual) are constant across all ~5,190 series, so not stored.
+
+## Files
+
+```
+code/
+  download.py     fetch + extract the 72 xlsx (browser UA required) -> input/
+  clean_data.py   universal parser: input xlsx -> output/series + output/observations
+  upload.py       output/* -> basedosdados-dev staging (bd.Table)
+  architecture/   series.csv, observations.csv  (source of truth for columns)
+au_abs_national_accounts__series.sql
+au_abs_national_accounts__observations.sql
+schema.yml
+```
+
+`input/` and `output/` are gitignored (data never committed).
+
+## Reproduce
+
+```bash
+uv run python models/au_abs_national_accounts/code/download.py
+uv run python models/au_abs_national_accounts/code/clean_data.py \
+    models/au_abs_national_accounts/input models/au_abs_national_accounts/output
+GOOGLE_APPLICATION_CREDENTIALS=~/.basedosdados/credentials/prod.json \
+  uv run python models/au_abs_national_accounts/code/upload.py --env dev
+```
+
+## Status
+
+- [x] 1–2. Architecture + universal parser (verified: 4,454 series / 233,873 obs;
+  spot-checked GDP growth exact; 0 conflicts; download→clean reproducible)
+- [x] 5. Uploaded to `basedosdados-dev` staging: `series` (4,454), `observations`
+  (233,873). Stale `values` staging table removed after the rename.
+- [x] 6. dbt models + `schema.yml` + `dbt_project.yml` entry written (NOT run yet).
+- [ ] 7. **NEXT — dev dbt checks** (stopped here per request):
+  ```bash
+  GOOGLE_APPLICATION_CREDENTIALS=~/.basedosdados/credentials/prod.json \
+    uv run dbt run  --select au_abs_national_accounts --profiles-dir ~/.dbt --target dev
+  GOOGLE_APPLICATION_CREDENTIALS=~/.basedosdados/credentials/prod.json \
+    uv run dbt test --select au_abs_national_accounts --profiles-dir ~/.dbt --target dev
+  ```
+- [ ] 8–9. Discover IDs + register dev metadata (dataset `under_review`; 2 tables,
+  columns via `bulk_upsert_columns` with PT/EN/ES; OL linking; cloud tables;
+  coverage 1960–2025; table Update). Then verification checkpoint.
+- [ ] 10–13. Prod metadata → PR (needs `deploy-flow`? no — static onboarding) →
+  merge → table-approve → verify → publish.
+- [ ] 12 (optional). Annual Prefect refresh pipeline (poll late-October window).
+
+## Open notes
+
+- `series` is an unpartitioned dimension (no temporal column); coverage handling
+  for it decided at the metadata step.
+- Column descriptions need PT/EN/ES at metadata time; architecture CSV holds EN.

--- a/models/au_abs_national_accounts/au_abs_national_accounts__observations.sql
+++ b/models/au_abs_national_accounts/au_abs_national_accounts__observations.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        schema="au_abs_national_accounts",
+        alias="observations",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1959, "end": 2030, "interval": 1},
+        },
+        cluster_by=["series_id"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(financial_year as string) financial_year,
+    safe_cast(series_id as string) series_id,
+    safe_cast(value as float64) value
+from {{ set_datalake_project("au_abs_national_accounts_staging.observations") }} as t

--- a/models/au_abs_national_accounts/au_abs_national_accounts__series.sql
+++ b/models/au_abs_national_accounts/au_abs_national_accounts__series.sql
@@ -1,0 +1,18 @@
+{{
+    config(
+        schema="au_abs_national_accounts",
+        alias="series",
+        materialized="table",
+    )
+}}
+
+
+select
+    safe_cast(series_id as string) series_id,
+    safe_cast(description as string) description,
+    safe_cast(unit as string) unit,
+    safe_cast(source_table_no as string) source_table_no,
+    safe_cast(source_table_name as string) source_table_name,
+    safe_cast(series_start as date) series_start,
+    safe_cast(series_end as date) series_end
+from {{ set_datalake_project("au_abs_national_accounts_staging.series") }} as t

--- a/models/au_abs_national_accounts/code/architecture/observations.csv
+++ b/models/au_abs_national_accounts/code/architecture/observations.csv
@@ -1,0 +1,5 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Calendar year in which the financial year of the observation ends,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Partition column; the financial year 2024-25 ends in 2025 so is stored as 2025,Series End
+financial_year,STRING,Australian financial year of the observation in YYYY-YY format,,no,,,no,Runs 1 July to 30 June such as 2024-25,derived
+series_id,STRING,ABS series identifier linking the observation to the series table,,no,,,no,Foreign key to the au_abs_national_accounts series table,Series ID
+value,FLOAT64,Observed value of the series for the financial year,,no,,,no,Unit varies by series and is given in the series table so no fixed measurement unit is set here,value

--- a/models/au_abs_national_accounts/code/architecture/series.csv
+++ b/models/au_abs_national_accounts/code/architecture/series.csv
@@ -1,0 +1,8 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+series_id,STRING,ABS series identifier uniquely identifying a time series across all ABS releases,,no,,,no,Primary key; stable ABS-wide identifier such as A2420896J,Series ID
+description,STRING,Full description of the data item as published by the ABS,,no,,,no,,Data Item Description
+unit,STRING,Unit of measure of the series as published by the ABS,,no,,,no,Varies by series such as $ Millions / Percent / Index Numbers,Unit
+source_table_no,STRING,Number of the source ABS 5204.0 table the series is published in,,no,,,no,From 1 to 72,table
+source_table_name,STRING,Name of the source ABS 5204.0 table the series is published in,,no,,,no,,table
+series_start,DATE,Date of the first observation of the series,,no,,,no,June-dated financial-year end,Series Start
+series_end,DATE,Date of the last observation of the series,,no,,,no,June-dated financial-year end,Series End

--- a/models/au_abs_national_accounts/code/clean_data.py
+++ b/models/au_abs_national_accounts/code/clean_data.py
@@ -1,0 +1,255 @@
+"""Universal parser for the ABS Australian System of National Accounts (5204.0).
+
+Every ASNA time-series workbook shares one layout: an ``Index`` sheet plus one or
+more ``Data`` sheets carrying a fixed metadata block (Unit, Series Type, Data
+Type, Frequency, Collection Month, Series Start/End, No. Obs, Series ID) above
+June-dated annual rows. This single parser ingests all 71 standard files into a
+long two-table design keyed on the ABS Series ID:
+
+  - series.parquet              one row per series_id (the dictionary/dimension)
+  - observations/year=YYYY/...  long fact (year, financial_year, series_id, value)
+
+Table 14 (Market Sector Productivity) is skipped: it is a growth-cycle summary
+with no Series IDs, not an annual time series.
+
+Usage:
+    python clean_data.py <input_dir_with_xlsx> <output_dir>
+"""
+
+import datetime as dt
+import glob
+import os
+import sys
+
+import openpyxl
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+SKIP_FILES = {"5204014_Market_Sector_Productivity"}
+
+# Series Type (always "Original"), Data Type ("DERIVED") and Frequency ("Annual")
+# are constant across all ~5,190 ASNA series, so they are dropped rather than
+# stored. Only these labels are needed to parse the block.
+META_LABELS = {
+    "Unit": "unit",
+    "Series Start": "series_start",
+    "Series End": "series_end",
+    "Series ID": "series_id",
+}
+
+
+def _table_no_name(base: str):
+    """`5204005_GVA_by_Industry` -> ("5", "GVA by Industry")."""
+    stem, _, rest = base.partition("_")
+    table_no = str(int(stem[4:7]))  # 5204005 -> 005 -> 5
+    table_name = rest.replace("_", " ").strip()
+    return table_no, table_name
+
+
+def _fin_year(end_year: int) -> str:
+    """Calendar year the FY ends in -> "YYYY-YY" (2025 -> "2024-25")."""
+    return f"{end_year - 1}-{end_year % 100:02d}"
+
+
+def parse_workbook(path: str):
+    base = os.path.basename(path).replace(".xlsx", "")
+    table_no, table_name = _table_no_name(base)
+    wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    data_sheets = [s for s in wb.sheetnames if s.lower().startswith("data")]
+
+    series_rows = []
+    value_rows = []
+    n_nonnumeric = 0
+
+    for sheet in data_sheets:
+        ws = wb[sheet]
+        rows = list(ws.iter_rows(values_only=True))
+        if not rows:
+            continue
+
+        # Locate the metadata block by the label in column A.
+        label_idx = {}
+        for i, r in enumerate(rows[:15]):
+            a = r[0]
+            if isinstance(a, str):
+                a = a.strip().rstrip(".")
+                for lbl in META_LABELS:
+                    if a == lbl.rstrip("."):
+                        label_idx[lbl] = i
+        if "Series ID" not in label_idx:
+            continue
+
+        desc_row = rows[0]
+        sid_row = rows[label_idx["Series ID"]]
+        unit_row = rows[label_idx["Unit"]]
+        sstart_row = rows[label_idx["Series Start"]]
+        send_row = rows[label_idx["Series End"]]
+        data_start = max(label_idx.values()) + 1
+
+        # Valid series columns are those with a Series ID.
+        cols = [
+            j for j in range(1, len(sid_row)) if sid_row[j] not in (None, "")
+        ]
+
+        def _d(v):
+            return v.date() if isinstance(v, dt.datetime) else None
+
+        def _desc(v):
+            # ABS descriptions carry a trailing " ;" separator artifact; strip it.
+            if v is None:
+                return None
+            return str(v).strip().rstrip(";").strip() or None
+
+        for j in cols:
+            series_rows.append(
+                {
+                    "series_id": str(sid_row[j]).strip(),
+                    "description": _desc(desc_row[j]),
+                    "unit": (
+                        str(unit_row[j]).strip()
+                        if unit_row[j] is not None
+                        else None
+                    ),
+                    "source_table_no": table_no,
+                    "source_table_name": table_name,
+                    "series_start": _d(sstart_row[j]),
+                    "series_end": _d(send_row[j]),
+                }
+            )
+
+        for r in rows[data_start:]:
+            d = r[0]
+            if not isinstance(d, dt.datetime):
+                continue
+            year = d.year
+            fy = _fin_year(year)
+            for j in cols:
+                v = r[j]
+                if v is None or v == "":
+                    continue
+                try:
+                    fv = float(v)
+                except (TypeError, ValueError):
+                    n_nonnumeric += 1
+                    continue
+                value_rows.append(
+                    {
+                        "year": year,
+                        "financial_year": fy,
+                        "series_id": str(sid_row[j]).strip(),
+                        "value": fv,
+                    }
+                )
+
+    wb.close()
+    return series_rows, value_rows, n_nonnumeric
+
+
+def main(input_dir: str, output_dir: str):
+    files = sorted(glob.glob(os.path.join(input_dir, "*.xlsx")))
+    files = [
+        f
+        for f in files
+        if os.path.basename(f).replace(".xlsx", "") not in SKIP_FILES
+    ]
+    print(f"Parsing {len(files)} files (Table 14 skipped)")
+
+    all_series, all_values, nonnum = [], [], 0
+    for f in files:
+        s, v, nn = parse_workbook(f)
+        all_series.extend(s)
+        all_values.extend(v)
+        nonnum += nn
+
+    series = pd.DataFrame(all_series)
+    values = pd.DataFrame(all_values)
+
+    # ---- series dictionary: one row per series_id (first occurrence wins) ----
+    dup_series = series["series_id"].duplicated().sum()
+    series = series.drop_duplicates(
+        subset="series_id", keep="first"
+    ).reset_index(drop=True)
+
+    # ---- values: dedup cross-listed (year, series_id); flag any conflicts ----
+    before = len(values)
+    conflicts = values.groupby(["year", "series_id"])["value"].nunique()
+    n_conflict = int((conflicts > 1).sum())
+    values = values.drop_duplicates(
+        subset=["year", "series_id"], keep="first"
+    ).reset_index(drop=True)
+
+    print(
+        f"series rows: {len(series)}  (dropped {dup_series} cross-listed duplicates)"
+    )
+    print(
+        f"values rows: {len(values)}  (dropped {before - len(values)} cross-listed duplicates)"
+    )
+    print(f"value cells that were non-numeric and skipped: {nonnum}")
+    print(
+        f"(year, series_id) pairs with CONFLICTING values across tables: {n_conflict}"
+    )
+    print(f"year range: {values['year'].min()}..{values['year'].max()}")
+    print(f"distinct units: {sorted(series['unit'].dropna().unique())}")
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # series.parquet (explicit schema; DATE for the two date columns)
+    series = series[
+        [
+            "series_id",
+            "description",
+            "unit",
+            "source_table_no",
+            "source_table_name",
+            "series_start",
+            "series_end",
+        ]
+    ]
+    series_schema = pa.schema(
+        [
+            ("series_id", pa.string()),
+            ("description", pa.string()),
+            ("unit", pa.string()),
+            ("source_table_no", pa.string()),
+            ("source_table_name", pa.string()),
+            ("series_start", pa.date32()),
+            ("series_end", pa.date32()),
+        ]
+    )
+    series_tbl = pa.Table.from_pandas(
+        series, schema=series_schema, preserve_index=False
+    )
+    series_dir = os.path.join(output_dir, "series")
+    os.makedirs(series_dir, exist_ok=True)
+    pq.write_table(
+        series_tbl,
+        os.path.join(series_dir, "series.parquet"),
+        compression="snappy",
+    )
+
+    # values: partitioned by year
+    values = values[["year", "financial_year", "series_id", "value"]]
+    values_schema = pa.schema(
+        [
+            ("year", pa.int64()),
+            ("financial_year", pa.string()),
+            ("series_id", pa.string()),
+            ("value", pa.float64()),
+        ]
+    )
+    values_tbl = pa.Table.from_pandas(
+        values, schema=values_schema, preserve_index=False
+    )
+    values_dir = os.path.join(output_dir, "observations")
+    pq.write_to_dataset(
+        values_tbl,
+        root_path=values_dir,
+        partition_cols=["year"],
+        compression="snappy",
+    )
+    print(f"\nWrote {series_dir}/series.parquet and {values_dir}/year=*/")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])

--- a/models/au_abs_national_accounts/code/download.py
+++ b/models/au_abs_national_accounts/code/download.py
@@ -1,0 +1,46 @@
+"""Download the ABS Australian System of National Accounts (5204.0) source files.
+
+Fetches the "All time series spreadsheets" zip for the latest release and extracts
+the 72 .xlsx workbooks into an input directory. A browser User-Agent is required;
+abs.gov.au returns 403 to the default requests/urllib agent.
+
+Usage:
+    python download.py <output_input_dir>   # default: models/au_abs_national_accounts/input
+"""
+
+import io
+import os
+import sys
+import urllib.request
+import zipfile
+
+RELEASE = "2024-25"
+ZIP_URL = (
+    "https://www.abs.gov.au/statistics/economy/national-accounts/"
+    f"australian-system-national-accounts/{RELEASE}/All-time-series-spreadsheets.zip"
+)
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+
+
+def main(input_dir: str):
+    os.makedirs(input_dir, exist_ok=True)
+    req = urllib.request.Request(ZIP_URL, headers={"User-Agent": UA})
+    print(f"Downloading {ZIP_URL}")
+    with urllib.request.urlopen(req) as resp:
+        blob = resp.read()
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        names = [n for n in zf.namelist() if n.lower().endswith(".xlsx")]
+        zf.extractall(input_dir, members=names)
+    print(f"Extracted {len(names)} xlsx files to {input_dir}")
+
+
+if __name__ == "__main__":
+    out = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "input",
+        )
+    )
+    main(out)

--- a/models/au_abs_national_accounts/code/upload.py
+++ b/models/au_abs_national_accounts/code/upload.py
@@ -1,0 +1,149 @@
+"""Upload cleaned au_abs_national_accounts parquet tables to BigQuery.
+
+Usage:
+    uv run python models/au_abs_national_accounts/code/upload.py [--env dev|prod] [table ...]
+
+--env dev (default) -> basedosdados-dev. Point GOOGLE_APPLICATION_CREDENTIALS at
+the matching service account (locally, ~/.basedosdados/credentials/prod.json has
+the BigQuery perms the default ADC lacks; the target project still comes from
+--env, so dev writes to basedosdados-dev). Uploads sequentially, stops on first
+failure, and reports row counts as the verification artifact.
+
+Two tables, both under models/au_abs_national_accounts/output/:
+    series         one parquet file (the dictionary/dimension), unpartitioned
+    observations   hive-partitioned by year=YYYY (the long fact)
+"""
+
+import os
+import subprocess
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+import basedosdados as bd  # noqa: E402
+import google.cloud.storage as gcs  # noqa: E402
+from google.cloud import bigquery  # noqa: E402
+
+
+def _gcloud_project():
+    """The active gcloud project (a billing project the local ADC can use)."""
+    try:
+        return (
+            subprocess.check_output(
+                ["gcloud", "config", "get-value", "project"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            or None
+        )
+    except Exception:
+        return None
+
+
+_argv = sys.argv[1:]
+if "--env" in _argv:
+    _i = _argv.index("--env")
+    ENV = _argv[_i + 1]
+    _argv = _argv[:_i] + _argv[_i + 2 :]
+else:
+    ENV = "dev"
+BILLING_PROJECT = "basedosdados" if ENV == "prod" else "basedosdados-dev"
+DATASET_ID = "au_abs_national_accounts"
+OUTPUT_ROOT = Path(__file__).resolve().parent.parent / "output"
+
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    # GCS staging bucket is requester-pays; bill to the target project.
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+
+def upload_table(slug: str) -> int:
+    path = OUTPUT_ROOT / slug
+    if not path.exists():
+        raise FileNotFoundError(f"Missing output path: {path}")
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=slug)
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=slug)
+    try:
+        st.delete_table(mode="staging", not_found_ok=True)
+    except Exception as e:
+        print(f"  [warn] staging prefix cleanup: {e}")
+
+    tb.create(
+        path=str(path),
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    # Verify row count. The local ADC identity can create the staging table but
+    # may lack bigquery.jobs.create in basedosdados-dev; bill the count job to a
+    # project where it can (BQ_BILLING env, default the gcloud project), reading
+    # the dev table cross-project. Non-fatal: the create above is the real work.
+    q = f"select count(*) as n from `{BILLING_PROJECT}.{DATASET_ID}_staging.{slug}`"
+    last = None
+    for job_project in [
+        BILLING_PROJECT,
+        os.environ.get("BQ_BILLING"),
+        _gcloud_project(),
+    ]:
+        if not job_project:
+            continue
+        try:
+            n = next(
+                iter(bigquery.Client(project=job_project).query(q).result())
+            ).n
+            print(
+                f"  {slug}: uploaded, {n:,} rows (verified via {job_project})",
+                flush=True,
+            )
+            return n
+        except Exception as e:
+            last = e
+    print(
+        f"  {slug}: uploaded (staging table created); count not verified locally: {last}",
+        flush=True,
+    )
+    return -1
+
+
+def all_slugs() -> list[str]:
+    return sorted(
+        p.name
+        for p in OUTPUT_ROOT.iterdir()
+        if p.is_dir() and not p.name.startswith(".")
+    )
+
+
+def main():
+    only = set(_argv)
+    slugs = [s for s in all_slugs() if not only or s in only]
+    if not slugs:
+        print("no output tables found; run clean_data.py first")
+        sys.exit(1)
+    print(
+        f"=== uploading {len(slugs)} tables to {BILLING_PROJECT} (env={ENV}) ===",
+        flush=True,
+    )
+    total = 0
+    for slug in slugs:
+        print(f"=== {slug} ===", flush=True)
+        try:
+            n = upload_table(slug)
+            total += max(n, 0)
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+            sys.exit(1)
+    print(f"ALL TABLES UPLOADED — {total:,} rows verified")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_abs_national_accounts/schema.yml
+++ b/models/au_abs_national_accounts/schema.yml
@@ -1,0 +1,73 @@
+---
+version: 2
+models:
+  - name: au_abs_national_accounts__series
+    description: >-
+      Dictionary of the Australian System of National Accounts (ABS 5204.0) time
+      series. One row per ABS Series ID, giving its description, unit of measure,
+      the source ABS table it is published in, and its first and last observation
+      dates. All series are Original, Annual and ABS-classified as DERIVED, so
+      those constant fields are not stored.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [series_id]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: series_id
+        description: >-
+          ABS series identifier uniquely identifying a time series across all ABS
+          releases, such as A2420896J
+        tests: [not_null, unique]
+      - name: description
+        description: Full description of the data item as published by the ABS
+      - name: unit
+        description: >-
+          Unit of measure of the series as published by the ABS, such as $
+          Millions, Percent or Index Numbers
+      - name: source_table_no
+        description: Number of the source ABS 5204.0 table the series is published
+          in, from 1 to 72
+      - name: source_table_name
+        description: Name of the source ABS 5204.0 table the series is published in
+      - name: series_start
+        description: Date of the first observation of the series, dated to the end
+          of the financial year in June
+      - name: series_end
+        description: Date of the last observation of the series, dated to the end
+          of the financial year in June
+  - name: au_abs_national_accounts__observations
+    description: >-
+      Long time-series values of the Australian System of National Accounts (ABS
+      5204.0). One row per series and financial year. The unit of each value
+      varies by series and is given in the series table.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [year, series_id]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: year
+        description: >-
+          Calendar year in which the financial year of the observation ends, so
+          the financial year 2024-25 is stored as 2025
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: financial_year
+        description: Australian financial year of the observation in YYYY-YY format,
+          such as 2024-25
+        tests: [not_null]
+      - name: series_id
+        description: ABS series identifier linking the observation to the series table
+        tests:
+          - not_null
+          - relationships:
+              to: ref('au_abs_national_accounts__series')
+              field: series_id
+      - name: value
+        description: >-
+          Observed value of the series for the financial year, in the unit given
+          by the series table


### PR DESCRIPTION
## Summary

Onboard the **Australian System of National Accounts** (ABS catalogue 5204.0) — the annual national accounts compiled by the Australian Bureau of Statistics — covering financial years **1959‑60 through 2024‑25**.

## Design

- The 72 ABS time‑series workbooks share one machine layout keyed on the **ABS Series ID**, so a single universal parser ingests all 71 standard tables. Table 14 (Market Sector Productivity), a growth‑cycle summary with no Series IDs, is dropped.
- **Long two‑table design** (mirrors FRED's series + observations):
  - `series` (**4,454** rows): dictionary — `series_id`, description, unit, source ABS 5204.0 table, first/last observation dates.
  - `observations` (**233,873** rows): long fact partitioned by `year`, with `financial_year`, `series_id`, `value`. The unit varies by series and lives in `series`.
  - Fact table named `observations` — **not** `values`, a BigQuery reserved word.
- `year` = calendar year the financial year ends in (FY2024‑25 → 2025), plus a readable `financial_year` string.
- `Series Type` / `Data Type` / `Frequency` are constant across all series and dropped. **English** column names.

## Cadence & coverage

Source releases **annually** (late October; next 2026‑10‑23). Being annual, all tables stay **AllFree** (no BD Pro rolling window).

## Validation

- Uploaded to `basedosdados-dev`; `dbt run` + `dbt test --target dev` **green (11/11)**: unique keys, not‑nulls, proportions, FK `year`→time directory, FK `series_id`→`series`.
- Metadata registered and **published on the staging backend** (`au_abs_national_accounts`).
- Download → clean is reproducible (identical 4,454 / 233,873); GDP‑growth values spot‑checked exact.

## Files

- `models/au_abs_national_accounts/`: `code/{download,clean_data,upload}.py`, `code/architecture/{series,observations}.csv`, `au_abs_national_accounts__{series,observations}.sql`, `schema.yml`, `ONBOARDING_PLAN.md`
- `dbt_project.yml` entry

## Notes / follow‑ups

- **Observation level:** `observations` uses `year` only; `series` has none. A `time_series` entity for the series grain could not be created — the backend's entity‑category lookup fails on a GraphQL casing bug. Revisit when the MCP is patched.
- Prod stays `under_review`; publish after merge → table‑approve materializes the prod tables → verify.

## Checklist

- [x] Data cleaned & validated (row counts, spot‑checks)
- [x] Uploaded to dev; `dbt run` + `dbt test` green
- [x] Metadata registered + published on staging
- [ ] Merge → table‑approve materializes prod tables
- [ ] Verify prod tables + flip prod dataset to `published`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
