### PR TITLE
fix(mx_sesnsp_incidencia_delictiva): all_bdpro coverage (6mo rolling window infeasible with <6mo data)

### DIFF
--- a/pipelines/datasets/mx_sesnsp_incidencia_delictiva/flows.py
+++ b/pipelines/datasets/mx_sesnsp_incidencia_delictiva/flows.py
@@ -27,9 +27,8 @@ from pipelines.datasets.mx_sesnsp_incidencia_delictiva.tasks import (
     download_sesnsp,
 )
 from pipelines.utils.metadata.domain import (
+    AllBdpro,
     DateFormat,
-    FreeLag,
-    PartBdpro,
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
@@ -47,21 +46,19 @@ DATASET_ID = constants.DATASET_ID.value
 
 # Coverage spec per table.
 #
-# All four tables refresh monthly, so each carries the BD Pro rolling window:
-# the most recent 6 months are pro-only, everything older is free. Each run
-# recomputes free_end = source_end - free_lag, rewrites both DateTimeRanges, and
-# re-issues the BigQuery Row Access Policies, so the window slides forward on its
-# own.
+# All four tables carry the whole new-methodology series as BD Pro (all_bdpro):
+# every row is pro-gated. The 6-month rolling window (part_bdpro) is not usable
+# yet — with only ~6 months of data the free window (source_end - 6 months)
+# falls before the data starts, producing an inverted DateTimeRange the backend
+# rejects. Revisit part_bdpro once the tables hold more than 6 months of data.
 #
-# part_bdpro requires BOTH a free (is_closed=False) and a pro (is_closed=True)
-# Coverage to already exist on the table, or assert_coverage_topology raises
-# before anything is written. The frozen *_2015_2025 tables are not in this
-# pipeline and stay AllFree.
+# all_bdpro requires a single pro (is_closed=True) Coverage and NO free Coverage
+# on each table, or assert_coverage_topology raises before anything is written.
+# The frozen *_2015_2025 tables are not in this pipeline and stay AllFree.
 _COVERAGE = {
-    table: PartBdpro(
+    table: AllBdpro(
         date_column=YearMonth(year="ano", month="mes"),
         date_format=DateFormat.YEAR_MONTH,
-        free_lag=FreeLag(unit="months", value=6),
     )
     for table in constants.ALL_TABLES.value
 }


### PR DESCRIPTION
Follow-up to #1804. Switches the 4 ongoing `mx_sesnsp_incidencia_delictiva` tables from `PartBdpro(free_lag=6 months)` to **`AllBdpro`** (all new-methodology data gated as BD Pro).

## Why
The first full prod run (`materialize_to_prod=True, update_metadata=True`) materialized all prod data correctly, then **failed at `register_table_materialization → upsert_coverage_datetime_range`**. Root cause: the 6-month rolling window is infeasible with only ~6 months of data. `register_table_materialization` sets the free range's end to `source_end − 6 months = 2025-12` while its start stays `2026-01`, producing an **inverted DateTimeRange (start 2026-01 > end 2025-12)** that the backend rejects (surfaced as the generic `BaseDosDadosException: The API URL ... may be incorrect`). This would fail every run until the tables hold more than 6 months of data.

`AllBdpro` needs no rolling-window arithmetic — a single pro coverage over the full series, no inverted range, no Row Access Policy (`needs_row_access_policy` is only true for `PartBdpro`).

## Change
- `flows.py`: `_COVERAGE` now builds `AllBdpro(date_column=YearMonth("ano","mes"), date_format=YEAR_MONTH)` for the 4 ongoing tables; dropped the `FreeLag`/`PartBdpro` imports.
- Prod coverage topology already reconciled out-of-band: the 4 free coverages were deleted (AllBdpro requires pro-only), leaving one pro coverage (`is_closed=True`, `2026-01..2026-06`) per table. Verified.

## Notes
- The frozen `*_2015_2025` tables are unaffected (not in this pipeline).
- Revisit `PartBdpro` (rolling window) once the tables hold more than 6 months of data.
- Local checks: flow imports, all 4 specs resolve to `AllBdpro`, ruff clean.
