### PR TITLE
fix(fr_insee_sirene): french staging table names so table-approve resolves

### DIFF
--- a/models/br_bd_diretorios_fr/br_bd_diretorios_fr__categorie_juridique.sql
+++ b/models/br_bd_diretorios_fr/br_bd_diretorios_fr__categorie_juridique.sql
@@ -12,4 +12,4 @@ select
     safe_cast(descricao_nivel_2 as string) descricao_nivel_2,
     safe_cast(id_nivel_1 as string) id_nivel_1,
     safe_cast(descricao_nivel_1 as string) descricao_nivel_1
-from {{ set_datalake_project("br_bd_diretorios_fr_staging.categoria_juridica") }} as t
+from {{ set_datalake_project("br_bd_diretorios_fr_staging.categorie_juridique") }} as t

--- a/models/br_bd_diretorios_fr/br_bd_diretorios_fr__commune.sql
+++ b/models/br_bd_diretorios_fr/br_bd_diretorios_fr__commune.sql
@@ -11,4 +11,4 @@ select
     safe_cast(id_regiao as string) id_regiao,
     safe_cast(nome_comuna as string) nome_comuna,
     safe_cast(tipo_comuna as string) tipo_comuna
-from {{ set_datalake_project("br_bd_diretorios_fr_staging.comuna") }} as t
+from {{ set_datalake_project("br_bd_diretorios_fr_staging.commune") }} as t

--- a/models/br_bd_diretorios_fr/br_bd_diretorios_fr__departement.sql
+++ b/models/br_bd_diretorios_fr/br_bd_diretorios_fr__departement.sql
@@ -10,4 +10,4 @@ select
     safe_cast(id_regiao as string) id_regiao,
     safe_cast(id_comuna_sede as string) id_comuna_sede,
     safe_cast(nome_departamento as string) nome_departamento
-from {{ set_datalake_project("br_bd_diretorios_fr_staging.departamento") }} as t
+from {{ set_datalake_project("br_bd_diretorios_fr_staging.departement") }} as t

--- a/models/br_bd_diretorios_fr/br_bd_diretorios_fr__region.sql
+++ b/models/br_bd_diretorios_fr/br_bd_diretorios_fr__region.sql
@@ -10,4 +10,4 @@ select
     safe_cast(id_comuna_sede as string) id_comuna_sede,
     safe_cast(nome_regiao as string) nome_regiao,
     safe_cast(nome_regiao_maiusculo as string) nome_regiao_maiusculo
-from {{ set_datalake_project("br_bd_diretorios_fr_staging.regiao") }} as t
+from {{ set_datalake_project("br_bd_diretorios_fr_staging.region") }} as t

--- a/models/fr_insee_sirene/code/gen_dbt.py
+++ b/models/fr_insee_sirene/code/gen_dbt.py
@@ -13,14 +13,11 @@ MODELS_DIR = Path(__file__).resolve().parents[1]  # models/fr_insee_sirene
 CLUSTER = {
     "unite_legale": "siren",
     "etablissement": "siret",
-    "unite_legale_historico": "siren",
-    "etablissement_historico": "siret",
+    "unite_legale_historique": "siren",
+    "etablissement_historique": "siret",
 }
-# Output/prod table slug (French). Staging source keeps the schema_map key name.
-OUT_ALIAS = {
-    "unite_legale_historico": "unite_legale_historique",
-    "etablissement_historico": "etablissement_historique",
-}
+# schema_map keys are the French slugs (== staging source == output alias).
+OUT_ALIAS: dict[str, str] = {}
 CAST = {
     "STRING": "string",
     "DATE": "date",

--- a/models/fr_insee_sirene/code/schema_map.py
+++ b/models/fr_insee_sirene/code/schema_map.py
@@ -379,6 +379,6 @@ ETABLISSEMENT_HISTORICO = {
 TABLES = {
     "unite_legale": UNITE_LEGALE,
     "etablissement": ETABLISSEMENT,
-    "unite_legale_historico": UNITE_LEGALE_HISTORICO,
-    "etablissement_historico": ETABLISSEMENT_HISTORICO,
+    "unite_legale_historique": UNITE_LEGALE_HISTORICO,
+    "etablissement_historique": ETABLISSEMENT_HISTORICO,
 }

--- a/models/fr_insee_sirene/fr_insee_sirene__etablissement_historique.sql
+++ b/models/fr_insee_sirene/fr_insee_sirene__etablissement_historique.sql
@@ -35,4 +35,4 @@ select
     safe_cast(changement_activite_principale as string) changement_activite_principale,
     safe_cast(caractere_employeur as string) caractere_employeur,
     safe_cast(changement_caractere_employeur as string) changement_caractere_employeur
-from {{ set_datalake_project("fr_insee_sirene_staging.etablissement_historico") }} as t
+from {{ set_datalake_project("fr_insee_sirene_staging.etablissement_historique") }} as t

--- a/models/fr_insee_sirene/fr_insee_sirene__unite_legale_historique.sql
+++ b/models/fr_insee_sirene/fr_insee_sirene__unite_legale_historique.sql
@@ -47,4 +47,4 @@ select
     safe_cast(changement_caractere_employeur as string) changement_caractere_employeur,
     safe_cast(societe_mission as string) societe_mission,
     safe_cast(changement_societe_mission as string) changement_societe_mission
-from {{ set_datalake_project("fr_insee_sirene_staging.unite_legale_historico") }} as t
+from {{ set_datalake_project("fr_insee_sirene_staging.unite_legale_historique") }} as t


### PR DESCRIPTION
## Fix: French staging table names for `fr_insee_sirene` + `br_bd_diretorios_fr`

Follow-up to #1794. That merge's table-approve failed to materialize because the 6 tables renamed to French slugs kept **Portuguese** staging-table names, so the `dev → basedosdados-staging` bridge (which keys off the French model alias) couldn't find their source:

```
Database Error in model br_bd_diretorios_fr__categorie_juridique
  Not found: Table basedosdados-staging:br_bd_diretorios_fr_staging.categoria_juridica
```

This PR points each model's `FROM` at the **French** staging name, matching the output slug:

| model | staging `FROM` (was → now) |
|---|---|
| region | `regiao` → `region` |
| departement | `departamento` → `departement` |
| commune | `comuna` → `commune` |
| categorie_juridique | `categoria_juridica` → `categorie_juridique` |
| unite_legale_historique | `unite_legale_historico` → `unite_legale_historique` |
| etablissement_historique | `etablissement_historico` → `etablissement_historique` |

The dev staging tables + GCS folders were renamed to French to match (server-side, no re-upload), and the generators (`schema_map.py`, `gen_dbt.py`) updated so staging = output = French, consistently. Validated with `dbt run --select br_bd_diretorios_fr` (PASS=6) against the French staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected source table references for French administrative and legal-category data.
  * Standardized historical business registry naming to use the `_historique` convention.
  * Updated data mappings to ensure historical establishment and legal-unit records are sourced correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->