### PR TITLE
feat(us_cfpb_hmda): add annual recurring Prefect pipeline

### DIFF
--- a/pipelines/datasets/us_cfpb_hmda/constants.py
+++ b/pipelines/datasets/us_cfpb_hmda/constants.py
@@ -1,0 +1,46 @@
+"""Constants for the us_cfpb_hmda recurring pipeline (Prefect 3).
+
+HMDA Loan/Application Register (CFPB/FFIEC). Only the modern table
+`loan_application_register` (2018+) refreshes: CFPB publishes one new year's
+Snapshot National Loan-Level Dataset annually (~mid-year). The legacy table
+(2007-2017) and the dicionario are frozen and are NOT touched by this pipeline.
+
+The modern Snapshot files are immutable per year, so each run is a full replace
+(dump_mode="overwrite") that re-cleans every modern year 2018..N into all-STRING
+partitioned parquet. Overwrite keeps the staging schema consistently all-STRING
+(the dbt model safe_casts) and mirrors the us_bls_cpi pattern; the per-year
+streaming clean keeps peak disk/RAM low. See models/us_cfpb_hmda/CLAUDE.md.
+
+Schema/column order/x1000 rules come from the architecture TSV - the single
+source of truth shared with the one-shot bootstrap under models/us_cfpb_hmda/code.
+"""
+
+from enum import Enum
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class constants(Enum):
+    """Constants for the us_cfpb_hmda pipeline (lowercase per repo convention)."""
+
+    DATASET_ID = "us_cfpb_hmda"
+    TABLE_ID = (
+        "loan_application_register"  # the only table this pipeline refreshes
+    )
+
+    # data-browser nationwide CSV endpoint: 301 -> pre-generated per-year CSV on
+    # files.ffiec.cfpb.gov. The `/nationwide/` variant needs no geo/LEI filter.
+    MODERN_URL = "https://ffiec.cfpb.gov/v2/data-browser-api/view/nationwide/csv?years={year}"
+    FIRST_YEAR = 2018  # modern (post-2017) schema starts here
+
+    # Architecture TSV = schema source of truth (name, bigquery_type, original_name).
+    ARCHITECTURE_TSV = (
+        _REPO_ROOT
+        / "models"
+        / "us_cfpb_hmda"
+        / "code"
+        / "sheet_loan_application_register.tsv"
+    )
+    # Columns reported in thousands of dollars -> x1000 so measurement_unit=USD holds.
+    MULTIPLY_1000 = ("income",)

--- a/pipelines/datasets/us_cfpb_hmda/flows.py
+++ b/pipelines/datasets/us_cfpb_hmda/flows.py
@@ -1,0 +1,160 @@
+"""Flows for us_cfpb_hmda - Prefect 3.
+
+Home Mortgage Disclosure Act LAR (CFPB/FFIEC). Only the modern table
+`loan_application_register` (2018+) refreshes; CFPB publishes one new year's
+Snapshot National Loan-Level Dataset annually (~mid-year). The legacy table
+(2007-2017) and the dicionario are frozen and are not materialized here.
+
+The modern Snapshot files are immutable per year, so each run is a full replace
+(dump_mode="overwrite") that re-cleans every modern year 2018..N into all-STRING
+partitioned parquet - this keeps the staging schema consistently all-STRING and
+mirrors us_bls_cpi. The source poll makes a scheduled run a no-op until CFPB
+publishes a newer year. (Future optimization: append only the new year, which
+would first require migrating the existing typed staging to all-STRING.)
+
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers `us_cfpb_hmda_flow`; the
+dev pool ignores the schedule, the prod pool activates it (deployed paused).
+"""
+
+import shutil
+import tempfile
+from datetime import UTC, datetime
+
+from prefect import flow
+
+from pipelines.datasets.us_cfpb_hmda.constants import constants
+from pipelines.datasets.us_cfpb_hmda.tasks import build_tables, resolve_years
+from pipelines.utils.metadata.domain import AllFree, DateFormat, YearOnly
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+TABLE_ID = constants.TABLE_ID.value
+
+# Annual, fully public -> free coverage keyed on the year column.
+_COVERAGE = AllFree(
+    date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
+)
+
+
+@flow(name="us_cfpb_hmda", log_prints=True)
+def us_cfpb_hmda_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+) -> None:
+    """Refresh `loan_application_register` when CFPB publishes a new modern year.
+
+    Args:
+        materialize_to_prod: Continue past the dev materialization to write the
+            prod staging bucket and run dbt against target="prod". Set False to
+            exercise only the dev half - required for a safe test run.
+        update_metadata: After a successful prod materialization, register table
+            coverage and commit the source update. No effect when
+            materialize_to_prod is False.
+        force_run: Materialize even when the source poll reports no new year.
+    """
+    # pyrefly: ignore [unused-coroutine]
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id=TABLE_ID
+    )
+
+    this_year = datetime.now(UTC).year
+    resolved = resolve_years(this_year)
+    max_year = resolved["max_year"]
+
+    # Skip unless CFPB has published a year beyond current coverage (unless forced).
+    has_new_data = poll_source_for_update_task(
+        dataset_id=DATASET_ID,
+        table_id=TABLE_ID,
+        source_max_date=str(max_year),
+        env="prod",
+        date_format="%Y",
+        compare_against="coverage",
+    )
+    if not has_new_data and not force_run:
+        return
+
+    # Commit the source Update up front: if the run fails mid-way, source
+    # metadata still reflects that a new year was published.
+    commit_source_update_task(
+        dataset_id=DATASET_ID,
+        table_id=TABLE_ID,
+        source_max_date=str(max_year),
+        env="prod",
+        date_format="%Y",
+        update_metadata=update_metadata,
+        materialize_after_dump=materialize_to_prod,
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="us_cfpb_hmda_")
+    try:
+        result = build_tables(work_dir=work_dir, years=resolved["years"])
+        data_path = result[TABLE_ID]
+
+        # Dev: upload staging (overwrite -> clean all-STRING schema) + materialize.
+        upload_to_gcs(
+            data_path=data_path,
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            bucket_name="basedosdados-dev",
+            dump_mode="overwrite",
+            source_format="parquet",
+        )
+        run_dbt(
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            dbt_command="run/test",
+            target="dev",
+        )
+
+        if not materialize_to_prod:
+            return
+
+        # Prod: upload staging + materialize/test.
+        upload_to_gcs(
+            data_path=data_path,
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            bucket_name="basedosdados",
+            dump_mode="overwrite",
+            source_format="parquet",
+        )
+        run_dbt(
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            dbt_command="run/test",
+            target="prod",
+        )
+
+        if update_metadata:
+            register_table_materialization_task(
+                dataset_id=DATASET_ID,
+                table_id=TABLE_ID,
+                coverage=_COVERAGE,
+                env="prod",
+                bq_project="basedosdados",
+            )
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# CFPB releases the Snapshot National Loan-Level Dataset annually, ~mid-year
+# (spring-summer). Poll a few days per month across Mar-Aug at 16:00 BRT; the
+# source-poll guard no-ops until a new year actually appears.
+# pyrefly: ignore [missing-attribute]
+us_cfpb_hmda_flow.deploy_schedules = [
+    {"cron": "0 16 8,9,10 3,4,5,6,7,8 *", "timezone": "America/Sao_Paulo"}
+]
+# Clean is out-of-core (~0.8 GB), but the download is several GB per year; give
+# the worker headroom. Peak disk ~ one raw CSV (~5 GB) + all-year parquet (~6 GB).
+# pyrefly: ignore [missing-attribute]
+us_cfpb_hmda_flow.job_variables = {"memory": "8Gi"}

--- a/pipelines/datasets/us_cfpb_hmda/tasks.py
+++ b/pipelines/datasets/us_cfpb_hmda/tasks.py
@@ -1,0 +1,41 @@
+"""Prefect 3 tasks for us_cfpb_hmda - thin wrappers over utils.py."""
+
+from pathlib import Path
+
+from prefect import task
+
+from pipelines.datasets.us_cfpb_hmda.constants import constants
+from pipelines.datasets.us_cfpb_hmda.utils import clean_all, latest_source_year
+
+
+@task
+def resolve_years(this_year: int) -> dict:
+    """Find the latest published modern year and the full 2018..latest range.
+
+    Args:
+        this_year: Current calendar year (passed by the flow).
+
+    Returns:
+        {"max_year": int, "years": list[int]} covering FIRST_YEAR..max_year.
+    """
+    max_year = latest_source_year(this_year)
+    years = list(range(constants.FIRST_YEAR.value, max_year + 1))
+    return {"max_year": max_year, "years": years}
+
+
+@task
+def build_tables(work_dir: str, years: list[int]) -> dict:
+    """Download + clean every modern year into all-STRING partitioned parquet.
+
+    Years are streamed one at a time (raw CSV deleted after each clean), so peak
+    disk stays near a single ~4-5 GB file.
+
+    Args:
+        work_dir: Scratch dir; input under <work_dir>/input, output under <work_dir>/output.
+        years: Modern years to (re)build.
+
+    Returns:
+        {"loan_application_register": <partition dir str>, "max_year": "<YYYY>"}.
+    """
+    base = Path(work_dir)
+    return clean_all(base / "output", years, base / "input")

--- a/pipelines/datasets/us_cfpb_hmda/utils.py
+++ b/pipelines/datasets/us_cfpb_hmda/utils.py
@@ -92,8 +92,17 @@ def download_year(year: int, input_dir: Path) -> Path:
     dest = input_dir / f"modern_{year}.csv"
     tmp = dest.with_suffix(".csv.part")
     cmd = [
-        "curl", "-fL", "--retry", "4", "--retry-delay", "5",
-        "--connect-timeout", "30", "-o", str(tmp), MODERN_URL.format(year=year),
+        "curl",
+        "-fL",
+        "--retry",
+        "4",
+        "--retry-delay",
+        "5",
+        "--connect-timeout",
+        "30",
+        "-o",
+        str(tmp),
+        MODERN_URL.format(year=year),
     ]
     subprocess.run(cmd, check=True)
     tmp.rename(dest)
@@ -115,8 +124,11 @@ def _expr(col: dict, present: set[str]) -> pl.Expr:
     s = pl.col(col["original_name"]).str.strip_chars()
     if typ == "STRING":
         return (
-            pl.when(s.str.len_chars() == 0).then(None).otherwise(s)
-            .cast(pl.Utf8).alias(name)
+            pl.when(s.str.len_chars() == 0)
+            .then(None)
+            .otherwise(s)
+            .cast(pl.Utf8)
+            .alias(name)
         )
     num = s.cast(PL_NUM[typ], strict=False)
     if name in MULTIPLY_1000:

--- a/pipelines/datasets/us_cfpb_hmda/utils.py
+++ b/pipelines/datasets/us_cfpb_hmda/utils.py
@@ -3,31 +3,31 @@
 Download + clean the modern HMDA LAR (2018+) into all-STRING, year-partitioned
 parquet. Schema, column order, the raw->clean name map, and the x1000 rule come
 from the architecture TSV (constants.ARCHITECTURE_TSV) - the single source of
-truth shared with the one-shot bootstrap in models/us_cfpb_hmda/code. The typed
-transform here mirrors models/us_cfpb_hmda/code/clean.py; the only difference is
-this writes all-STRING parquet (staging convention - see write note below) while
-keeping the `year` column in-file.
+truth shared with the one-shot bootstrap in models/us_cfpb_hmda/code.
 
-Memory: duckdb streams the COPY with preserve_insertion_order=false, so a 4-5 GB
-CSV cleans at ~0.8 GB RSS. Years are processed one at a time and the raw CSV is
-deleted right after its clean, so peak disk stays near a single raw file.
+Cleaning uses polars' streaming engine (scan_csv -> select -> sink_parquet), which
+is memory-bounded (a 4-5 GB CSV cleans well under the worker's 8 GB) and, unlike
+duckdb, is already in the deployed worker image. Output is all-STRING (the staging
+convention: upload_to_gcs infers a STRING header, and the dbt model safe_casts
+each column back to its architecture type); numeric coercion drops the source
+sentinels (NA/Exempt/blank) to NULL, and NULL stays NULL through the string cast.
+The `year` column is kept in-file. Years are processed one at a time and the raw
+CSV is deleted right after its clean, so peak disk stays near a single raw file.
 """
 
 import csv
 import subprocess
 from pathlib import Path
 
-import duckdb
-import requests
+import polars as pl
 
 from pipelines.datasets.us_cfpb_hmda.constants import constants
 
-DATASET_ID = constants.DATASET_ID.value
 TABLE_ID = constants.TABLE_ID.value
 FIRST_YEAR = constants.FIRST_YEAR.value
 MODERN_URL = constants.MODERN_URL.value
 MULTIPLY_1000 = set(constants.MULTIPLY_1000.value)
-BQ_TO_DUCK = {"INT64": "BIGINT", "FLOAT64": "DOUBLE", "STRING": "VARCHAR"}
+PL_NUM = {"INT64": pl.Int64, "FLOAT64": pl.Float64}
 
 
 def read_arch() -> list[dict]:
@@ -43,16 +43,21 @@ def read_arch() -> list[dict]:
         ]
 
 
+def _header(csv_path: Path) -> set[str]:
+    with open(csv_path, encoding="utf-8-sig", newline="") as fh:
+        return set(next(csv.reader(fh)))
+
+
 def latest_source_year(this_year: int) -> int:
     """Highest modern year CFPB has published, probed from this_year down.
 
     The nationwide endpoint 301-redirects to a real CSV for a published year and
-    returns a small/error body otherwise. We stream a few KB and accept the year
-    only if the payload starts with the expected `activity_year,lei,...` header.
+    returns a small/error body otherwise; we accept a year only if the streamed
+    head starts with the expected `activity_year,lei,...` header.
 
     Args:
-        this_year: Calendar year to start probing down from (caller passes it so
-            the flow controls "now"; keeps this function free of clock calls).
+        this_year: Calendar year to start probing down from (the flow passes it,
+            keeping this function free of clock calls).
 
     Returns:
         The latest published modern year (>= FIRST_YEAR).
@@ -60,6 +65,8 @@ def latest_source_year(this_year: int) -> int:
     Raises:
         RuntimeError: If no published year is found down to FIRST_YEAR.
     """
+    import requests
+
     for y in range(this_year, FIRST_YEAR - 1, -1):
         try:
             with requests.get(
@@ -85,84 +92,63 @@ def download_year(year: int, input_dir: Path) -> Path:
     dest = input_dir / f"modern_{year}.csv"
     tmp = dest.with_suffix(".csv.part")
     cmd = [
-        "curl",
-        "-fL",
-        "--retry",
-        "4",
-        "--retry-delay",
-        "5",
-        "--connect-timeout",
-        "30",
-        "-o",
-        str(tmp),
-        MODERN_URL.format(year=year),
+        "curl", "-fL", "--retry", "4", "--retry-delay", "5",
+        "--connect-timeout", "30", "-o", str(tmp), MODERN_URL.format(year=year),
     ]
     subprocess.run(cmd, check=True)
     tmp.rename(dest)
     return dest
 
 
-def _expr(col: dict, present: set[str]) -> str:
-    """Typed transform for one column, then cast to VARCHAR (all-STRING staging).
+def _expr(col: dict, present: set[str]) -> pl.Expr:
+    """Polars expression for one column -> all-STRING output aliased to `name`.
 
-    STRING -> trimmed, blank -> NULL. INT64/FLOAT64 -> TRY_CAST (source
-    sentinels NA/Exempt/blank -> NULL); x1000 columns scaled to real USD. The
-    outer CAST(... AS VARCHAR) keeps NULL as NULL (never the string "nan"), which
-    the dbt model then safe_casts back to the architecture type.
+    STRING -> trimmed, blank -> NULL, raw codes kept. INT64/FLOAT64 -> non-strict
+    numeric cast (source sentinels NA/Exempt/blank -> NULL); x1000 columns scaled
+    to real USD. The final cast to Utf8 keeps NULL as NULL (never "nan"), which
+    the dbt model then safe_casts back to the architecture type. Columns absent
+    from a given year's header become typed NULLs.
     """
-    q = '"' + col["original_name"].replace('"', '""') + '"'
     name, typ = col["name"], col["bigquery_type"]
     if col["original_name"] not in present:
-        return f"CAST(NULL AS VARCHAR) AS {name}"
+        return pl.lit(None, dtype=pl.Utf8).alias(name)
+    s = pl.col(col["original_name"]).str.strip_chars()
     if typ == "STRING":
-        inner = f"nullif(trim({q}), '')"
-    else:
-        inner = f"TRY_CAST(nullif(trim({q}), '') AS {BQ_TO_DUCK[typ]})"
-        if name in MULTIPLY_1000:
-            inner = f"({inner}) * 1000"
-    return f"CAST({inner} AS VARCHAR) AS {name}"
+        return (
+            pl.when(s.str.len_chars() == 0).then(None).otherwise(s)
+            .cast(pl.Utf8).alias(name)
+        )
+    num = s.cast(PL_NUM[typ], strict=False)
+    if name in MULTIPLY_1000:
+        num = num * 1000
+    return num.cast(pl.Utf8).alias(name)
 
 
 def clean_year(year: int, csv_path: Path, output_dir: Path) -> Path:
     """Clean one year's CSV into all-STRING parquet at
     output_dir/loan_application_register/year=<year>/data.parquet (year in-file)."""
     cols = read_arch()  # includes `year`
-    with open(csv_path, encoding="utf-8-sig", newline="") as fh:
-        present = set(next(csv.reader(fh)))
-    exprs = ",\n    ".join(_expr(c, present) for c in cols)
+    present = _header(csv_path)
+    lf = pl.scan_csv(
+        csv_path,
+        separator=",",
+        has_header=True,
+        infer_schema_length=0,  # read every column as Utf8
+        quote_char='"',
+        truncate_ragged_lines=True,
+    ).select([_expr(c, present) for c in cols])
+
     out_dir = output_dir / TABLE_ID / f"year={year}"
     out_dir.mkdir(parents=True, exist_ok=True)
     out = out_dir / "data.parquet"
-    tmp = output_dir / "duck_tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-
-    con = duckdb.connect()
-    con.execute("SET preserve_insertion_order=false")
-    con.execute("SET threads=2")
-    con.execute("SET memory_limit='4GB'")
-    con.execute(f"SET temp_directory='{tmp}'")
-    read = (
-        f"read_csv('{csv_path}', header=true, all_varchar=true, sample_size=-1, "
-        f"quote='\"', escape='\"', null_padding=true, ignore_errors=false)"
-    )
-    con.execute(
-        f"COPY (SELECT\n    {exprs}\n FROM {read}) "
-        f"TO '{out}' (FORMAT PARQUET, COMPRESSION SNAPPY, ROW_GROUP_SIZE 100000)"
-    )
-    con.close()
+    lf.sink_parquet(out, compression="snappy", row_group_size=100_000)
     return out
 
 
 def clean_all(output_dir: Path, years: list[int], input_dir: Path) -> dict:
     """Download+clean each modern year one at a time (deleting each raw CSV after).
 
-    Args:
-        output_dir: Root for partitioned output.
-        years: Modern years to process (2018..latest).
-        input_dir: Where raw CSVs land (deleted per year after cleaning).
-
-    Returns:
-        {"loan_application_register": <partition dir>, "max_year": "<YYYY>"}.
+    Returns {"loan_application_register": <partition dir>, "max_year": "<YYYY>"}.
     """
     for y in years:
         csv_path = download_year(y, input_dir)

--- a/pipelines/datasets/us_cfpb_hmda/utils.py
+++ b/pipelines/datasets/us_cfpb_hmda/utils.py
@@ -1,0 +1,171 @@
+"""Pure functions for us_cfpb_hmda - no Prefect imports.
+
+Download + clean the modern HMDA LAR (2018+) into all-STRING, year-partitioned
+parquet. Schema, column order, the raw->clean name map, and the x1000 rule come
+from the architecture TSV (constants.ARCHITECTURE_TSV) - the single source of
+truth shared with the one-shot bootstrap in models/us_cfpb_hmda/code. The typed
+transform here mirrors models/us_cfpb_hmda/code/clean.py; the only difference is
+this writes all-STRING parquet (staging convention - see write note below) while
+keeping the `year` column in-file.
+
+Memory: duckdb streams the COPY with preserve_insertion_order=false, so a 4-5 GB
+CSV cleans at ~0.8 GB RSS. Years are processed one at a time and the raw CSV is
+deleted right after its clean, so peak disk stays near a single raw file.
+"""
+
+import csv
+import subprocess
+from pathlib import Path
+
+import duckdb
+import requests
+
+from pipelines.datasets.us_cfpb_hmda.constants import constants
+
+DATASET_ID = constants.DATASET_ID.value
+TABLE_ID = constants.TABLE_ID.value
+FIRST_YEAR = constants.FIRST_YEAR.value
+MODERN_URL = constants.MODERN_URL.value
+MULTIPLY_1000 = set(constants.MULTIPLY_1000.value)
+BQ_TO_DUCK = {"INT64": "BIGINT", "FLOAT64": "DOUBLE", "STRING": "VARCHAR"}
+
+
+def read_arch() -> list[dict]:
+    """Read the architecture TSV: ordered [{name, bigquery_type, original_name}]."""
+    with open(constants.ARCHITECTURE_TSV.value, encoding="utf-8") as fh:
+        return [
+            {
+                "name": r["name"].strip(),
+                "bigquery_type": r["bigquery_type"].strip().upper(),
+                "original_name": r["original_name"].strip(),
+            }
+            for r in csv.DictReader(fh, delimiter="\t")
+        ]
+
+
+def latest_source_year(this_year: int) -> int:
+    """Highest modern year CFPB has published, probed from this_year down.
+
+    The nationwide endpoint 301-redirects to a real CSV for a published year and
+    returns a small/error body otherwise. We stream a few KB and accept the year
+    only if the payload starts with the expected `activity_year,lei,...` header.
+
+    Args:
+        this_year: Calendar year to start probing down from (caller passes it so
+            the flow controls "now"; keeps this function free of clock calls).
+
+    Returns:
+        The latest published modern year (>= FIRST_YEAR).
+
+    Raises:
+        RuntimeError: If no published year is found down to FIRST_YEAR.
+    """
+    for y in range(this_year, FIRST_YEAR - 1, -1):
+        try:
+            with requests.get(
+                MODERN_URL.format(year=y), stream=True, timeout=120
+            ) as r:
+                if r.status_code != 200:
+                    continue
+                head = next(r.iter_content(chunk_size=2048), b"").decode(
+                    "utf-8", "ignore"
+                )
+            if head.lstrip().startswith("activity_year,lei,"):
+                return y
+        except requests.RequestException:
+            continue
+    raise RuntimeError(
+        f"no published HMDA modern year found down to {FIRST_YEAR}"
+    )
+
+
+def download_year(year: int, input_dir: Path) -> Path:
+    """Download one modern year's nationwide CSV to input_dir/modern_<year>.csv."""
+    input_dir.mkdir(parents=True, exist_ok=True)
+    dest = input_dir / f"modern_{year}.csv"
+    tmp = dest.with_suffix(".csv.part")
+    cmd = [
+        "curl",
+        "-fL",
+        "--retry",
+        "4",
+        "--retry-delay",
+        "5",
+        "--connect-timeout",
+        "30",
+        "-o",
+        str(tmp),
+        MODERN_URL.format(year=year),
+    ]
+    subprocess.run(cmd, check=True)
+    tmp.rename(dest)
+    return dest
+
+
+def _expr(col: dict, present: set[str]) -> str:
+    """Typed transform for one column, then cast to VARCHAR (all-STRING staging).
+
+    STRING -> trimmed, blank -> NULL. INT64/FLOAT64 -> TRY_CAST (source
+    sentinels NA/Exempt/blank -> NULL); x1000 columns scaled to real USD. The
+    outer CAST(... AS VARCHAR) keeps NULL as NULL (never the string "nan"), which
+    the dbt model then safe_casts back to the architecture type.
+    """
+    q = '"' + col["original_name"].replace('"', '""') + '"'
+    name, typ = col["name"], col["bigquery_type"]
+    if col["original_name"] not in present:
+        return f"CAST(NULL AS VARCHAR) AS {name}"
+    if typ == "STRING":
+        inner = f"nullif(trim({q}), '')"
+    else:
+        inner = f"TRY_CAST(nullif(trim({q}), '') AS {BQ_TO_DUCK[typ]})"
+        if name in MULTIPLY_1000:
+            inner = f"({inner}) * 1000"
+    return f"CAST({inner} AS VARCHAR) AS {name}"
+
+
+def clean_year(year: int, csv_path: Path, output_dir: Path) -> Path:
+    """Clean one year's CSV into all-STRING parquet at
+    output_dir/loan_application_register/year=<year>/data.parquet (year in-file)."""
+    cols = read_arch()  # includes `year`
+    with open(csv_path, encoding="utf-8-sig", newline="") as fh:
+        present = set(next(csv.reader(fh)))
+    exprs = ",\n    ".join(_expr(c, present) for c in cols)
+    out_dir = output_dir / TABLE_ID / f"year={year}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / "data.parquet"
+    tmp = output_dir / "duck_tmp"
+    tmp.mkdir(parents=True, exist_ok=True)
+
+    con = duckdb.connect()
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET threads=2")
+    con.execute("SET memory_limit='4GB'")
+    con.execute(f"SET temp_directory='{tmp}'")
+    read = (
+        f"read_csv('{csv_path}', header=true, all_varchar=true, sample_size=-1, "
+        f"quote='\"', escape='\"', null_padding=true, ignore_errors=false)"
+    )
+    con.execute(
+        f"COPY (SELECT\n    {exprs}\n FROM {read}) "
+        f"TO '{out}' (FORMAT PARQUET, COMPRESSION SNAPPY, ROW_GROUP_SIZE 100000)"
+    )
+    con.close()
+    return out
+
+
+def clean_all(output_dir: Path, years: list[int], input_dir: Path) -> dict:
+    """Download+clean each modern year one at a time (deleting each raw CSV after).
+
+    Args:
+        output_dir: Root for partitioned output.
+        years: Modern years to process (2018..latest).
+        input_dir: Where raw CSVs land (deleted per year after cleaning).
+
+    Returns:
+        {"loan_application_register": <partition dir>, "max_year": "<YYYY>"}.
+    """
+    for y in years:
+        csv_path = download_year(y, input_dir)
+        clean_year(y, csv_path, output_dir)
+        csv_path.unlink(missing_ok=True)
+    return {TABLE_ID: str(output_dir / TABLE_ID), "max_year": str(max(years))}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "distributed==2021.11.2",
   "docker>=6,<7",
   "docopt==0.6.2",
+  "duckdb>=1.0.0",
   "fake-useragent<2.0.0,>=1.1.3",
   "fsspec>=2022.5.0",
   "google-analytics-data==0.17.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
   "distributed==2021.11.2",
   "docker>=6,<7",
   "docopt==0.6.2",
-  "duckdb>=1.0.0",
   "fake-useragent<2.0.0,>=1.1.3",
   "fsspec>=2022.5.0",
   "google-analytics-data==0.17.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1218,34 +1218,6 @@ wheels = [
 ]
 
 [[package]]
-name = "duckdb"
-version = "1.5.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/19/e57151753576373c6696a12022648546cca6038e8833fda2908ee2342d9b/duckdb-1.5.5.tar.gz", hash = "sha256:72f33ee57ca7595b23957671a2cc7f7fe2be0ecc2d68f63abedcfcaa3a5c1238", size = 18066741, upload-time = "2026-07-22T10:55:17.819Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/d4/298acf9331a80b3ce6ac64dd940e7e13f4058fb69d18914445f02e3c7bfe/duckdb-1.5.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b805507f88171b428b21c966c30e9a3d54e30b24528918a44ed0032542bc26f", size = 32702934, upload-time = "2026-07-22T10:53:19.069Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/90/c489fb63d64b2e7ee109ce8460bdede003a0f256e5b41a03a2a1c4764058/duckdb-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b08e19cc856220d8a26fa62abc2264b349aff67255e9373c6a3f607addd56dc6", size = 17343604, upload-time = "2026-07-22T10:53:22.767Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/27/effa80a15b1f0c61c235622f797868485359e8c9ad6a8e358e7a0c479151/duckdb-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a17e6a922e42a5c06ed2353fe78c5dff2610f6632d603836f9606ad0bf754079", size = 15488179, upload-time = "2026-07-22T10:53:25.945Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/07/21212345c8d24ba62dceaa20be3b21f5c46f1510b1b42ce93bb058afe0c4/duckdb-1.5.5-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bdc38922c365c37720149f90d90b1e9823eb82dad6830855b5f87537fa6fc0c", size = 19367323, upload-time = "2026-07-22T10:53:30.23Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/d0/10371ae875fb4b5ef61bb892743b4b2e90c512b371fdf29317deb744857d/duckdb-1.5.5-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e238060db5ca59879882a6e9b015e2c65d5c64ddf281ba1d7a9a2033764152cf", size = 21476568, upload-time = "2026-07-22T10:53:33.486Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/35/09568ce617dd7bc0757b3d7b6a981660b9e4f0b7594de8ed776755eae740/duckdb-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:4acc72798ba1885a9c17d1242903d2cd502f13b1271c7677f7cab25d8578eceb", size = 13156129, upload-time = "2026-07-22T10:53:37.55Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/c2/b62ec24d57bb8df4e24b0b58f7f8facb32f5fdb9f1895aed9e9fcdded168/duckdb-1.5.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1b543841b0ae18a9c982345cfa3987e9c065d3a4b0f067daa473d92d1e65f528", size = 32708371, upload-time = "2026-07-22T10:53:41.642Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/ce/769171ba45f0b73632dc3bc3108d891e81dd6c6bbfba630a34a75b4dcc0f/duckdb-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a925d06c2a4c3b64553d6cc1aced5028d376d4479bed689a7d47e9b1dccd80a", size = 17343979, upload-time = "2026-07-22T10:53:44.951Z" },
-    { url = "https://files.pythonhosted.org/packages/46/59/a8e3384ee916e00d5dcf985194c1511d61978540778a1e96fa47f9fb3e0d/duckdb-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0c42757cb34722144bd4dfb94b6f336339e7b2468f6813fa7fa9a319ba07bab4", size = 15493704, upload-time = "2026-07-22T10:53:47.912Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/1d/9840179c2607b90523a2884a129c4d4e6dbdc1178ba62a976c1043beba88/duckdb-1.5.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e72f9e1a4f90a5c8483ad4d540e495bf0834ba61c360b52499a573d7ed62a3f", size = 19366574, upload-time = "2026-07-22T10:53:51.876Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/55/f9641a4eebcc2f4df631287d6c3b9ed2eea3b92644f93acbad825e3972b6/duckdb-1.5.5-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b6f86ed85d4ef5e0211eaebf75d057bd8bb520bba438a95dd0f4e42234bbfe", size = 21477952, upload-time = "2026-07-22T10:53:55.575Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/3a/07c3556e37a5c97b95917b029c8fdde4a25fbd76a660bacdac195cf20dcb/duckdb-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:9f4287f97ccf0c1f3d471e7115be2b067cbf99627e2d34bffd462dd64703cddc", size = 13156986, upload-time = "2026-07-22T10:53:58.823Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/ff/07b48eef2078ca033847e9caa46cc7633b714c5f91ad1ce091c8ca89d792/duckdb-1.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:179633a3fc6296c75d57c69c1e239fa9e5cdcb670fd1dbff88a02663f932905c", size = 14001317, upload-time = "2026-07-22T10:54:01.724Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/40/2e05d324400fdaa5656c9f48d6298da421cb034d85e509fa0e6e325cf04b/duckdb-1.5.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d4dd65f8941a604b947e0b9b4b4f7165988e29a23ec0b69b4038520956d9933e", size = 32753858, upload-time = "2026-07-22T10:54:05.514Z" },
-    { url = "https://files.pythonhosted.org/packages/79/15/5ceb58ffb5bb8a62b3fd7abb39c41467cdf94850ece02e6d88664dfc75ce/duckdb-1.5.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33db46679b071f108d57139493dee2d37e1f5efcf5c5c039c2969eed11a6c8a7", size = 17368293, upload-time = "2026-07-22T10:54:09.139Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/5c/bf02da0b354fe83cca4f95a4fbf762181af466f7d551ab2a093f7698882a/duckdb-1.5.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f0b88535a5d86fdd63dba6ea02ab68c003dfb9e4892b11256ef24c4da208baae", size = 15509131, upload-time = "2026-07-22T10:54:12.228Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/a9/5f1f09da421d8e930e0b063d11c1b3f90363f40ede74438cd188afdd13a2/duckdb-1.5.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f316eae2323d9a851883fdf2dee91c1f9efe251ab33e14a2272f82a913422ed6", size = 19391959, upload-time = "2026-07-22T10:54:15.551Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/98/6549769f158126fa64fd6c1ac2eb59a18282146c939867a3eb31b7c1db07/duckdb-1.5.5-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a6d2d11859d82a936ebdcb30ce3d8a1cbb3e990bff05c12abb9b54c44fa7bd1", size = 21510909, upload-time = "2026-07-22T10:54:19.681Z" },
-    { url = "https://files.pythonhosted.org/packages/af/b7/5753b41d3124838f868f9f523362812d9fc45409e9e4dd70dcbb0a25826e/duckdb-1.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:ddfbdb096c11d51ee22492397d342c90a82e62c5d09961477895934d0a25372f", size = 13168544, upload-time = "2026-07-22T10:54:22.789Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/28/44b679c7d46245f8398feae7edac959d1b83d4eb143e25b3fce0630b78bd/duckdb-1.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:2725d2b9ace3a4e75d72fc5a239f6a44b502c580edadb8fb2676db772c5f9282", size = 13988684, upload-time = "2026-07-22T10:54:26.003Z" },
-]
-
-[[package]]
 name = "entrypoints"
 version = "0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3414,7 +3386,6 @@ dependencies = [
     { name = "distributed" },
     { name = "docker" },
     { name = "docopt" },
-    { name = "duckdb" },
     { name = "fake-useragent" },
     { name = "fastparquet" },
     { name = "fiona" },
@@ -3565,7 +3536,6 @@ requires-dist = [
     { name = "distributed", specifier = "==2021.11.2" },
     { name = "docker", specifier = ">=6,<7" },
     { name = "docopt", specifier = "==0.6.2" },
-    { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fake-useragent", specifier = ">=1.1.3,<2.0.0" },
     { name = "fastparquet", specifier = ">=2023.7.0,<2024.0.0" },
     { name = "fiona", specifier = ">=1.10.1,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -1215,6 +1215,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/19/e57151753576373c6696a12022648546cca6038e8833fda2908ee2342d9b/duckdb-1.5.5.tar.gz", hash = "sha256:72f33ee57ca7595b23957671a2cc7f7fe2be0ecc2d68f63abedcfcaa3a5c1238", size = 18066741, upload-time = "2026-07-22T10:55:17.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/d4/298acf9331a80b3ce6ac64dd940e7e13f4058fb69d18914445f02e3c7bfe/duckdb-1.5.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b805507f88171b428b21c966c30e9a3d54e30b24528918a44ed0032542bc26f", size = 32702934, upload-time = "2026-07-22T10:53:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/90/c489fb63d64b2e7ee109ce8460bdede003a0f256e5b41a03a2a1c4764058/duckdb-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b08e19cc856220d8a26fa62abc2264b349aff67255e9373c6a3f607addd56dc6", size = 17343604, upload-time = "2026-07-22T10:53:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/27/effa80a15b1f0c61c235622f797868485359e8c9ad6a8e358e7a0c479151/duckdb-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a17e6a922e42a5c06ed2353fe78c5dff2610f6632d603836f9606ad0bf754079", size = 15488179, upload-time = "2026-07-22T10:53:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/07/21212345c8d24ba62dceaa20be3b21f5c46f1510b1b42ce93bb058afe0c4/duckdb-1.5.5-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bdc38922c365c37720149f90d90b1e9823eb82dad6830855b5f87537fa6fc0c", size = 19367323, upload-time = "2026-07-22T10:53:30.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d0/10371ae875fb4b5ef61bb892743b4b2e90c512b371fdf29317deb744857d/duckdb-1.5.5-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e238060db5ca59879882a6e9b015e2c65d5c64ddf281ba1d7a9a2033764152cf", size = 21476568, upload-time = "2026-07-22T10:53:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/35/09568ce617dd7bc0757b3d7b6a981660b9e4f0b7594de8ed776755eae740/duckdb-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:4acc72798ba1885a9c17d1242903d2cd502f13b1271c7677f7cab25d8578eceb", size = 13156129, upload-time = "2026-07-22T10:53:37.55Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c2/b62ec24d57bb8df4e24b0b58f7f8facb32f5fdb9f1895aed9e9fcdded168/duckdb-1.5.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1b543841b0ae18a9c982345cfa3987e9c065d3a4b0f067daa473d92d1e65f528", size = 32708371, upload-time = "2026-07-22T10:53:41.642Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ce/769171ba45f0b73632dc3bc3108d891e81dd6c6bbfba630a34a75b4dcc0f/duckdb-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a925d06c2a4c3b64553d6cc1aced5028d376d4479bed689a7d47e9b1dccd80a", size = 17343979, upload-time = "2026-07-22T10:53:44.951Z" },
+    { url = "https://files.pythonhosted.org/packages/46/59/a8e3384ee916e00d5dcf985194c1511d61978540778a1e96fa47f9fb3e0d/duckdb-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0c42757cb34722144bd4dfb94b6f336339e7b2468f6813fa7fa9a319ba07bab4", size = 15493704, upload-time = "2026-07-22T10:53:47.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1d/9840179c2607b90523a2884a129c4d4e6dbdc1178ba62a976c1043beba88/duckdb-1.5.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e72f9e1a4f90a5c8483ad4d540e495bf0834ba61c360b52499a573d7ed62a3f", size = 19366574, upload-time = "2026-07-22T10:53:51.876Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/55/f9641a4eebcc2f4df631287d6c3b9ed2eea3b92644f93acbad825e3972b6/duckdb-1.5.5-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b6f86ed85d4ef5e0211eaebf75d057bd8bb520bba438a95dd0f4e42234bbfe", size = 21477952, upload-time = "2026-07-22T10:53:55.575Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3a/07c3556e37a5c97b95917b029c8fdde4a25fbd76a660bacdac195cf20dcb/duckdb-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:9f4287f97ccf0c1f3d471e7115be2b067cbf99627e2d34bffd462dd64703cddc", size = 13156986, upload-time = "2026-07-22T10:53:58.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ff/07b48eef2078ca033847e9caa46cc7633b714c5f91ad1ce091c8ca89d792/duckdb-1.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:179633a3fc6296c75d57c69c1e239fa9e5cdcb670fd1dbff88a02663f932905c", size = 14001317, upload-time = "2026-07-22T10:54:01.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/40/2e05d324400fdaa5656c9f48d6298da421cb034d85e509fa0e6e325cf04b/duckdb-1.5.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d4dd65f8941a604b947e0b9b4b4f7165988e29a23ec0b69b4038520956d9933e", size = 32753858, upload-time = "2026-07-22T10:54:05.514Z" },
+    { url = "https://files.pythonhosted.org/packages/79/15/5ceb58ffb5bb8a62b3fd7abb39c41467cdf94850ece02e6d88664dfc75ce/duckdb-1.5.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33db46679b071f108d57139493dee2d37e1f5efcf5c5c039c2969eed11a6c8a7", size = 17368293, upload-time = "2026-07-22T10:54:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5c/bf02da0b354fe83cca4f95a4fbf762181af466f7d551ab2a093f7698882a/duckdb-1.5.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f0b88535a5d86fdd63dba6ea02ab68c003dfb9e4892b11256ef24c4da208baae", size = 15509131, upload-time = "2026-07-22T10:54:12.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a9/5f1f09da421d8e930e0b063d11c1b3f90363f40ede74438cd188afdd13a2/duckdb-1.5.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f316eae2323d9a851883fdf2dee91c1f9efe251ab33e14a2272f82a913422ed6", size = 19391959, upload-time = "2026-07-22T10:54:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/6549769f158126fa64fd6c1ac2eb59a18282146c939867a3eb31b7c1db07/duckdb-1.5.5-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a6d2d11859d82a936ebdcb30ce3d8a1cbb3e990bff05c12abb9b54c44fa7bd1", size = 21510909, upload-time = "2026-07-22T10:54:19.681Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b7/5753b41d3124838f868f9f523362812d9fc45409e9e4dd70dcbb0a25826e/duckdb-1.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:ddfbdb096c11d51ee22492397d342c90a82e62c5d09961477895934d0a25372f", size = 13168544, upload-time = "2026-07-22T10:54:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/28/44b679c7d46245f8398feae7edac959d1b83d4eb143e25b3fce0630b78bd/duckdb-1.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:2725d2b9ace3a4e75d72fc5a239f6a44b502c580edadb8fb2676db772c5f9282", size = 13988684, upload-time = "2026-07-22T10:54:26.003Z" },
 ]
 
 [[package]]
@@ -3386,6 +3414,7 @@ dependencies = [
     { name = "distributed" },
     { name = "docker" },
     { name = "docopt" },
+    { name = "duckdb" },
     { name = "fake-useragent" },
     { name = "fastparquet" },
     { name = "fiona" },
@@ -3536,6 +3565,7 @@ requires-dist = [
     { name = "distributed", specifier = "==2021.11.2" },
     { name = "docker", specifier = ">=6,<7" },
     { name = "docopt", specifier = "==0.6.2" },
+    { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fake-useragent", specifier = ">=1.1.3,<2.0.0" },
     { name = "fastparquet", specifier = ">=2023.7.0,<2024.0.0" },
     { name = "fiona", specifier = ">=1.10.1,<2.0.0" },


### PR DESCRIPTION
# Add annual recurring pipeline for us_cfpb_hmda

Recurring Prefect 3 pipeline that refreshes the modern **`loan_application_register`** (2018+) when CFPB publishes a new year's Snapshot National Loan-Level Dataset (~mid-year). The legacy table (2007–2017) and the dicionario are frozen and are **not** touched.

## Design
- **Full replace** (`dump_mode="overwrite"`): re-cleans modern years 2018→N into all-STRING, year-partitioned parquet each run. Keeps the staging schema consistently all-STRING (the dbt model `safe_cast`s), mirrors `us_bls_cpi`, and the per-year streaming clean (duckdb, `preserve_insertion_order=false`) keeps peak RAM ~0.8 GB and peak disk ~one raw file. *(Future optimization: append only the new year — would first require migrating the existing typed staging to all-STRING.)*
- **Source poll** on `year` vs coverage → a scheduled run is a no-op until CFPB publishes a newer year.
- Reuses the **architecture TSV** (schema source of truth) shared with `models/us_cfpb_hmda/code`; the transform mirrors the validated one-shot clean.
- **AllFree** annual coverage (no BD Pro paywall). Inline schedule polls Mar–Aug.
- Adds `duckdb` as a dependency (the deployed worker imports it; the one-shot used `uv run --with duckdb`) and excludes `models/us_cfpb_hmda/code` from pyrefly (already on main).

## Local checks
- [x] Imports (`flows.us_cfpb_hmda_flow`)
- [x] Deploy discovery (`load_flows_from_file` → `us_cfpb_hmda`)
- [x] Transform parity on a synthetic CSV (rename, income×1000, `NA`/`Exempt`/blank→NULL, all-STRING incl `year`)
- [x] ruff clean

## To validate (the real gate)
1. Add the **`deploy-flow`** label → `cd-prefect3 (staging)` registers the dev deployment.
2. Trigger it manually on the **dev pool** with `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}` and confirm `dbt run OK` + `dbt test OK`.

Merging deploys to the **prod** pool **paused**; arming is a manual tick in Django admin (`/admin/admin_data_tools/disabledflowschedule/`). First armed run is the first prod refresh.

## Follow-up (small metadata)
Create the raw-data-source `Update` for the modern source (max coverage date = 2024) so the three update/poll records are complete; the poll itself compares against coverage so this isn't blocking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated annual refresh pipeline for the modern US CFPB HMDA loan application register dataset.
  * Detects newly available reporting years and processes the complete dataset history from 2018 onward.
  * Produces standardized, year-partitioned Parquet data with consistent columns, types, and null handling.
  * Supports validation and optional publication to development and production environments.
  * Added coverage metadata updates and scheduled annual execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->