### PR TITLE
[Feature] br_senado_dados_abertos (T2 time-series paywall)

### DIFF
--- a/pipelines/datasets/br_senado_dados_abertos/flows.py
+++ b/pipelines/datasets/br_senado_dados_abertos/flows.py
@@ -1,11 +1,12 @@
 """
 Flows for br_senado_dados_abertos — Prefect 3.
 
-Senado Federal legislative open data. One flow refreshes all ten tables from the
-public Legislative Open Data API each day: dimensions in full, the four
+Senado Federal legislative open data. One flow refreshes all 18 tables from the
+public Legislative Open Data API each day: the ten dimensions in full, the eight
 time-series tables (votacao, votacao_parlamentar, votacao_orientacao_bancada,
-processo) for the recent window only — uploaded with ``dump_mode="append"``,
-which replaces just those ``ano=`` partitions and leaves history in place. Like
+processo, relatoria, votacao_comissao, votacao_comissao_parlamentar, discurso)
+for the recent window only — uploaded with ``dump_mode="append"``, which replaces
+just those ``ano=`` partitions and leaves history in place. Like
 the Câmara pipeline, there is no source-poll gate: legislative activity changes
 continuously, so a daily run is always meaningful.
 
@@ -39,7 +40,7 @@ from pipelines.utils.tasks import (
 DATASET_ID = constants.DATASET_ID.value
 ALL_TABLES = constants.ALL_TABLES.value
 
-# BD Pro rolling window: the four time-series tables paywall their most recent
+# BD Pro rolling window: the eight time-series tables paywall their most recent
 # 6 months (part_bdpro), everything older is free. register_table_materialization_task
 # recomputes free_end = source_end - free_lag, rewrites both DateTimeRanges, and
 # re-issues the BigQuery Row Access Policies each run, so the window slides on
@@ -65,6 +66,26 @@ _COVERAGE = {
     ),
     "processo": PartBdpro(
         date_column=DateOnly(col="data_apresentacao"),
+        date_format=DateFormat.YEAR_MD,
+        free_lag=FreeLag(unit="months", value=6),
+    ),
+    "relatoria": PartBdpro(
+        date_column=DateOnly(col="data_designacao"),
+        date_format=DateFormat.YEAR_MD,
+        free_lag=FreeLag(unit="months", value=6),
+    ),
+    "votacao_comissao": PartBdpro(
+        date_column=DateOnly(col="data_reuniao"),
+        date_format=DateFormat.YEAR_MD,
+        free_lag=FreeLag(unit="months", value=6),
+    ),
+    "votacao_comissao_parlamentar": PartBdpro(
+        date_column=DateOnly(col="data_reuniao"),
+        date_format=DateFormat.YEAR_MD,
+        free_lag=FreeLag(unit="months", value=6),
+    ),
+    "discurso": PartBdpro(
+        date_column=DateOnly(col="data_sessao"),
         date_format=DateFormat.YEAR_MD,
         free_lag=FreeLag(unit="months", value=6),
     ),


### PR DESCRIPTION
## What

Extends the BD Pro rolling window to the **four T2 time-series tables**, which refresh daily but were still fully free. They join the four T1 tables already gated, so all eight daily-refreshed time-series tables now paywall their most recent 6 months; the ten dimension tables stay free.

Added to the flow's `_COVERAGE` as `PartBdpro(free_lag=6 months)`, each keyed on its own date column:

| Table | date column |
|---|---|
| relatoria | `data_designacao` |
| votacao_comissao | `data_reuniao` |
| votacao_comissao_parlamentar | `data_reuniao` |
| discurso | `data_sessao` |

Also fixes stale module docstrings (the flow moves 18 tables / 8 time-series now, not the original 10 / 4).

## Why

House rule: any table refreshed monthly or more often paywalls its recent window; everything older stays free. These four refresh daily, so by that rule they belong in `part_bdpro`. Matches the T1 tables and the `us_bls_cpi` / `br_ibge_ipca` precedent.

## Prerequisite — already done on prod

`register_table_materialization_task` hard-fails at `assert_coverage_topology` unless both a free and a pro Coverage already exist on a `part_bdpro` table. The four T2 tables were onboarded `AllFree` (free Coverage only), so a **pro Coverage (`is_closed=True`) + pro DateTimeRange** was created on each in prod before this change:

| Table | pro Coverage id |
|---|---|
| relatoria | `8493b6f4` |
| votacao_comissao | `1d11e120` |
| votacao_comissao_parlamentar | `b02ac480` |
| discurso | `22b9164f` |

Topology verified free+pro on all four. The placeholder pro ranges (2026-02…2026-08) are rewritten to the exact `free_end+1 … source_max` by the pipeline on the next run.

## Effect after merge

flows.py changed → `cd-prefect3 (production)` redeploys the flow (the armed schedule persists via backend sync, since the deployment is already known). The next daily run then calls `register_table_materialization_task` for these four tables too: it recomputes `free_end = source_max − 6 months`, rewrites both DateTimeRanges, and issues the two BigQuery Row Access Policies (`bdpro_filter`, `allusers_filter`). The window rolls itself on every subsequent run.

**No dbt/model change** — the paywall is enforced by Row Access Policies in BigQuery, not SQL. Scope: 1 file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Senate open-data coverage documentation to reflect 18 available tables.
  * Clarified that 10 dimension tables use full refreshes and 8 time-series tables use recent-window coverage.
  * Updated BD Pro documentation to include 8 time-series tables.
  * Added coverage details for committee reports, voting records, parliamentary committee votes, and speeches, using six-month rolling windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->