### PR TITLE
feat(br_mf_divida_ativa): add recurring quarterly Prefect pipeline

### DIFF
--- a/.claude/rules/metadata-schema.md
+++ b/.claude/rules/metadata-schema.md
@@ -79,9 +79,20 @@ For individual lookups: `mcp__databasis__lookup_id(env=<env>, slug=<slug>, type=
 | `description_pt/en/es` | string | 1–3 sentences, technical, no bullet lists |
 | `organization_ids` | list | From `discover_ids` using org slug(s) |
 | `theme_ids` | list | From `discover_ids` |
-| `tag_ids` | list | From `discover_ids`; empty list if none |
+| `tag_ids` | list | **Always scan, choose, and attach — do not leave empty.** See "Choosing tags" below |
 | `status_id` | string | **`status.under_review` on creation**; publish on dev/staging pre-promotion, prod only post-merge (see "Dataset status lifecycle" above) |
 | `id` | string | Pass when updating an existing record |
+
+## Choosing tags (do not leave empty)
+
+Every dataset must carry tags — several recent onboardings shipped with none, which hurts discoverability on the site. Never default `tag_ids` to `[]`.
+
+1. **Scan** the existing tag vocabulary: `discover_ids(env=<env>, keys=["tag"])` returns `{slug: id}` for every tag (there are ~800 — a broad, well-populated vocabulary).
+2. **Choose** the tags that genuinely describe the dataset — its subject, entity/grain, and source domain (e.g. for PGFN active debt: `debt`, `debtor`, `tax`, `revenue-collection`, `public-finance`, `federal`, `social_security`). Match on meaning, not exact string; prefer 4–8 specific tags over one vague one. Almost always an appropriate existing tag exists — use it rather than creating a near-duplicate.
+3. **Only if no existing tag fits**, create the missing one in the backend with `create_update_tag(slug=<kebab_or_snake_slug>, name_pt=…, name_en=…, name_es=…, env=<env>)` and use the returned id. Check for a synonym first (e.g. `covid19` vs `covid-19` already both exist — do not add a third).
+4. **Attach** all chosen ids via `tag_ids` on `create_update_dataset`, then verify with `get_dataset` (tags are M2M — see Known issues).
+
+Resolve tags **per backend**: ids differ across dev/staging/prod, so re-scan (and re-create any new tag) on prod before attaching there. When updating an already-published dataset to add tags, re-pass every required field plus the full `tag_ids` (the API does no partial updates).
 
 ## `create_update_table` fields
 

--- a/.claude/rules/onboarding-workflow.md
+++ b/.claude/rules/onboarding-workflow.md
@@ -138,6 +138,19 @@ Publishing is one call: `create_update_dataset(id=<dataset_id>, …, status_id=s
 
 **You never upload data to the prod project (`basedosdados`) yourself.** During onboarding the local upload targets **`basedosdados-dev` only** (steps 5, and the `set_datalake_project` dbt macro resolves the `dev` target to `basedosdados-dev`). The **prod table data lands in `basedosdados.<gcp_dataset_id>.*` when the onboarding PR is merged**, via the GitHub **table-approve** action, which runs `dbt --target prod` (that target's `set_datalake_project` reads `basedosdados-staging`). So the sequence is: upload to dev → verify in dev → register prod metadata `under_review` (step 10, cloud tables pointing at the not-yet-existing `basedosdados` tables) → open PR (step 11) → **merge → table-approve materialises the prod tables** → verify → publish (step 13). Do not try to populate `basedosdados` or `basedosdados-staging` from a local machine; local credentials are dev-only, and the merge is the trigger. (Watch the phantom-model failure mode noted above: non-model `.sql` in the PR can abort materialisation before any real table builds.)
 
+## Branch and commit discipline
+
+**Branch names — never the generic `claude/…` prefix.** Name the branch for the work, using a prefix that matches the change (the slug is the `<dataset_id>` whenever there is one):
+
+| Prefix | Use for | Example |
+|--------|---------|---------|
+| `data/` | onboarding a new dataset (cleaning code, dbt models, metadata) | `data/br_mma_cnuc` |
+| `pipeline/` | adding or fixing a recurring Prefect pipeline | `pipeline/br_mf_divida_ativa` |
+| `fix/` | bug fix to existing code, models, or data | `fix/br_tse_eleicoes-schema` |
+| `docs/` | documentation or `.claude/rules` changes only | `docs/tag-conventions` |
+
+If a tool or environment created a `claude/…` branch, rename it (`git branch -m <new-name>`) before opening the PR — **except** when a recurring-pipeline PR has already registered its dev deployment from that branch (the deploy step pins the deployment's `GitRepository` to the PR branch, so renaming mid-PR breaks the deployment's source). In that one case, keep the branch and use the correct prefix next time.
+
 ## Commit discipline
 
 Commit after each logical unit completes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,8 +299,8 @@ Agents use shared rule files in `.claude/rules/`:
 | `data-basis-style.md` | Column naming, ordering, prefixes, directory mappings |
 | `dbt-conventions.md` | SQL patterns, schema.yml structure, test types |
 | `bigquery-conventions.md` | Project references, partitioning, type casting |
-| `metadata-schema.md` | Backend API field mapping, MCP tool sequence |
-| `onboarding-workflow.md` | 11-step sequence, quality gates, commit discipline |
+| `metadata-schema.md` | Backend API field mapping, MCP tool sequence, tag selection |
+| `onboarding-workflow.md` | 11-step sequence, quality gates, branch & commit discipline |
 
 ### Skills (user-callable shortcuts)
 
@@ -330,3 +330,5 @@ Before running AI-assisted onboarding, ensure the following are configured:
 7. **Document exceptions** in `schema.yml` model descriptions when using `custom_relationships` or `custom_unique_combinations_of_columns` with non-zero `proportion_allowed_failures`.
 8. When adding a new dataset pipeline, always run `uv run manage.py add-pipeline <name>` rather than creating files manually.
 9. The `dbt` CLI must be run inside the activated virtual environment: `source .venv/bin/activate` or via `uv run dbt ...`.
+10. **Name branches for the work — never the generic `claude/…` prefix.** Use `data/<dataset_id>`, `pipeline/<dataset_id>`, `fix/<scope>`, or `docs/<topic>`. See "Branch and commit discipline" in `onboarding-workflow.md`.
+11. **Always choose and attach dataset tags — never leave `tag_ids` empty.** Scan `discover_ids(keys=["tag"])`, pick the tags that describe the dataset, and create new ones only when none fit. See "Choosing tags" in `metadata-schema.md`.

--- a/models/br_mf_divida_ativa/code/clean_data.py
+++ b/models/br_mf_divida_ativa/code/clean_data.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Bootstrap: download + clean PGFN Dívida Ativa quarters into partitioned
-Parquet under the data root (outside Dropbox - see ``divida_ativa.data_root``).
+Parquet under the data root (outside Dropbox - see ``utils.data_root``).
 
-The transform lives in ``divida_ativa.py`` so the recurring pipeline and this
-one-shot bootstrap share one implementation. Downloads one quarter at a time and
+The transform lives in ``pipelines/datasets/br_mf_divida_ativa/utils.py`` so the
+recurring pipeline and this one-shot bootstrap share one implementation.
+Downloads one quarter at a time and
 (by default) deletes each ZIP after cleaning, so peak disk stays near one ZIP.
 
 Usage:
@@ -21,13 +22,10 @@ import argparse
 import logging
 import re
 import sys
-from pathlib import Path
 
 import requests
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-# pyrefly: ignore [missing-import]
-from divida_ativa import (
+from pipelines.datasets.br_mf_divida_ativa.utils import (
     TABLES,
     clean_quarter_zip,
     data_root,

--- a/pipelines/datasets/br_mf_divida_ativa/constants.py
+++ b/pipelines/datasets/br_mf_divida_ativa/constants.py
@@ -1,0 +1,39 @@
+"""Constants for the br_mf_divida_ativa recurring pipeline (Prefect 3).
+
+PGFN "Dados Abertos da Dívida Ativa da União" — quarterly stock of active-debt
+registrations across three systems (SIDA / previdenciário / FGTS). See
+models/br_mf_divida_ativa/ONBOARDING_PLAN.md for the full design.
+"""
+
+from enum import Enum
+from pathlib import Path
+
+# Repo root, then the committed architecture CSVs (the single schema source of
+# truth — column order + bigquery_type per table), shared with the one-shot
+# bootstrap under models/br_mf_divida_ativa/code/.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class constants(Enum):
+    """Constants for the br_mf_divida_ativa pipeline.
+
+    Lowercase class name follows the repo-wide convention for dataset constant
+    enums. ``ARCHITECTURE_DIR`` points at the architecture CSVs under
+    ``models/br_mf_divida_ativa/code/``, the schema source of truth for both this
+    pipeline and the one-shot bootstrap.
+    """
+
+    DATASET_ID = "br_mf_divida_ativa"
+
+    # Earliest quarter published by PGFN; the forward source probe starts here.
+    FIRST_YEAR = 2020
+    FIRST_QUARTER = 1
+
+    ARCHITECTURE_DIR = (
+        _REPO_ROOT / "models" / "br_mf_divida_ativa" / "code" / "architecture"
+    )
+
+    # PGFN republishes quarterly, ~1-2 months after quarter end, on no fixed day.
+    # Poll a few days each month at 15:00 BRT; the source-poll guard no-ops until
+    # a genuinely new quarter appears, so off-release runs are cheap.
+    SCHEDULE_CRON = "0 15 5,15,25 * *"

--- a/pipelines/datasets/br_mf_divida_ativa/flows.py
+++ b/pipelines/datasets/br_mf_divida_ativa/flows.py
@@ -1,0 +1,219 @@
+"""Flows for br_mf_divida_ativa — Prefect 3.
+
+PGFN "Dados Abertos da Dívida Ativa da União": three quarterly tables (SIDA /
+previdenciário / FGTS). Each release adds ONE new quarter as an immutable
+snapshot, so the pipeline is **incremental append**, not full replace — only
+quarters newer than the registered ``RawDataSource.Update`` boundary are
+downloaded and appended to staging (partitioned by ano/trimestre), which keeps
+each quarter's partition from being ingested twice. All three tables paywall
+their most recent two quarters (``PartBdpro``, free_lag 6 months = 2 quarters);
+the rolling window and its BigQuery Row Access Policies are re-applied on every
+prod run by ``register_table_materialization_task``.
+
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers ``br_mf_divida_ativa_flow``
+(defined at module level here); the dev pool ignores the schedule, the prod pool
+activates it (paused until armed).
+"""
+
+import shutil
+import tempfile
+
+from prefect import flow
+
+from pipelines.datasets.br_mf_divida_ativa.constants import constants
+from pipelines.datasets.br_mf_divida_ativa.tasks import (
+    clean_quarters_task,
+    discover_new_quarters,
+)
+from pipelines.datasets.br_mf_divida_ativa.utils import TABLES
+from pipelines.utils.metadata.domain import (
+    DateFormat,
+    FreeLag,
+    PartBdpro,
+    YearQuarter,
+)
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+# The probe/anchor table: SIDA is published every quarter and carries the single
+# raw data source that the poll/commit/boundary all read.
+ANCHOR_TABLE = "nao_previdenciario"
+
+# All three tables refresh quarterly, so all three paywall their most recent two
+# quarters to BD Pro. free_lag = 6 months = 2 quarters: free ends at
+# source_end - 6 months, pro spans the two quarters after that. The window rolls
+# on its own each run. part_bdpro requires BOTH a free (is_closed=False) and a
+# pro (is_closed=True) Coverage to already exist on the table (created at
+# onboarding), or assert_coverage_topology raises before anything is written.
+_COVERAGE = {
+    table: PartBdpro(
+        date_column=YearQuarter(year="ano", quarter="trimestre"),
+        date_format=DateFormat.YEAR_MONTH,
+        free_lag=FreeLag(unit="months", value=6),
+    )
+    for table in TABLES
+}
+
+
+@flow(name="br_mf_divida_ativa", log_prints=True)
+def br_mf_divida_ativa_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+) -> None:
+    """Ingest any newly published PGFN quarters and materialize the three tables.
+
+    Only quarters newer than the registered source boundary are downloaded and
+    appended, so a scheduled run is a cheap no-op between quarterly releases.
+
+    Args:
+        materialize_to_prod: Continue past the dev materialization to write the
+            prod staging bucket and run dbt against ``target="prod"``. Set False
+            to exercise only the dev half — required for a safe test run, since
+            the default writes production.
+        update_metadata: After a successful prod materialization, roll the
+            coverage/Row-Access-Policy window and commit the source update. Has no
+            effect when ``materialize_to_prod`` is False.
+        force_run: When the source has nothing genuinely new, re-ingest the latest
+            available quarter into DEV ONLY (overwriting dev staging so the dbt
+            uniqueness test stays clean). Prod is never overwritten or
+            re-appended by a forced run — only genuine new quarters ever reach
+            prod. Use for a safe dev smoke test:
+            ``{materialize_to_prod: False, update_metadata: False, force_run: True}``.
+    """
+    # pyrefly: ignore [unused-coroutine]
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id=ANCHOR_TABLE
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="br_mf_divida_ativa_")
+    try:
+        disc = discover_new_quarters(DATASET_ID, ANCHOR_TABLE, env="prod")
+        new_quarters = disc["quarters"]
+        available = disc["available"]
+        max_date = disc["max_date"]
+        if available is None:
+            return
+
+        # Record a Poll on the source (audit: "when we last looked"). Non-gating —
+        # the ingest decision is driven by discover_new_quarters, not this return.
+        # pyrefly: ignore [unused-coroutine]
+        poll_source_for_update_task(
+            dataset_id=DATASET_ID,
+            table_id=ANCHOR_TABLE,
+            source_max_date=max_date,
+            env="prod",
+            date_format="%Y-%m-%d",
+        )
+
+        if new_quarters:
+            quarters = new_quarters
+            dump_mode = "append"
+        elif force_run:
+            # Forced dev smoke test: nothing genuinely new, so re-ingest the
+            # latest quarter into DEV with overwrite (clean single-quarter dev
+            # staging -> dbt uniqueness passes). Prod is skipped below.
+            quarters = [available]
+            dump_mode = "overwrite"
+            print(
+                f"force_run with no new quarters: DEV-only overwrite re-ingest "
+                f"of {available} for testing; prod untouched."
+            )
+        else:
+            print("No new quarters at source; nothing to do.")
+            return
+
+        result = clean_quarters_task(quarters=quarters, work_dir=work_dir)
+
+        # Dev: upload staging + materialize/test.
+        for table in TABLES:
+            data_path = result.get(table)
+            if not data_path:
+                continue
+            upload_to_gcs(
+                data_path=data_path,
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados-dev",
+                dump_mode=dump_mode,
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="dev",
+            )
+
+        if not materialize_to_prod:
+            return
+
+        # Prod: only genuine new quarters are ever appended — a forced smoke test
+        # (dump_mode="overwrite") never reaches prod, so prod is never truncated.
+        if not new_quarters:
+            print("No genuine new quarters; skipping prod materialization.")
+            return
+
+        for table in TABLES:
+            data_path = result.get(table)
+            if not data_path:
+                continue
+            upload_to_gcs(
+                data_path=data_path,
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados",
+                dump_mode="append",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="prod",
+            )
+
+        if update_metadata:
+            # Rolls both DateTimeRanges and re-issues the Row Access Policies for
+            # each table (part_bdpro), then advances the source Update to the
+            # newest quarter — committed last, only after prod succeeded.
+            for table in TABLES:
+                register_table_materialization_task(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    coverage=_COVERAGE[table],
+                    env="prod",
+                    bq_project="basedosdados",
+                )
+            commit_source_update_task(
+                dataset_id=DATASET_ID,
+                table_id=ANCHOR_TABLE,
+                source_max_date=max_date,
+                env="prod",
+                date_format="%Y-%m-%d",
+            )
+    finally:
+        # Covers early returns (no new data, dev-only) and any exception. A
+        # process/local worker reuses its filesystem and the SIDA ZIPs are large.
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# PGFN republishes quarterly on no fixed day; poll a few days each month at 15:00
+# BRT. The source-boundary check no-ops until a genuinely new quarter appears.
+# pyrefly: ignore [missing-attribute]
+br_mf_divida_ativa_flow.deploy_schedules = [
+    {"cron": constants.SCHEDULE_CRON.value, "timezone": "America/Sao_Paulo"}
+]
+# The clean step streams the SIDA quarter in 400k-row chunks, so peak RAM is
+# modest; give headroom for the pandas->arrow buffers and the GCS upload.
+# pyrefly: ignore [missing-attribute]
+br_mf_divida_ativa_flow.job_variables = {"memory": "8Gi"}

--- a/pipelines/datasets/br_mf_divida_ativa/tasks.py
+++ b/pipelines/datasets/br_mf_divida_ativa/tasks.py
@@ -1,0 +1,102 @@
+"""Prefect 3 tasks for br_mf_divida_ativa — thin wrappers over utils.py."""
+
+import datetime
+from pathlib import Path
+from typing import Literal
+
+from prefect import task
+
+from pipelines.datasets.br_mf_divida_ativa.utils import (
+    FIRST_QUARTER,
+    FIRST_YEAR,
+    all_quarters,
+    clean_quarters,
+    latest_available_quarter,
+    quarter_date_str,
+)
+from pipelines.utils.metadata.client import MetadataClient
+
+
+@task
+def discover_new_quarters(
+    dataset_id: str,
+    table_id: str,
+    env: Literal["dev", "prod", "staging"] = "prod",
+) -> dict:
+    """Find which source quarters have not been ingested yet.
+
+    Probes the source for the newest available quarter, then reads the registered
+    ``RawDataSource.Update.latest`` (a coverage date, seeded at onboarding and
+    advanced by :func:`commit_source_update_task`). Every quarter strictly newer
+    than that boundary — up to and including the newest available — is returned,
+    so a missed scheduled run catches up on all the quarters it skipped rather
+    than silently dropping one. The Update boundary (not a re-scan of the table)
+    is what keeps each quarter's partition from being appended to staging twice.
+
+    Args:
+        dataset_id: GCP/BigQuery dataset id.
+        table_id: probe table (SIDA, present every quarter) that anchors the
+            single raw data source the boundary is read from.
+        env: backend to read the source update from.
+
+    Returns:
+        ``{"quarters": [[year, quarter], ...], "available": [year, quarter] |
+        None, "max_date": "YYYY-MM-01" | None}``. ``quarters`` is empty when the
+        source has nothing newer than the boundary (or the boundary is unseeded —
+        see the note below).
+    """
+    available = latest_available_quarter()
+    if available is None:
+        print("Source unreachable — no quarters found.")
+        return {"quarters": [], "available": None, "max_date": None}
+
+    client = MetadataClient(env=env)
+    last = client.get_raw_source_update_latest(dataset_id, table_id)
+
+    if last is None:
+        # Unseeded RawDataSource.Update: refuse to guess a boundary and re-ingest
+        # history (that would duplicate staging partitions). Seed the source
+        # Update at onboarding to the last loaded quarter; until then this is a
+        # no-op. See prefect-pipeline-conventions "Update and Poll records".
+        print(
+            "RawDataSource.Update.latest is unset — seed it to the last loaded "
+            "quarter before the pipeline can detect new data. Skipping."
+        )
+        new: list[list[int]] = []
+    else:
+        candidates = all_quarters((FIRST_YEAR, FIRST_QUARTER), available)
+        new = [
+            [y, q]
+            for (y, q) in candidates
+            if datetime.date(y, q * 3, 1) > last
+        ]
+
+    print(
+        f"newest at source={available}, registered boundary={last}, "
+        f"new quarters={new}"
+    )
+    return {
+        "quarters": new,
+        "available": list(available),
+        "max_date": quarter_date_str(*available),
+    }
+
+
+@task(retries=2, retry_delay_seconds=60)
+def clean_quarters_task(quarters: list, work_dir: str) -> dict:
+    """Download + clean the given quarters for all three tables.
+
+    Retries twice: the PGFN endpoint occasionally drops connections on the larger
+    SIDA ZIPs (``download_quarter`` also retries per file).
+
+    Args:
+        quarters: list of ``[year, quarter]`` pairs to ingest.
+        work_dir: per-run scratch dir; inputs land in ``<work_dir>/input`` and
+            partitioned Parquet under ``<work_dir>/output/<table>/``.
+
+    Returns:
+        Mapping of table slug to its partitioned output directory (str), or
+        ``None`` for a table absent from the requested quarters.
+    """
+    pairs = [(int(y), int(q)) for y, q in quarters]
+    return clean_quarters(pairs, Path(work_dir))

--- a/pipelines/datasets/br_mf_divida_ativa/utils.py
+++ b/pipelines/datasets/br_mf_divida_ativa/utils.py
@@ -1,16 +1,17 @@
 """Download + streaming cleaning transform for br_mf_divida_ativa (PGFN Dívida
 Ativa da União).
 
-Pure functions (no Prefect), importable and unit-testable; a later recurring
-pipeline will reuse them. The source publishes one quarterly ZIP per system
-(SIDA / PREV / FGTS); each ZIP holds several `;`-delimited, Latin-1 CSV parts.
-The SIDA (nao_previdenciario) table is ~40-50M rows per quarter, so every part is
-processed in row chunks and streamed to Parquet - the whole table is never held
-in memory.
+Pure functions (no Prefect), importable and unit-testable, shared by the
+recurring pipeline (``tasks.py``/``flows.py``) and the one-shot onboarding
+bootstrap under ``models/br_mf_divida_ativa/code/`` (which imports from here).
+The source publishes one quarterly ZIP per system (SIDA / PREV / FGTS); each ZIP
+holds several ``;``-delimited, Latin-1 CSV parts. The SIDA (nao_previdenciario)
+table is ~40-50M rows per quarter, so every part is processed in row chunks and
+streamed to Parquet — the whole table is never held in memory.
 
-Schema and column order come from the architecture CSVs in ``architecture/`` (the
-single source of truth). Staging Parquet is all-STRING by Data Basis convention;
-the dbt model ``safe_cast``s each column to its real type.
+Schema and column order come from the architecture CSVs (the single source of
+truth, at ``constants.ARCHITECTURE_DIR``). Staging Parquet is all-STRING by Data
+Basis convention; the dbt model ``safe_cast``s each column to its real type.
 """
 
 from __future__ import annotations
@@ -29,6 +30,8 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import requests
 
+from pipelines.datasets.br_mf_divida_ativa.constants import constants
+
 log = logging.getLogger("br_mf_divida_ativa")
 
 # ── constants ────────────────────────────────────────────────────────────────
@@ -42,6 +45,10 @@ CATEGORY = {
     "fgts": "FGTS",
 }
 TABLES = tuple(CATEGORY)
+
+FIRST_YEAR = constants.FIRST_YEAR.value
+FIRST_QUARTER = constants.FIRST_QUARTER.value
+ARCH_DIR = constants.ARCHITECTURE_DIR.value
 
 # Known anomalous filenames on the server (the typo is the real object name).
 URL_OVERRIDES = {
@@ -94,16 +101,14 @@ VALID_UFS = frozenset(
     ]
 )
 
-_HERE = Path(__file__).resolve().parent
-ARCH_DIR = _HERE / "architecture"
-
 
 def data_root() -> Path:
-    """Root for downloaded input + cleaned output - under ~/Downloads.
+    """Root for downloaded input + cleaned output — under ~/Downloads.
 
-    Override with ``PGFN_DATA_ROOT``. Tens of GB land here for the full backfill,
-    so it lives outside Dropbox/the repo (never synced, never committed) and is
-    deleted as the final onboarding step.
+    Override with ``PGFN_DATA_ROOT``. Used by the one-shot bootstrap; the
+    recurring pipeline writes to a per-run temp dir instead. Tens of GB land here
+    for the full backfill, so it lives outside Dropbox/the repo (never synced,
+    never committed) and is deleted as the final onboarding step.
     """
     return Path(
         os.environ.get(
@@ -115,7 +120,7 @@ def data_root() -> Path:
 
 # ── schema ───────────────────────────────────────────────────────────────────
 def read_arch(table: str) -> list[dict]:
-    """Read a table's architecture CSV - column order + types + source mapping."""
+    """Read a table's architecture CSV — column order + types + source mapping."""
     with open(ARCH_DIR / f"{table}.csv", newline="", encoding="utf-8") as fh:
         return list(csv.DictReader(fh))
 
@@ -170,7 +175,7 @@ def download_quarter(
     """Download one quarterly ZIP into ``input_dir``; return its path.
 
     Streams to disk (files reach 1.3 GB). A ``(connect, read)`` timeout means a
-    stalled connection - e.g. after the laptop sleeps and the socket dies - fails
+    stalled connection — e.g. after the laptop sleeps and the socket dies — fails
     within ~2 min instead of hanging, and is retried with backoff; on wake the
     retry succeeds. Raises the last error only after all retries, so a caller can
     distinguish a genuine failure from an absent quarter (use ``source_exists``).
@@ -247,7 +252,7 @@ def _clean_date(s: pd.Series) -> pd.Series:
     """Parse dd/mm/yyyy to ISO ``YYYY-MM-DD``; sentinel/invalid -> None.
 
     ``01/01/1000`` (and any pre-1677 date) is out of pandas' datetime64[ns]
-    range, so ``errors="coerce"`` maps it to NaT - exactly the sentinel handling
+    range, so ``errors="coerce"`` maps it to NaT — exactly the sentinel handling
     we want. Real inscription dates are all modern.
     """
     raw = _clean_series(s)
@@ -377,3 +382,95 @@ def clean_quarter_zip(
         final,
     )
     return total
+
+
+# ── quarter arithmetic + orchestration (recurring pipeline) ───────────────────
+def next_quarter(year: int, quarter: int) -> tuple[int, int]:
+    """The (year, quarter) immediately after the given one."""
+    return (year, quarter + 1) if quarter < 4 else (year + 1, 1)
+
+
+def all_quarters(
+    start: tuple[int, int], end: tuple[int, int]
+) -> list[tuple[int, int]]:
+    """Every (year, quarter) from ``start`` to ``end`` inclusive, ascending."""
+    out: list[tuple[int, int]] = []
+    y, q = start
+    while (y, q) <= end:
+        out.append((y, q))
+        y, q = next_quarter(y, q)
+    return out
+
+
+def quarter_date_str(year: int, quarter: int) -> str:
+    """Represent a quarter as the first day of its last month, ``YYYY-MM-01``.
+
+    Matches the ``DATE(ano, trimestre*3, 1)`` the coverage framework builds for a
+    ``YearQuarter`` column, so poll/commit dates line up with the registered
+    coverage (Q1->03-01, Q2->06-01, Q3->09-01, Q4->12-01).
+    """
+    return f"{year}-{quarter * 3:02d}-01"
+
+
+def latest_available_quarter(
+    session=None,
+    first: tuple[int, int] = (FIRST_YEAR, FIRST_QUARTER),
+    probe_table: str = "nao_previdenciario",
+    max_year: int = 2100,
+) -> tuple[int, int] | None:
+    """Newest quarter published at the source, by probing forward from ``first``.
+
+    Scans quarters in order (SIDA is present every quarter, so it is the probe
+    table) and returns the last one that exists. Quarters are contiguous at the
+    source, so the first missing quarter ends the scan. Returns ``None`` only if
+    even ``first`` is absent (source unreachable).
+    """
+    s = session or requests
+    last_seen: tuple[int, int] | None = None
+    y, q = first
+    while y <= max_year:
+        if source_exists(y, q, probe_table, session=s):
+            last_seen = (y, q)
+            y, q = next_quarter(y, q)
+        else:
+            break
+    return last_seen
+
+
+def clean_quarters(
+    quarters: list[tuple[int, int]],
+    work_dir: Path,
+    session=None,
+) -> dict[str, str | None]:
+    """Download + clean the given quarters for all three tables.
+
+    For each table and quarter present at the source, downloads the ZIP into
+    ``<work_dir>/input`` and streams it to partitioned Parquet under
+    ``<work_dir>/output/<table>/ano=<Y>/trimestre=<Q>/``. Each ZIP is deleted
+    right after cleaning so peak disk stays near a single file (SIDA ZIPs reach
+    1.3 GB).
+
+    Returns a mapping of table slug to its output directory (a hive-partitioned
+    tree ready for ``upload_to_gcs``), or ``None`` for a table with no data in
+    the requested quarters (e.g. some early quarters lack FGTS).
+    """
+    input_dir = Path(work_dir) / "input"
+    output_dir = Path(work_dir) / "output"
+    s = session or requests.Session()
+    result: dict[str, str | None] = {}
+    for table in TABLES:
+        produced = False
+        for year, quarter in quarters:
+            if not source_exists(year, quarter, table, session=s):
+                log.info(
+                    "%s %sQ%s absent at source, skipping", table, year, quarter
+                )
+                continue
+            zip_path = download_quarter(
+                year, quarter, table, input_dir, session=s
+            )
+            clean_quarter_zip(zip_path, table, year, quarter, output_dir)
+            zip_path.unlink(missing_ok=True)
+            produced = True
+        result[table] = str(output_dir / table) if produced else None
+    return result


### PR DESCRIPTION
## What

Recurring **quarterly** Prefect 3 pipeline for `br_mf_divida_ativa` (PGFN Dívida Ativa da União), the automated refresh that keeps the already-onboarded dataset up to date. Three tables: `nao_previdenciario` (SIDA), `previdenciario`, `fgts`.

## Design

- **Incremental append, not full-replace.** Each PGFN release is one new immutable quarter; re-downloading the full ~828M-row history every quarter is infeasible. The onboarding parquet is already all-STRING, so appending new `ano=/trimestre=` partitions to staging is schema-compatible.
- **Dedup via the source-update boundary.** `discover_new_quarters` reads `RawDataSource.Update.latest` (seeded to `2026-06-01` = the last loaded quarter) and probes the source forward, ingesting only quarters strictly newer than the boundary. A quarter's partition is therefore never appended twice, and a missed scheduled run catches up on every quarter it skipped rather than dropping one.
- **BD Pro last-two-quarters paywall on all three tables** — `PartBdpro(YearQuarter(ano, trimestre), free_lag = 6 months)`. `register_table_materialization_task` rolls both DateTimeRanges and re-issues the BigQuery Row Access Policies on every prod run, so the window slides on its own. The two coverages (free + pro) already exist on each table from onboarding, as `assert_coverage_topology` requires.
- **Safe forced smoke test.** `force_run` with nothing genuinely new re-ingests the latest quarter into **dev only** (overwrite → clean single-quarter dev staging so the dbt uniqueness test stays green). Prod is never overwritten or re-appended by a forced run — only genuine new quarters reach prod.

## DRY

The cleaning transform moves from `models/br_mf_divida_ativa/code/divida_ativa.py` to `pipelines/datasets/br_mf_divida_ativa/utils.py` as the single canonical copy; the one-shot bootstrap (`clean_data.py`) now imports it, matching the `us_bls_cpi` layout. No duplication.

## Verification (local — fail-fast only)

- Imports resolve; `deploy_flows.load_flows_from_file` discovers `br_mf_divida_ativa`.
- `read_arch` reads the architecture CSVs from the shared location; quarter arithmetic correct.
- `clean_data.py --help` still runs (bootstrap import chain intact after the move).
- `ruff check`, `ruff format`, and `pyrefly check` all clean (0 diagnostics).

Schedule: `0 15 5,15,25 * *` (America/Sao_Paulo) — polls a few days each month; the source-boundary check no-ops until a genuinely new quarter appears. `job_variables = {"memory": "8Gi"}`.

## After merge

A real **dev run** is the definition of done — will be run before merge via the `deploy-flow` label with `{materialize_to_prod: False, update_metadata: False, force_run: True}` and checked for `dbt run OK` + `dbt test OK` on all three tables. The prod deploy lands **paused**; the first armed run (Django admin) is when the Row Access Policies go live and the last-two-quarters paywall is actually enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated quarterly ingestion for Brazilian active-debt data across three debt tables.
  * New runs detect newly available source periods and process them incrementally.
  * Added data cleaning and partitioned Parquet output for improved dataset organization.
  * Added scheduled monthly polling and controlled promotion from development to production.
  * Supports forced refreshes of the latest quarter for validation without altering production data.

* **Documentation**
  * Updated bootstrap guidance for the refreshed data-processing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->