### PR TITLE
[Fix] br_senado_dados_abertos (senador_mandato tests)

### DIFF
--- a/models/br_senado_dados_abertos/code/architecture_spec.py
+++ b/models/br_senado_dados_abertos/code/architecture_spec.py
@@ -1132,12 +1132,13 @@ _t(
             {"notnull": True},
         ),
         (
+            # Not every mandate carries a CodigoMandato — older ones (historical
+            # senators) legitimately lack it, so no not_null here.
             "id_mandato",
             "str",
             "Código identificador do mandato",
             "Mandate identifier code",
             "Código identificador del mandato",
-            {"notnull": True},
         ),
         (
             "sigla_uf",
@@ -1145,7 +1146,9 @@ _t(
             "Sigla da unidade da federação de mandato",
             "Federative unit abbreviation of the mandate",
             "Sigla de la unidad federativa del mandato",
-            {"dir": DIR_UF},
+            # Keep the uf directory FK, but exempt extinct units the current
+            # directory omits (GB = Guanabara, dissolved into RJ in 1975).
+            {"dir": DIR_UF, "dir_except": ["GB"]},
         ),
         (
             "participacao",

--- a/models/br_senado_dados_abertos/code/gen_dbt.py
+++ b/models/br_senado_dados_abertos/code/gen_dbt.py
@@ -128,19 +128,24 @@ def gen_schema_entry(slug: str, spec: dict) -> str:
         out.append(f"        description: {pt}")
         tests = []
         if opts.get("notnull"):
-            tests.append(("not_null", None))
+            tests.append(("not_null", None, None))
         d = opts.get("dir")
+        # dir_except: values legitimately absent from the directory (e.g. extinct
+        # UFs) — exempted from the relationship test via a `where` config.
+        exc = opts.get("dir_except")
         if d == DIR_ANO:
             tests.append(
                 # pyrefly: ignore [bad-argument-type]
-                ("rel", ("br_bd_diretorios_data_tempo__ano", "ano.ano"))
+                ("rel", ("br_bd_diretorios_data_tempo__ano", "ano.ano"), exc)
             )
         elif d == DIR_UF:
-            # pyrefly: ignore [bad-argument-type]
-            tests.append(("rel", ("br_bd_diretorios_brasil__uf", "sigla")))
+            tests.append(
+                # pyrefly: ignore [bad-argument-type]
+                ("rel", ("br_bd_diretorios_brasil__uf", "sigla"), exc)
+            )
         if tests:
             out.append("        tests:")
-            for kind, arg in tests:
+            for kind, arg, rel_exc in tests:
                 if kind == "not_null":
                     out.append("          - not_null")
                 else:
@@ -149,6 +154,12 @@ def gen_schema_entry(slug: str, spec: dict) -> str:
                     out.append("          - relationships:")
                     out.append(f"              to: ref('{model}')")
                     out.append(f"              field: {field}")
+                    if rel_exc:
+                        vals = ", ".join(f"'{v}'" for v in rel_exc)
+                        out.append("              config:")
+                        out.append(
+                            f'                where: "{name} not in ({vals})"'
+                        )
     return "\n".join(out)
 
 

--- a/models/br_senado_dados_abertos/schema.yml
+++ b/models/br_senado_dados_abertos/schema.yml
@@ -411,13 +411,14 @@ models:
         tests: [not_null]
       - name: id_mandato
         description: Código identificador do mandato
-        tests: [not_null]
       - name: sigla_uf
         description: Sigla da unidade da federação de mandato
         tests:
           - relationships:
               to: ref('br_bd_diretorios_brasil__uf')
               field: sigla
+              config:
+                where: sigla_uf not in ('GB')
       - name: participacao
         description: Condição de participação no mandato (Titular ou Suplente)
       - name: numero_legislatura_1


### PR DESCRIPTION
## What

Relaxes two `senador_mandato` dbt tests that fail against real Senate data:

- **`id_mandato` — drop `not_null`.** 686 mandate rows carry no `id_mandato` in the source API (older/partial records). It is not a reliable key, so the not-null assertion is removed.
- **`sigla_uf` — keep the `br_bd_diretorios_brasil.uf` relationship, exempt the 6 `GB` rows.** Six senators sat for **Guanabara (GB)**, an extinct UF absent from the directory. Rather than drop the FK test, the relationship now carries a `where: "sigla_uf not in ('GB')"` config, so the directory link is still enforced for every live UF.

Mechanically: `architecture_spec.py` gains a `dir_except` option on the `sigla_uf` column and drops `notnull` on `id_mandato`; `gen_dbt.py` emits the `where` config for `dir_except`; `schema.yml` is regenerated.

## Why this shape

These bugs surfaced on the T1 first-prod run (`chirpy-nyala`) because the T2 onboarding deliberately skipped the dev dbt pass. They are genuine data-shape facts (extinct UF, missing keys), not test noise, so the fix relaxes the assertions to match reality while preserving the directory FK for all valid values.

## Not included (deliberately)

An earlier revision of this branch also gated the flow to **skip the dev `run/test` pass on prod runs** (to spare the `basedosdados-dev` query quota). That has been **dropped**: the house precedent (`br_me_cnpj`, `br_camara_dados_abertos`, `br_ibge_ipca`) is to run the dev `run/test` pass on every materialization, then the prod half. The flow keeps that behavior unchanged. The quota exhaustion that motivated the gating was a transient collision with concurrent onboarding queries, not the steady-state once-a-day cost.

## Scope

Test-only relaxation — 3 files, no schema or data change. Prod tables already materialized; a re-run applies the corrected tests.
