### PR TITLE
fix(br_rf_cno): correção no source_format para o conjunto rf_cno

### DIFF
--- a/pipelines/crawler/rf/flows.py
+++ b/pipelines/crawler/rf/flows.py
@@ -87,6 +87,7 @@ def _run_rf(
         table_id=table_id,
         bucket_name="basedosdados-dev",
         dump_mode="append",
+        source_format="parquet",
     )
 
     run_dbt(
@@ -106,6 +107,7 @@ def _run_rf(
         table_id=table_id,
         bucket_name="basedosdados",
         dump_mode="append",
+        source_format="parquet",
     )
 
     run_dbt(

--- a/pipelines/datasets/br_rf_cno/README.md
+++ b/pipelines/datasets/br_rf_cno/README.md
@@ -241,3 +241,17 @@ com o `left join` de `sigla_uf` já aplicado). Não precisou `--full-refresh` ne
 ### 2026-07-17 — migração de metadados no backend (`br_me_cno` → `br_rf_cno`)
 As cloud tables/colunas do backend apontavam para o `br_me_cno` (vazio); reconciliadas para o
 `br_rf_cno` e a `areas` registrada do zero. Ver a seção *Metadados no backend* acima.
+
+### 2026-08-13 — `source_format` quebrou o upload das 4 tabelas
+O `upload_to_gcs` do `crawler/rf/flows.py` nunca passou `source_format`, caindo no default
+`"csv"` enquanto o `process_file` escreve parquet. O parâmetro errado era inofensivo até
+`beba2076` (#1677), que introduziu o `_sync_staging_schema` no ramo `dump_mode="append"` com
+staging já existente — ele chama `dump_header(source_format)`, que varre o diretório atrás de
+`.csv` e levanta `FileNotFoundError: Nenhum arquivo csv encontrado em br_rf_cno/output/<tabela>`.
+As quatro tabelas falharam no upload de dev, depois de limpar os parquets com sucesso.
+
+O `RawDataSource.Update` avançou para `2026-08-13` mesmo assim (o `commit_source_update_task`
+roda antes do crawl, por desenho). Sem consequência para as execuções seguintes: o poll compara
+contra a cobertura, que não se moveu.
+
+**Fix:** `source_format="parquet"` nos dois `upload_to_gcs` (dev e prod).

--- a/pipelines/datasets/br_rf_cno/flows.py
+++ b/pipelines/datasets/br_rf_cno/flows.py
@@ -7,6 +7,9 @@ particularidades por tabela: ver `pipelines/datasets/br_rf_cno/README.md`.
 
 A data de partição é gravada sem componente de hora (date-only); com hora, o
 `safe_cast(data as date)` do model virava NULL e o filtro incremental nunca inseria.
+
+O `process_file` escreve parquet, então o `_run_rf` declara `source_format="parquet"`
+no upload: com o default `"csv"`, o `dump_header` procura arquivo que não existe.
 """
 
 from prefect import flow

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -3,6 +3,7 @@ Tasks compartilhadas — Prefect 3.
 """
 
 import json
+import re
 from pathlib import Path
 from time import sleep
 from typing import Any
@@ -54,6 +55,23 @@ async def rename_flow_run_dataset_table(
 # ──────────────────────────────────────────────────────────────────────────────
 
 
+def _bq_safe_column_name(name: str) -> str:
+    """Normaliza um nome de coluna como o BigQuery faz ao inferir o schema.
+
+    As colunas que o crawler não renomeia chegam com o nome cru da fonte —
+    com espaço e acento, quando é o caso. Ao criar a tabela externa o
+    BigQuery troca cada caractere inválido por `_`, então `Nome do município`
+    vira `Nome_do_munic_pio`.
+
+    Args:
+        name: nome como vem do arquivo de dados.
+
+    Returns:
+        O nome com todo caractere fora de `[0-9a-zA-Z_]` trocado por `_`.
+    """
+    return re.sub(r"[^0-9a-zA-Z_]", "_", name)
+
+
 def _sync_staging_schema(
     tb: bd.Table,
     data_path: str | Path,
@@ -75,6 +93,12 @@ def _sync_staging_schema(
     remove nem reordena. Um arquivo parcial ou uma carga de um período só não
     pode encolher o schema de uma tabela histórica.
 
+    A comparação é feita sobre os nomes normalizados por
+    `_bq_safe_column_name`: o arquivo traz o nome cru e a tabela guarda o nome
+    já sanitizado pelo BigQuery, então comparar as duas grafias direto acusa
+    coluna nova em toda execução. A coluna acrescentada também leva o nome
+    normalizado — o cru pode não ser um identificador válido.
+
     Args:
         tb: tabela `basedosdados` já instanciada, apontando para a staging.
         data_path: arquivo ou diretório com os dados que serão carregados.
@@ -89,8 +113,15 @@ def _sync_staging_schema(
     client = bigquery.Client(project=billing_project_id)
     table = client.get_table(tb.table_full_name["staging"])
 
-    current = {field.name for field in table.schema}
-    new_fields = [field for field in incoming if field.name not in current]
+    current = {_bq_safe_column_name(field.name) for field in table.schema}
+    new_fields = [
+        bigquery.SchemaField(
+            name=_bq_safe_column_name(field.name),
+            field_type=field.field_type,
+        )
+        for field in incoming
+        if _bq_safe_column_name(field.name) not in current
+    ]
 
     if not new_fields:
         return


### PR DESCRIPTION
## O que aconteceu?

O `upload_to_gcs` do CNO não declarava `source_format` e caía no default `csv`, mas o crawler escreve parquet: o `dump_header` não achava arquivo e as quatro tabelas falhavam. Corrigido isso, o `_sync_staging_schema` comparava o nome cru do arquivo com o ajustado pelo BigQuery (`Nome do município` × `Nome_do_munic_pio`) e pedia coluna nova todo run.

## O que foi feito para resolver o problema?

`source_format="parquet"` nos dois uploads e comparação por nome normalizado.

## Testes em dev:

- Microdados: https://prefect3.basedosdados.org/runs/flow-run/e33e65a8-c5f6-45f1-800a-598a4666c174
- Areas: https://prefect3.basedosdados.org/runs/flow-run/42bd94c5-7f56-4b51-b56e-bb973a26f922
- CNAES: https://prefect3.basedosdados.org/runs/flow-run/568da8d5-251c-44d3-b080-2ba03a268282
- Vinculos: https://prefect3.basedosdados.org/runs/flow-run/a4fc1c7e-762f-4a0a-b787-1b35d6cf10a8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Receita Federal uploads so Parquet files are correctly recognized in development and production environments.
  * Prevented upload failures caused by mismatched file format handling.
  * Improved compatibility with BigQuery by normalizing source column names during schema updates.

* **Documentation**
  * Documented Parquet file requirements and added a correction-history entry describing the upload issue and resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->