### PR TITLE
feat(au_ato_abr): onboard Australian Business Register (ABN Bulk Extract)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -49,6 +49,9 @@ models:
     au_alexander_politicians:
       +materialized: table
       +schema: au_alexander_politicians
+    au_ato_abr:
+      +materialized: table
+      +schema: au_ato_abr
     br_anatel_banda_larga_fixa:
       +materialized: table
       +schema: br_anatel_banda_larga_fixa

--- a/models/au_ato_abr/.gitignore
+++ b/models/au_ato_abr/.gitignore
@@ -1,0 +1,5 @@
+input/
+output/
+*.parquet
+*.xml
+*.zip

--- a/models/au_ato_abr/ONBOARDING_PLAN.md
+++ b/models/au_ato_abr/ONBOARDING_PLAN.md
@@ -1,0 +1,59 @@
+# au_ato_abr — Australian Business Register (ABN Bulk Extract)
+
+Onboarding plan and design record. Analog of br_rf_cnpj (CNPJ), fr_insee_sirene
+(SIRENE), mx_* (DENUE): a national business register.
+
+## Source
+- Publisher: Australian Taxation Office (ATO) / Australian Business Register (ABR)
+- Landing: https://data.gov.au/data/dataset/abn-bulk-extract
+- Data: two ZIPs (`public_split_1_10.zip`, `public_split_11_20.zip`), 20 XML files,
+  one `<ABR>` record per business, ~20.4M records, ~12.5 GB uncompressed.
+- Schema: `bulkextract.xsd` (kept in `code/bulkextract.xsd`).
+- License: **CC BY 3.0 AU** (https://creativecommons.org/licenses/by/3.0/au/) —
+  redistribution + commercial use permitted.
+- Cadence: **weekly full snapshot** (each release replaces the whole register).
+- Snapshot onboarded: **extraction_date = 2026-08-12** (from `<ExtractTime>`).
+- Note: **no ANZSIC / industry code** exists in the extract.
+
+## Data model (CNPJ-style stacked snapshots)
+Each weekly extract is a full photograph; we **stack** extracts and keep an
+`extraction_date` DATE partition column (mirrors CNPJ `data_referencia`). Tables
+`materialized="incremental"`, partitioned by `extraction_date` (day granularity).
+
+| Table | Grain | Notes |
+|-------|-------|-------|
+| `entity` | one row per ABN per snapshot | main register: status, entity type, name, ASIC, GST, state, postcode |
+| `other_name` | one row per trading/business/other name | `<OtherEntity>` 0..* — name_type TRD/BN/OTN |
+| `dgr` | one row per DGR endorsement | `<DGR>` 0..* — deductible gift recipient |
+| `dicionario` | code → label | abn_status, entity_type, gst_status, state_code, asic_number_type, replaced, name_type |
+
+- Observation level: `company` (all three data tables).
+- Individuals (sole traders, `entity_type=IND`) are **included**; `entity_name`
+  holds the assembled given+family name; `entity_name` flagged `has_sensitive_data`.
+- Coded columns are STRING + dicionario. Geography (`state_code`, `postcode`) is
+  STRING for now; link to `br_bd_diretorios_au` (state/territory) and a POA
+  postcode directory when those land in prod.
+- Date sentinels (`19000101`) mapped to NULL.
+
+## Tier: PartBdpro
+Weekly refresh ⇒ the recent snapshot window is paywalled to BD Pro; older
+snapshots free. The rolling window and Row Access Policies are applied by the
+recurring pipeline (`register_table_materialization_task`), not the static
+onboard. At onboarding there is a single snapshot, so the free/pro split is
+degenerate; the pro Coverage + policies go live with the pipeline (step 12).
+
+## Files
+- `code/clean_data.py` — streams `<ABR>` from the ZIPs (no full extraction),
+  writes typed partitioned parquet for the 3 tables + a dicionario CSV.
+- `code/columns_json/*.json` — trilingual column definitions (bulk_upsert source).
+- `code/architecture/*.csv` — BD architecture source of truth (built from JSON).
+- `au_ato_abr__*.sql`, `schema.yml` — dbt models + tests.
+
+## Workflow status
+1. context ✓  2. architecture ✓  3. download ✓  4. clean (running)
+5. upload dev — pending  6. dbt ✓ (written)  7. validate — pending
+8. discover — pending  9. metadata dev — pending  9b. publish dev/staging — pending
+[CHECKPOINT] 10. prod  11. PR  12. recurring pipeline (weekly, dump overwrite,
+PartBdpro window)  13. publish prod  14. cleanup scratch.
+
+Scratch data: `~/Downloads/au_ato_abr_data/` (deleted at step 14).

--- a/models/au_ato_abr/au_ato_abr__dgr.sql
+++ b/models/au_ato_abr/au_ato_abr__dgr.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        schema="au_ato_abr",
+        alias="dgr",
+        materialized="incremental",
+        partition_by={
+            "field": "extraction_date",
+            "data_type": "date",
+            "granularity": "day",
+        },
+    )
+}}
+
+-- Atualizado em 2026-08-14
+select
+    safe_cast(extraction_date as date) extraction_date,
+    safe_cast(abn as string) abn,
+    safe_cast(dgr_status_from_date as date) dgr_status_from_date,
+    safe_cast(dgr_name as string) dgr_name
+from {{ set_datalake_project("au_ato_abr_staging.dgr") }} as t
+{% if is_incremental() %}
+    where
+        safe_cast(extraction_date as date)
+        > (select max(extraction_date) from {{ this }})
+{% endif %}

--- a/models/au_ato_abr/au_ato_abr__dicionario.sql
+++ b/models/au_ato_abr/au_ato_abr__dicionario.sql
@@ -1,0 +1,10 @@
+{{ config(alias="dicionario", schema="au_ato_abr", materialized="table") }}
+
+-- Atualizado em 2026-08-14
+select
+    safe_cast(id_tabela as string) id_tabela,
+    safe_cast(nome_coluna as string) nome_coluna,
+    safe_cast(chave as string) chave,
+    safe_cast(cobertura_temporal as string) cobertura_temporal,
+    safe_cast(valor as string) valor
+from {{ set_datalake_project("au_ato_abr_staging.dicionario") }} as t

--- a/models/au_ato_abr/au_ato_abr__entity.sql
+++ b/models/au_ato_abr/au_ato_abr__entity.sql
@@ -1,0 +1,35 @@
+{{
+    config(
+        schema="au_ato_abr",
+        alias="entity",
+        materialized="incremental",
+        partition_by={
+            "field": "extraction_date",
+            "data_type": "date",
+            "granularity": "day",
+        },
+    )
+}}
+
+-- Atualizado em 2026-08-14
+select
+    safe_cast(extraction_date as date) extraction_date,
+    safe_cast(abn as string) abn,
+    safe_cast(abn_status as string) abn_status,
+    safe_cast(abn_status_from_date as date) abn_status_from_date,
+    safe_cast(entity_type as string) entity_type,
+    safe_cast(entity_name as string) entity_name,
+    safe_cast(asic_number as string) asic_number,
+    safe_cast(asic_number_type as string) asic_number_type,
+    safe_cast(gst_status as string) gst_status,
+    safe_cast(gst_status_from_date as date) gst_status_from_date,
+    safe_cast(state_code as string) state_code,
+    safe_cast(postcode as string) postcode,
+    safe_cast(record_last_updated_date as date) record_last_updated_date,
+    safe_cast(replaced as string) replaced
+from {{ set_datalake_project("au_ato_abr_staging.entity") }} as t
+{% if is_incremental() %}
+    where
+        safe_cast(extraction_date as date)
+        > (select max(extraction_date) from {{ this }})
+{% endif %}

--- a/models/au_ato_abr/au_ato_abr__other_name.sql
+++ b/models/au_ato_abr/au_ato_abr__other_name.sql
@@ -12,7 +12,9 @@
 }}
 
 -- Atualizado em 2026-08-14
-select
+-- distinct: the source occasionally repeats the identical (name_type, name) for
+-- an ABN within one snapshot; those rows carry no extra information.
+select distinct
     safe_cast(extraction_date as date) extraction_date,
     safe_cast(abn as string) abn,
     safe_cast(name_type as string) name_type,

--- a/models/au_ato_abr/au_ato_abr__other_name.sql
+++ b/models/au_ato_abr/au_ato_abr__other_name.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        schema="au_ato_abr",
+        alias="other_name",
+        materialized="incremental",
+        partition_by={
+            "field": "extraction_date",
+            "data_type": "date",
+            "granularity": "day",
+        },
+    )
+}}
+
+-- Atualizado em 2026-08-14
+select
+    safe_cast(extraction_date as date) extraction_date,
+    safe_cast(abn as string) abn,
+    safe_cast(name_type as string) name_type,
+    safe_cast(name as string) name
+from {{ set_datalake_project("au_ato_abr_staging.other_name") }} as t
+{% if is_incremental() %}
+    where
+        safe_cast(extraction_date as date)
+        > (select max(extraction_date) from {{ this }})
+{% endif %}

--- a/models/au_ato_abr/code/architecture/dgr.csv
+++ b/models/au_ato_abr/code/architecture/dgr.csv
@@ -1,0 +1,5 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+extraction_date,DATE,Data de extração do snapshot do registro (ABR); cada extração é uma fotografia completa do cadastro,,no,,,no,Partition column; snapshot date from the extract header,ExtractTime
+abn,STRING,Número de Empresa Australiano (ABN) da entidade endossada como DGR,,no,,,no,Foreign key to entity.abn,ABN
+dgr_status_from_date,DATE,Data a partir da qual a entidade foi endossada como beneficiária de doações dedutíveis (DGR),,no,,,no,Sentinel 19000101 mapped to null,DGR@DGRStatusFromDate
+dgr_name,STRING,"Nome do fundo ou instituição endossada como DGR, quando informado",,no,,,no,,DGR/NonIndividualName/NonIndividualNameText

--- a/models/au_ato_abr/code/architecture/dicionario.csv
+++ b/models/au_ato_abr/code/architecture/dicionario.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_tabela,STRING,Nome da tabela à qual a chave se refere,,no,,,no,,
+nome_coluna,STRING,Nome da coluna à qual a chave se refere,,no,,,no,,
+chave,STRING,Chave (valor codificado) presente na coluna original,,no,,,no,,
+cobertura_temporal,STRING,Cobertura temporal da chave,,no,,,no,,
+valor,STRING,Valor traduzido correspondente à chave,,no,,,no,,

--- a/models/au_ato_abr/code/architecture/entity.csv
+++ b/models/au_ato_abr/code/architecture/entity.csv
@@ -1,0 +1,15 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+extraction_date,DATE,Data de extração do snapshot do registro (ABR); cada extração é uma fotografia completa do cadastro,,no,,,no,Partition column; snapshot date from the extract header,ExtractTime
+abn,STRING,"Número de Empresa Australiano (ABN), identificador único de 11 dígitos da entidade",,no,,,no,,ABN
+abn_status,STRING,Situação do ABN: ativo (ACT) ou cancelado (CAN),,yes,,,no,,ABN@status
+abn_status_from_date,DATE,Data a partir da qual a situação atual do ABN passou a vigorar,,no,,,no,Sentinel 19000101 mapped to null,ABN@ABNStatusFromDate
+entity_type,STRING,"Código do tipo de entidade (ex.: IND para pessoa física/autônomo, PRV para empresa privada australiana)",,yes,,,no,,EntityType/EntityTypeInd
+entity_name,STRING,"Nome legal ou principal da entidade; para pessoas físicas (autônomos), o nome completo do indivíduo",,no,,,yes,For individuals assembled as given + family name,NonIndividualNameText or IndividualName
+asic_number,STRING,"Número de registro na ASIC (ACN — Australian Company Number, ou ARBN), quando aplicável",,no,,,no,,ASICNumber
+asic_number_type,STRING,"Tipo do número ASIC (ex.: ACN, ARBN)",,yes,,,no,,ASICNumber@ASICNumberType
+gst_status,STRING,"Situação de registro no GST (imposto sobre bens e serviços): ativo, cancelado ou não registrado",,yes,,,no,,GST@status
+gst_status_from_date,DATE,Data a partir da qual a situação atual do GST passou a vigorar,,no,,,no,Sentinel 19000101 mapped to null,GST@GSTStatusFromDate
+state_code,STRING,"Sigla do estado ou território da localização comercial principal da entidade (ex.: NSW, VIC, QLD)",,yes,,,no,Link to br_bd_diretorios_au state/territory directory when available in prod,BusinessAddress/AddressDetails/State
+postcode,STRING,Código postal (postcode) de 4 dígitos da localização comercial principal da entidade,,no,,,no,Link to an Australian POA postal-area directory when available,BusinessAddress/AddressDetails/Postcode
+record_last_updated_date,DATE,Data da última atualização do registro da entidade no ABR,,no,,,no,,ABR@recordLastUpdatedDate
+replaced,STRING,Indicador de que o registro substituiu um registro anterior nesta extração (Y ou N),,yes,,,no,,ABR@replaced

--- a/models/au_ato_abr/code/architecture/other_name.csv
+++ b/models/au_ato_abr/code/architecture/other_name.csv
@@ -1,0 +1,5 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+extraction_date,DATE,Data de extração do snapshot do registro (ABR); cada extração é uma fotografia completa do cadastro,,no,,,no,Partition column; snapshot date from the extract header,ExtractTime
+abn,STRING,Número de Empresa Australiano (ABN) da entidade à qual o nome pertence,,no,,,no,Foreign key to entity.abn,ABN
+name_type,STRING,"Tipo do nome: nome fantasia/comercial (TRD), nome de negócio (BN) ou outro nome (OTN)",,yes,,,no,,OtherEntity/NonIndividualName@type
+name,STRING,"Nome fantasia, comercial ou outro nome sob o qual a entidade opera",,no,,,no,,OtherEntity/NonIndividualName/NonIndividualNameText

--- a/models/au_ato_abr/code/build_architecture.py
+++ b/models/au_ato_abr/code/build_architecture.py
@@ -1,0 +1,129 @@
+"""Emit architecture CSVs (BD source of truth) from the columns_json + provenance.
+
+One CSV per table, columns in the canonical BD architecture order. Descriptions
+are the Portuguese ones from columns_json; EN/ES live in columns_json and are
+applied at metadata registration via bulk_upsert_columns.
+"""
+
+import csv
+import json
+from pathlib import Path
+
+HERE = Path(__file__).parent
+JSON_DIR = HERE / "columns_json"
+OUT_DIR = HERE / "architecture"
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+HEADER = [
+    "name",
+    "bigquery_type",
+    "description",
+    "temporal_coverage",
+    "covered_by_dictionary",
+    "directory_column",
+    "measurement_unit",
+    "has_sensitive_data",
+    "observations",
+    "original_name",
+]
+
+# provenance: name -> (original_name, observations)
+PROV = {
+    "entity": {
+        "extraction_date": (
+            "ExtractTime",
+            "Partition column; snapshot date from the extract header",
+        ),
+        "abn": ("ABN", ""),
+        "abn_status": ("ABN@status", ""),
+        "abn_status_from_date": (
+            "ABN@ABNStatusFromDate",
+            "Sentinel 19000101 mapped to null",
+        ),
+        "entity_type": ("EntityType/EntityTypeInd", ""),
+        "entity_name": (
+            "NonIndividualNameText or IndividualName",
+            "For individuals assembled as given + family name",
+        ),
+        "asic_number": ("ASICNumber", ""),
+        "asic_number_type": ("ASICNumber@ASICNumberType", ""),
+        "gst_status": ("GST@status", ""),
+        "gst_status_from_date": (
+            "GST@GSTStatusFromDate",
+            "Sentinel 19000101 mapped to null",
+        ),
+        "state_code": (
+            "BusinessAddress/AddressDetails/State",
+            "Link to br_bd_diretorios_au state/territory directory when available in prod",
+        ),
+        "postcode": (
+            "BusinessAddress/AddressDetails/Postcode",
+            "Link to an Australian POA postal-area directory when available",
+        ),
+        "record_last_updated_date": ("ABR@recordLastUpdatedDate", ""),
+        "replaced": ("ABR@replaced", ""),
+    },
+    "other_name": {
+        "extraction_date": (
+            "ExtractTime",
+            "Partition column; snapshot date from the extract header",
+        ),
+        "abn": ("ABN", "Foreign key to entity.abn"),
+        "name_type": ("OtherEntity/NonIndividualName@type", ""),
+        "name": ("OtherEntity/NonIndividualName/NonIndividualNameText", ""),
+    },
+    "dgr": {
+        "extraction_date": (
+            "ExtractTime",
+            "Partition column; snapshot date from the extract header",
+        ),
+        "abn": ("ABN", "Foreign key to entity.abn"),
+        "dgr_status_from_date": (
+            "DGR@DGRStatusFromDate",
+            "Sentinel 19000101 mapped to null",
+        ),
+        "dgr_name": ("DGR/NonIndividualName/NonIndividualNameText", ""),
+    },
+    "dicionario": {
+        c: ("", "")
+        for c in [
+            "id_tabela",
+            "nome_coluna",
+            "chave",
+            "cobertura_temporal",
+            "valor",
+        ]
+    },
+}
+
+
+def main():
+    for jf in sorted(JSON_DIR.glob("*.json")):
+        table = jf.stem
+        cols = json.loads(jf.read_text())
+        prov = PROV.get(table, {})
+        out = OUT_DIR / f"{table}.csv"
+        with open(out, "w", newline="", encoding="utf-8") as fh:
+            w = csv.writer(fh)
+            w.writerow(HEADER)
+            for c in cols:
+                orig, obs = prov.get(c["name"], ("", ""))
+                w.writerow(
+                    [
+                        c["name"],
+                        c["bigquery_type"],
+                        c["description_pt"],
+                        "",  # temporal_coverage (same as table)
+                        "yes" if c.get("covered_by_dictionary") else "no",
+                        "",  # directory_column (none wired yet)
+                        "",  # measurement_unit (no numeric quantities in this dataset)
+                        "yes" if c.get("has_sensitive_data") else "no",
+                        obs,
+                        orig,
+                    ]
+                )
+        print(f"wrote {out}  ({len(cols)} cols)")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_ato_abr/code/bulkextract.xsd
+++ b/models/au_ato_abr/code/bulkextract.xsd
@@ -1,0 +1,359 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	History:
+	April 2012: Added new value of BN to NameTypeEnum
+	Jan 2014: Tightened up definitions
+    Apr 2015: Added date of extract and main dgr
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xsd:element name="Transfer">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="TransferInfo">
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="FileSequenceNumber" type="xsd:integer"/>
+							<xsd:element name="RecordCount" type="xsd:integer"/>
+							<xsd:element name="ExtractTime" type="xsd:dateTime"/>
+						</xsd:sequence>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="ABR" minOccurs="0" maxOccurs="unbounded">
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="ABN" type="ABNType"/>
+							<xsd:element name="EntityType" type="EntityTypeType"/>
+							<xsd:choice>
+								<xsd:element name="MainEntity" type="MainEntityType"/>
+								<xsd:element name="LegalEntity" type="LegalEntityType"/>
+							</xsd:choice>
+							<xsd:element name="ASICNumber" type="ASICNumberType" minOccurs="0"/>
+							<xsd:element name="GST" type="GSTType" minOccurs="0"/>
+							<xsd:element name="DGR" type="DGRType" minOccurs="0" maxOccurs="unbounded"/>
+							<xsd:element name="OtherEntity" type="OtherEntityType" minOccurs="0" maxOccurs="unbounded"/>
+						</xsd:sequence>
+						<xsd:attribute name="recordLastUpdatedDate" type="xsd:int" use="required"/>
+						<xsd:attribute name="replaced" type="xsd:string" use="required"/>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="error" type="xsd:string" use="required"/>
+			<!--Attribute for 'Transfer' element-->
+		</xsd:complexType>
+	</xsd:element>
+	<!--EntityTypeType-->
+	<xsd:complexType name="EntityTypeType">
+		<xsd:sequence>
+			<xsd:element name="EntityTypeInd" type="EntityTypeEnum"/>
+			<xsd:element name="EntityTypeText"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--EntityTypeEnum-->
+	<xsd:simpleType name="EntityTypeEnum">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ADF"/>
+			<xsd:enumeration value="ARF"/>
+			<xsd:enumeration value="COP"/>
+			<xsd:enumeration value="CUT"/>
+			<xsd:enumeration value="DES"/>
+			<xsd:enumeration value="DIP"/>
+			<xsd:enumeration value="FGA"/>
+			<xsd:enumeration value="FGD"/>
+			<xsd:enumeration value="FHS"/>
+			<xsd:enumeration value="FPT"/>
+			<xsd:enumeration value="FSA"/>
+			<xsd:enumeration value="GOV"/>
+			<xsd:enumeration value="IND"/>
+			<xsd:enumeration value="JVT"/>
+			<xsd:enumeration value="LOC"/>
+			<xsd:enumeration value="LPT"/>
+			<xsd:enumeration value="NRF"/>
+			<xsd:enumeration value="OIE"/>
+			<xsd:enumeration value="PDF"/>
+			<xsd:enumeration value="PRV"/>
+			<xsd:enumeration value="PST"/>
+			<xsd:enumeration value="PTR"/>
+			<xsd:enumeration value="PTT"/>
+			<xsd:enumeration value="PUB"/>
+			<xsd:enumeration value="SMF"/>
+			<xsd:enumeration value="SSA"/>
+			<xsd:enumeration value="STA"/>
+			<xsd:enumeration value="STR"/>
+			<xsd:enumeration value="SUP"/>
+			<xsd:enumeration value="TER"/>
+			<xsd:enumeration value="TRT"/>
+			<xsd:enumeration value="UIE"/>
+			<xsd:enumeration value="CGT"/>
+			<xsd:enumeration value="LGA"/>
+			<xsd:enumeration value="LGC"/>
+			<xsd:enumeration value="LGE"/>
+			<xsd:enumeration value="LGP"/>
+			<xsd:enumeration value="LGS"/>
+			<xsd:enumeration value="LGT"/>
+			<xsd:enumeration value="SGA"/>
+			<xsd:enumeration value="SGC"/>
+			<xsd:enumeration value="SGE"/>
+			<xsd:enumeration value="SGP"/>
+			<xsd:enumeration value="SGS"/>
+			<xsd:enumeration value="SGT"/>
+			<xsd:enumeration value="TGA"/>
+			<xsd:enumeration value="TGC"/>
+			<xsd:enumeration value="TGE"/>
+			<xsd:enumeration value="TGP"/>
+			<xsd:enumeration value="TGS"/>
+			<xsd:enumeration value="TGT"/>
+			<xsd:enumeration value="CGA"/>
+			<xsd:enumeration value="CGC"/>
+			<xsd:enumeration value="CGE"/>
+			<xsd:enumeration value="CGP"/>
+			<xsd:enumeration value="CGS"/>
+			<xsd:enumeration value="CCB"/>
+			<xsd:enumeration value="CCC"/>
+			<xsd:enumeration value="CCL"/>
+			<xsd:enumeration value="CCN"/>
+			<xsd:enumeration value="CCO"/>
+			<xsd:enumeration value="CCP"/>
+			<xsd:enumeration value="CCR"/>
+			<xsd:enumeration value="CCS"/>
+			<xsd:enumeration value="CCT"/>
+			<xsd:enumeration value="CCU"/>
+			<xsd:enumeration value="CMT"/>
+			<xsd:enumeration value="CSA"/>
+			<xsd:enumeration value="CSP"/>
+			<xsd:enumeration value="CSS"/>
+			<xsd:enumeration value="CTC"/>
+			<xsd:enumeration value="CTD"/>
+			<xsd:enumeration value="CTF"/>
+			<xsd:enumeration value="CTH"/>
+			<xsd:enumeration value="CTI"/>
+			<xsd:enumeration value="CTL"/>
+			<xsd:enumeration value="CTQ"/>
+			<xsd:enumeration value="CTT"/>
+			<xsd:enumeration value="CTU"/>
+			<xsd:enumeration value="DIT"/>
+			<xsd:enumeration value="DST"/>
+			<xsd:enumeration value="DTT"/>
+			<xsd:enumeration value="FUT"/>
+			<xsd:enumeration value="FXT"/>
+			<xsd:enumeration value="HYT"/>
+			<xsd:enumeration value="LCB"/>
+			<xsd:enumeration value="LCC"/>
+			<xsd:enumeration value="LCL"/>
+			<xsd:enumeration value="LCN"/>
+			<xsd:enumeration value="LCO"/>
+			<xsd:enumeration value="LCP"/>
+			<xsd:enumeration value="LCR"/>
+			<xsd:enumeration value="LCS"/>
+			<xsd:enumeration value="LCT"/>
+			<xsd:enumeration value="LCU"/>
+			<xsd:enumeration value="LSA"/>
+			<xsd:enumeration value="LSP"/>
+			<xsd:enumeration value="LSS"/>
+			<xsd:enumeration value="LTC"/>
+			<xsd:enumeration value="LTD"/>
+			<xsd:enumeration value="LTF"/>
+			<xsd:enumeration value="LTH"/>
+			<xsd:enumeration value="LTI"/>
+			<xsd:enumeration value="LTL"/>
+			<xsd:enumeration value="LTQ"/>
+			<xsd:enumeration value="LTT"/>
+			<xsd:enumeration value="LTU"/>
+			<xsd:enumeration value="NPF"/>
+			<xsd:enumeration value="POF"/>
+			<xsd:enumeration value="PQT"/>
+			<xsd:enumeration value="PUT"/>
+			<xsd:enumeration value="SAF"/>
+			<xsd:enumeration value="SCB"/>
+			<xsd:enumeration value="SCC"/>
+			<xsd:enumeration value="SCL"/>
+			<xsd:enumeration value="SCN"/>
+			<xsd:enumeration value="SCO"/>
+			<xsd:enumeration value="SCP"/>
+			<xsd:enumeration value="SCR"/>
+			<xsd:enumeration value="SCS"/>
+			<xsd:enumeration value="SCT"/>
+			<xsd:enumeration value="SCU"/>
+			<xsd:enumeration value="SSP"/>
+			<xsd:enumeration value="SSS"/>
+			<xsd:enumeration value="STC"/>
+			<xsd:enumeration value="STD"/>
+			<xsd:enumeration value="STF"/>
+			<xsd:enumeration value="STH"/>
+			<xsd:enumeration value="STI"/>
+			<xsd:enumeration value="STL"/>
+			<xsd:enumeration value="STQ"/>
+			<xsd:enumeration value="STT"/>
+			<xsd:enumeration value="STU"/>
+			<xsd:enumeration value="TCB"/>
+			<xsd:enumeration value="TCC"/>
+			<xsd:enumeration value="TCL"/>
+			<xsd:enumeration value="TCN"/>
+			<xsd:enumeration value="TCO"/>
+			<xsd:enumeration value="TCP"/>
+			<xsd:enumeration value="TCR"/>
+			<xsd:enumeration value="TCS"/>
+			<xsd:enumeration value="TCT"/>
+			<xsd:enumeration value="TCU"/>
+			<xsd:enumeration value="TSA"/>
+			<xsd:enumeration value="TSP"/>
+			<xsd:enumeration value="TSS"/>
+			<xsd:enumeration value="TTC"/>
+			<xsd:enumeration value="TTD"/>
+			<xsd:enumeration value="TTF"/>
+			<xsd:enumeration value="TTH"/>
+			<xsd:enumeration value="TTI"/>
+			<xsd:enumeration value="TTL"/>
+			<xsd:enumeration value="TTQ"/>
+			<xsd:enumeration value="TTT"/>
+			<xsd:enumeration value="TTU"/>
+			<xsd:enumeration value="CSF"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!--MainEntityType-->
+	<xsd:complexType name="MainEntityType">
+		<xsd:sequence>
+			<xsd:element name="NonIndividualName" type="NonIndividualNameType"/>
+			<xsd:element name="BusinessAddress" type="BusinessAddressType"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--ASICNumberType-->
+	<xsd:complexType name="ASICNumberType">
+		<xsd:simpleContent>
+			<xsd:extension base="ASICNumberValue">
+				<xsd:attribute name="ASICNumberType" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--ASICNumberValue - Follows on from ASICNumberType above-->
+	<xsd:simpleType name="ASICNumberValue">
+		<xsd:restriction base="xsd:string">
+			<xsd:minLength value="0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!--GSTNumberType-->
+	<xsd:complexType name="GSTType">
+		<xsd:simpleContent>
+			<xsd:extension base="GSTValue">
+				<xsd:attribute name="status" type="xsd:string" use="required"/>
+				<xsd:attribute name="GSTStatusFromDate" use="required"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--GSTValue- Follows on from GSTNumberTypeabove-->
+	<xsd:simpleType name="GSTValue">
+		<xsd:restriction base="xsd:string">
+			<xsd:length value="0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!--DGRType-->
+	<xsd:complexType name="DGRType">
+		<xsd:sequence minOccurs="0">
+			<xsd:element name="NonIndividualName" type="NonIndividualNameType"/>
+		</xsd:sequence>
+		<xsd:attribute name="DGRStatusFromDate" use="required"/>
+		<xsd:attribute name="status" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<!--LegalEntityType-->
+	<xsd:complexType name="LegalEntityType">
+		<xsd:sequence>
+			<xsd:element name="IndividualName" type="IndividualNameType"/>
+			<xsd:element name="BusinessAddress" type="BusinessAddressType"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--OtherEntityType-->
+	<xsd:complexType name="OtherEntityType">
+		<xsd:sequence>
+			<xsd:element name="NonIndividualName" type="NonIndividualNameType"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--IndividualNameType-->
+	<xsd:complexType name="IndividualNameType">
+		<xsd:sequence>
+			<xsd:element name="NameTitle" type="NameTitleType" minOccurs="0"/>
+			<xsd:element name="GivenName" type="GivenNameType" minOccurs="0" maxOccurs="2"/>
+			<xsd:element name="FamilyName" type="FamilyNameType"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="NameTypeEnum" use="required"/>
+	</xsd:complexType>
+	<xsd:simpleType name="NameTitleType">
+		<xsd:restriction base="xsd:string"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="GivenNameType">
+		<xsd:restriction base="xsd:string"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="FamilyNameType">
+		<xsd:restriction base="xsd:string"/>
+	</xsd:simpleType>
+	<!--NameTypeEnum-->
+	<xsd:simpleType name="NameTypeEnum">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="MN"/>
+			<xsd:enumeration value="DGR"/>
+			<xsd:enumeration value="LGL"/>
+			<xsd:enumeration value="TRD"/>
+			<xsd:enumeration value="OTN"/>
+			<xsd:enumeration value="BN"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!--NonindividualNameType-->
+	<xsd:complexType name="NonIndividualNameType">
+		<xsd:sequence>
+			<xsd:element name="NonIndividualNameText" type="NonIndividualNameTextType"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="NameTypeEnum" use="required"/>
+	</xsd:complexType>
+	<!--	NonIndividualNameTextType-->
+	<xsd:simpleType name="NonIndividualNameTextType">
+		<xsd:restriction base="xsd:string"/>
+	</xsd:simpleType>
+	<!--ABNType-->
+	<xsd:complexType name="ABNType">
+		<xsd:simpleContent>
+			<xsd:extension base="ABNIdentifierType">
+				<xsd:attribute name="status" type="ABNTypeEnum" use="required"/>
+				<xsd:attribute name="ABNStatusFromDate" use="required"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--ABNIdentifierType - Follows on from ABNType above-->
+	<xsd:simpleType name="ABNIdentifierType">
+		<xsd:restriction base="xsd:string">
+			<xsd:length value="11"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!--ABNTypeEnum-->
+	<xsd:simpleType name="ABNTypeEnum">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="CAN"/>
+			<xsd:enumeration value="ACT"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!--BusinessAddressType-->
+	<xsd:complexType name="BusinessAddressType">
+		<xsd:sequence>
+			<xsd:element name="AddressDetails" type="AddressDetailsType"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--AddressDetailsType-->
+	<xsd:complexType name="AddressDetailsType">
+		<xsd:sequence>
+			<xsd:element name="State" type="StateEnum"/>
+			<xsd:element name="Postcode"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--'StateEnum-->
+	<xsd:simpleType name="StateEnum">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value=""/>
+			<xsd:enumeration value="AAT"/>
+			<xsd:enumeration value="QLD"/>
+			<xsd:enumeration value="ACT"/>
+			<xsd:enumeration value="NSW"/>
+			<xsd:enumeration value="WA"/>
+			<xsd:enumeration value="VIC"/>
+			<xsd:enumeration value="NT"/>
+			<xsd:enumeration value="TAS"/>
+			<xsd:enumeration value="SA"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+</xsd:schema>

--- a/models/au_ato_abr/code/clean_data.py
+++ b/models/au_ato_abr/code/clean_data.py
@@ -1,0 +1,459 @@
+"""Clean the Australian Business Register (ABR) ABN Bulk Extract into partitioned Parquet.
+
+Streams <ABR> records straight out of the two source ZIPs (no full extraction to
+disk) and writes three typed tables, hive-partitioned by ``extraction_date``:
+
+    output/entity/extraction_date=YYYY-MM-DD/data_*.parquet
+    output/other_name/extraction_date=YYYY-MM-DD/data_*.parquet
+    output/dgr/extraction_date=YYYY-MM-DD/data_*.parquet
+
+plus a dicionario CSV (code -> label) built from the observed enums.
+
+The ``extraction_date`` value comes from each file's <ExtractTime>. It is encoded
+in the output path only (hive style), never in the parquet body, matching the BD
+staging convention. A 0-row ``00_header.parquet`` is written first in every
+partition dir so the table-approve CI step never OOMs on a large first file.
+
+Env vars:
+    ABR_INPUT_DIR   default ~/Downloads/au_ato_abr_data/input
+    ABR_OUTPUT_DIR  default ~/Downloads/au_ato_abr_data/output
+    ABR_QUICK       if set, process only the first XML member and stop early
+                    (writes to a *_quick output dir for inspection)
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import sys
+import zipfile
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from lxml import etree
+
+HOME = Path.home()
+INPUT_DIR = Path(
+    os.environ.get("ABR_INPUT_DIR", HOME / "Downloads/au_ato_abr_data/input")
+)
+QUICK = bool(os.environ.get("ABR_QUICK"))
+_default_out = (
+    HOME
+    / "Downloads/au_ato_abr_data"
+    / ("output_quick" if QUICK else "output")
+)
+OUTPUT_DIR = Path(os.environ.get("ABR_OUTPUT_DIR", _default_out))
+
+CHUNK = 400_000  # rows per parquet file (bounds peak RAM)
+DATE_SENTINELS = {"19000101", "00000000", "10000101"}
+
+# ---- typed schemas (extraction_date lives in the path, not the file) --------
+ENTITY_COLS = [
+    "abn",
+    "abn_status",
+    "abn_status_from_date",
+    "entity_type",
+    "entity_name",
+    "asic_number",
+    "asic_number_type",
+    "gst_status",
+    "gst_status_from_date",
+    "state_code",
+    "postcode",
+    "record_last_updated_date",
+    "replaced",
+]
+ENTITY_SCHEMA = pa.schema(
+    [
+        ("abn", pa.string()),
+        ("abn_status", pa.string()),
+        ("abn_status_from_date", pa.date32()),
+        ("entity_type", pa.string()),
+        ("entity_name", pa.string()),
+        ("asic_number", pa.string()),
+        ("asic_number_type", pa.string()),
+        ("gst_status", pa.string()),
+        ("gst_status_from_date", pa.date32()),
+        ("state_code", pa.string()),
+        ("postcode", pa.string()),
+        ("record_last_updated_date", pa.date32()),
+        ("replaced", pa.string()),
+    ]
+)
+OTHER_NAME_SCHEMA = pa.schema(
+    [
+        ("abn", pa.string()),
+        ("name_type", pa.string()),
+        ("name", pa.string()),
+    ]
+)
+DGR_SCHEMA = pa.schema(
+    [
+        ("abn", pa.string()),
+        ("dgr_status_from_date", pa.date32()),
+        ("dgr_name", pa.string()),
+    ]
+)
+
+
+def pdate(s):
+    """Parse an ABR YYYYMMDD string to a date, mapping sentinels/garbage to None."""
+    if s is None:
+        return None
+    s = str(s).strip()
+    if len(s) != 8 or not s.isdigit() or s in DATE_SENTINELS:
+        return None
+    try:
+        return date(int(s[:4]), int(s[4:6]), int(s[6:8]))
+    except ValueError:
+        return None
+
+
+def clean_text(t):
+    if t is None:
+        return None
+    t = t.strip()
+    return t or None
+
+
+class PartitionWriter:
+    """Accumulates rows for one table and flushes fixed-size parquet chunks."""
+
+    def __init__(self, name, schema):
+        self.name = name
+        self.schema = schema
+        self.cols = [f.name for f in schema]
+        self.buf = {c: [] for c in self.cols}
+        self.n = 0
+        self.file_idx = 0
+        self.part_dirs = set()
+
+    def part_dir(self, extraction_date):
+        d = (
+            OUTPUT_DIR
+            / self.name
+            / f"extraction_date={extraction_date.isoformat()}"
+        )
+        if d not in self.part_dirs:
+            d.mkdir(parents=True, exist_ok=True)
+            # 0-row header first (guards table-approve CI against OOM on big first file)
+            header = pa.table(
+                {
+                    c: pa.array([], type=self.schema.field(c).type)
+                    for c in self.cols
+                },
+                schema=self.schema,
+            )
+            pq.write_table(
+                header, d / "00_header.parquet", compression="snappy"
+            )
+            self.part_dirs.add(d)
+        return d
+
+    def add(self, extraction_date, row):
+        self._ed = extraction_date
+        for c in self.cols:
+            self.buf[c].append(row.get(c))
+        self.n += 1
+        if self.n >= CHUNK:
+            self.flush()
+
+    def flush(self):
+        if self.n == 0:
+            return
+        d = self.part_dir(self._ed)
+        table = pa.table(
+            {
+                c: pa.array(self.buf[c], type=self.schema.field(c).type)
+                for c in self.cols
+            },
+            schema=self.schema,
+        )
+        self.file_idx += 1
+        pq.write_table(
+            table,
+            d / f"data_{self.file_idx:05d}.parquet",
+            compression="snappy",
+        )
+        self.buf = {c: [] for c in self.cols}
+        self.n = 0
+
+
+def parse_extract_date(stream):
+    """Read just the <ExtractTime> from the head of an XML stream -> date."""
+    ctx = etree.iterparse(stream, events=("end",), tag="ExtractTime")
+    for _, el in ctx:
+        txt = (el.text or "").strip()  # e.g. 2026-08-12T12:26:57
+        return date.fromisoformat(txt[:10])
+    return None
+
+
+def process_member(zf, member, writers, entity_types, asic_types, counts):
+    entity_w, other_w, dgr_w = writers
+    with zf.open(member) as f:
+        extraction_date = parse_extract_date(f)
+    if extraction_date is None:
+        raise RuntimeError(f"No ExtractTime in {member}")
+    with zf.open(member) as f:
+        ctx = etree.iterparse(f, events=("end",), tag="ABR")
+        for _, abr in ctx:
+            abn_el = abr.find("ABN")
+            abn = clean_text(abn_el.text) if abn_el is not None else None
+
+            et = abr.find("EntityType")
+            entity_type = (
+                clean_text(et.findtext("EntityTypeInd"))
+                if et is not None
+                else None
+            )
+            et_text = (
+                clean_text(et.findtext("EntityTypeText"))
+                if et is not None
+                else None
+            )
+            if entity_type and et_text and entity_type not in entity_types:
+                entity_types[entity_type] = et_text
+
+            # name + address: MainEntity (non-individual) XOR LegalEntity (individual)
+            main = abr.find("MainEntity")
+            legal = abr.find("LegalEntity")
+            entity_name = None
+            addr = None
+            if main is not None:
+                entity_name = clean_text(
+                    main.findtext("NonIndividualName/NonIndividualNameText")
+                )
+                addr = main.find("BusinessAddress/AddressDetails")
+            elif legal is not None:
+                ind = legal.find("IndividualName")
+                if ind is not None:
+                    parts = [
+                        clean_text(g.text) for g in ind.findall("GivenName")
+                    ]
+                    parts.append(clean_text(ind.findtext("FamilyName")))
+                    entity_name = " ".join(p for p in parts if p) or None
+                addr = legal.find("BusinessAddress/AddressDetails")
+
+            state_code = (
+                clean_text(addr.findtext("State"))
+                if addr is not None
+                else None
+            )
+            postcode = (
+                clean_text(addr.findtext("Postcode"))
+                if addr is not None
+                else None
+            )
+
+            asic_el = abr.find("ASICNumber")
+            asic_number = (
+                clean_text(asic_el.text) if asic_el is not None else None
+            )
+            asic_number_type = (
+                asic_el.get("ASICNumberType") if asic_el is not None else None
+            )
+            asic_number_type = clean_text(asic_number_type)
+            if asic_number_type:
+                asic_types.add(asic_number_type)
+
+            gst_el = abr.find("GST")
+            gst_status = (
+                clean_text(gst_el.get("status"))
+                if gst_el is not None
+                else None
+            )
+            gst_from = (
+                pdate(gst_el.get("GSTStatusFromDate"))
+                if gst_el is not None
+                else None
+            )
+
+            entity_w.add(
+                extraction_date,
+                {
+                    "abn": abn,
+                    "abn_status": clean_text(abn_el.get("status"))
+                    if abn_el is not None
+                    else None,
+                    "abn_status_from_date": pdate(
+                        abn_el.get("ABNStatusFromDate")
+                    )
+                    if abn_el is not None
+                    else None,
+                    "entity_type": entity_type,
+                    "entity_name": entity_name,
+                    "asic_number": asic_number,
+                    "asic_number_type": asic_number_type,
+                    "gst_status": gst_status,
+                    "gst_status_from_date": gst_from,
+                    "state_code": state_code,
+                    "postcode": postcode,
+                    "record_last_updated_date": pdate(
+                        abr.get("recordLastUpdatedDate")
+                    ),
+                    "replaced": clean_text(abr.get("replaced")),
+                },
+            )
+            counts["entity"] += 1
+
+            for oe in abr.findall("OtherEntity"):
+                nn = oe.find("NonIndividualName")
+                if nn is None:
+                    continue
+                other_w.add(
+                    extraction_date,
+                    {
+                        "abn": abn,
+                        "name_type": clean_text(nn.get("type")),
+                        "name": clean_text(
+                            nn.findtext("NonIndividualNameText")
+                        ),
+                    },
+                )
+                counts["other_name"] += 1
+
+            for dg in abr.findall("DGR"):
+                dgr_w.add(
+                    extraction_date,
+                    {
+                        "abn": abn,
+                        "dgr_status_from_date": pdate(
+                            dg.get("DGRStatusFromDate")
+                        ),
+                        "dgr_name": clean_text(
+                            dg.findtext(
+                                "NonIndividualName/NonIndividualNameText"
+                            )
+                        ),
+                    },
+                )
+                counts["dgr"] += 1
+
+            # free memory: drop the record and its already-processed siblings
+            abr.clear()
+            parent = abr.getparent()
+            if parent is not None:
+                while abr.getprevious() is not None:
+                    del parent[0]
+
+            if QUICK and counts["entity"] >= 200_000:
+                break
+
+
+# ---- entity_type / other static dictionaries --------------------------------
+ABN_STATUS = {"ACT": "Active", "CAN": "Cancelled"}
+GST_STATUS = {"ACT": "Registered", "CAN": "Cancelled", "NON": "Not registered"}
+NAME_TYPE = {
+    "TRD": "Trading name",
+    "BN": "Business name",
+    "OTN": "Other name",
+    "MN": "Main name",
+    "LGL": "Legal name",
+    "DGR": "DGR name",
+}
+REPLACED = {"Y": "Yes", "N": "No"}
+STATE_CODE = {
+    "NSW": "New South Wales",
+    "VIC": "Victoria",
+    "QLD": "Queensland",
+    "WA": "Western Australia",
+    "SA": "South Australia",
+    "TAS": "Tasmania",
+    "NT": "Northern Territory",
+    "ACT": "Australian Capital Territory",
+    "AAT": "Australian Antarctic Territory",
+}
+ASIC_TYPE_LABELS = {
+    "ACN": "Australian Company Number",
+    "ARBN": "Australian Registered Body Number",
+    "undetermined": "Undetermined",
+}
+
+
+def write_dicionario(entity_types, asic_types):
+    d = OUTPUT_DIR / "dicionario" / "data.csv"
+    d.parent.mkdir(parents=True, exist_ok=True)
+    rows = []
+
+    def add(table, col, mapping):
+        for k in sorted(mapping):
+            rows.append([table, col, k, "", mapping[k]])
+
+    # entity table
+    add("entity", "abn_status", ABN_STATUS)
+    add("entity", "entity_type", {k: entity_types[k] for k in entity_types})
+    add("entity", "gst_status", GST_STATUS)
+    add("entity", "state_code", STATE_CODE)
+    add(
+        "entity",
+        "asic_number_type",
+        {
+            k: ASIC_TYPE_LABELS.get(k, k.capitalize())
+            for k in sorted(asic_types)
+        },
+    )
+    add("entity", "replaced", REPLACED)
+    # other_name table
+    add("other_name", "name_type", NAME_TYPE)
+
+    with open(d, "w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(
+            [
+                "id_tabela",
+                "nome_coluna",
+                "chave",
+                "cobertura_temporal",
+                "valor",
+            ]
+        )
+        w.writerows(rows)
+    print(f"  dicionario: {len(rows)} rows -> {d}")
+
+
+def main():
+    zips = sorted(INPUT_DIR.glob("*.zip"))
+    if not zips:
+        sys.exit(f"No zips in {INPUT_DIR}")
+    print(f"Input:  {INPUT_DIR}  ({len(zips)} zips)")
+    print(f"Output: {OUTPUT_DIR}  QUICK={QUICK}")
+
+    entity_w = PartitionWriter("entity", ENTITY_SCHEMA)
+    other_w = PartitionWriter("other_name", OTHER_NAME_SCHEMA)
+    dgr_w = PartitionWriter("dgr", DGR_SCHEMA)
+    writers = (entity_w, other_w, dgr_w)
+    entity_types, asic_types = {}, set()
+    counts = {"entity": 0, "other_name": 0, "dgr": 0}
+
+    stop = False
+    for zp in zips:
+        zf = zipfile.ZipFile(zp)
+        for member in sorted(zf.namelist()):
+            if not member.lower().endswith(".xml"):
+                continue
+            print(f"  parsing {zp.name}:{member} ...", flush=True)
+            process_member(
+                zf, member, writers, entity_types, asic_types, counts
+            )
+            print(f"    running totals: {counts}", flush=True)
+            if QUICK and counts["entity"] >= 200_000:
+                stop = True
+                break
+        zf.close()
+        if stop:
+            break
+
+    for w in writers:
+        w.flush()
+    write_dicionario(entity_types, asic_types)
+
+    print("\n=== DONE ===")
+    print("counts:", counts)
+    print("entity_type codes seen:", len(entity_types))
+    print("asic_number_type values:", sorted(asic_types))
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_ato_abr/code/upload.py
+++ b/models/au_ato_abr/code/upload.py
@@ -1,0 +1,109 @@
+"""Upload cleaned au_ato_abr parquet tables to BigQuery staging.
+
+Usage:
+    GOOGLE_APPLICATION_CREDENTIALS=~/.basedosdados/credentials/staging.json \
+      ~/.local/bin/uv run python models/au_ato_abr/code/upload.py [--env dev|prod] [table ...]
+
+Dev (default) -> basedosdados-dev. Uploads smallest first, stops on first failure,
+prints the staging row count for each table so it can be checked against the
+cleaning-step totals.
+"""
+
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+import basedosdados as bd  # noqa: E402
+import google.cloud.storage as gcs  # noqa: E402
+import pyarrow as pa  # noqa: E402
+import pyarrow.csv as pacsv  # noqa: E402
+import pyarrow.parquet as pq  # noqa: E402
+from google.cloud import bigquery  # noqa: E402
+
+_argv = sys.argv[1:]
+if "--env" in _argv:
+    _i = _argv.index("--env")
+    ENV = _argv[_i + 1]
+    _argv = _argv[:_i] + _argv[_i + 2 :]
+else:
+    ENV = "dev"
+BILLING_PROJECT = "basedosdados" if ENV == "prod" else "basedosdados-dev"
+DATASET_ID = "au_ato_abr"
+OUTPUT_ROOT = Path(__file__).resolve().parent.parent / "output"
+
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+# smallest first
+TABLES = ["dicionario", "dgr", "other_name", "entity"]
+
+
+def ensure_dicionario_parquet():
+    d = OUTPUT_ROOT / "dicionario"
+    pqf = d / "data.parquet"
+    csvf = d / "data.csv"
+    if pqf.exists() or not csvf.exists():
+        return
+    t = pacsv.read_csv(csvf)
+    # force all-string
+    t = t.cast(pa.schema([(n, pa.string()) for n in t.column_names]))
+    pq.write_table(t, pqf, compression="snappy")
+    csvf.unlink()
+    print(f"  built {pqf} ({t.num_rows} rows)")
+
+
+def upload_table(slug: str) -> int:
+    path = OUTPUT_ROOT / slug
+    if not path.exists():
+        raise FileNotFoundError(f"Missing output path: {path}")
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=slug)
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=slug)
+    try:
+        st.delete_table(mode="staging", not_found_ok=True)
+    except Exception as e:
+        print(f"  [warn] staging prefix cleanup: {e}")
+
+    tb.create(
+        path=str(path),
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    client = bigquery.Client(project=BILLING_PROJECT)
+    q = f"select count(*) as n from `{BILLING_PROJECT}.{DATASET_ID}_staging.{slug}`"
+    n = next(iter(client.query(q).result())).n
+    print(f"  {slug}: {n:,} rows in staging", flush=True)
+    return n
+
+
+def main():
+    ensure_dicionario_parquet()
+    only = set(_argv)
+    tables = [t for t in TABLES if not only or t in only]
+    print(
+        f"=== uploading {tables} to {BILLING_PROJECT} (env={ENV}) ===",
+        flush=True,
+    )
+    for slug in tables:
+        print(f"=== {slug} ===", flush=True)
+        try:
+            upload_table(slug)
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+            sys.exit(1)
+    print("ALL TABLES UPLOADED")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_ato_abr/schema.yml
+++ b/models/au_ato_abr/schema.yml
@@ -1,0 +1,142 @@
+---
+version: 2
+models:
+  - name: au_ato_abr__entity
+    description: >
+      Registro de entidades do Australian Business Register (ABR), com uma linha
+      por Número de Empresa Australiano (ABN) em cada extração (snapshot). Cada
+      extração é uma fotografia completa do cadastro; a coluna extraction_date
+      identifica a data em que os dados foram extraídos pelo ABR.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [extraction_date, abn]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values: [asic_number, asic_number_type, gst_status_from_date]
+      - custom_dictionary_coverage:
+          columns_covered_by_dictionary:
+            - abn_status
+            - entity_type
+            - gst_status
+            - state_code
+            - asic_number_type
+            - replaced
+          dictionary_model: ref('au_ato_abr__dicionario')
+    columns:
+      - name: extraction_date
+        description: >
+          Data de extração do snapshot do registro (ABR)
+        tests: [not_null]
+      - name: abn
+        description: >
+          Número de Empresa Australiano (ABN), identificador único de 11 dígitos
+        tests: [not_null]
+      - name: abn_status
+        description: >
+          Situação do ABN: ativo (ACT) ou cancelado (CAN)
+      - name: abn_status_from_date
+        description: >
+          Data a partir da qual a situação atual do ABN passou a vigorar
+      - name: entity_type
+        description: >
+          Código do tipo de entidade (ex.: IND, PRV, PUB)
+      - name: entity_name
+        description: >
+          Nome legal ou principal da entidade
+      - name: asic_number
+        description: >
+          Número de registro na ASIC (ACN ou ARBN), quando aplicável
+      - name: asic_number_type
+        description: >
+          Tipo do número ASIC
+      - name: gst_status
+        description: >
+          Situação de registro no GST
+      - name: gst_status_from_date
+        description: >
+          Data a partir da qual a situação atual do GST passou a vigorar
+      - name: state_code
+        description: >
+          Sigla do estado ou território da localização comercial principal
+      - name: postcode
+        description: >
+          Código postal de 4 dígitos da localização comercial principal
+      - name: record_last_updated_date
+        description: >
+          Data da última atualização do registro no ABR
+      - name: replaced
+        description: >
+          Indicador de que o registro substituiu um anterior (Y ou N)
+  - name: au_ato_abr__other_name
+    description: >
+      Nomes fantasia, comerciais e outros nomes ("other entity names") sob os
+      quais as entidades do ABR operam. Uma linha por nome; relaciona-se à tabela
+      entity pela coluna abn.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [extraction_date, abn, name_type, name]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+      - custom_dictionary_coverage:
+          columns_covered_by_dictionary: [name_type]
+          dictionary_model: ref('au_ato_abr__dicionario')
+    columns:
+      - name: extraction_date
+        description: >
+          Data de extração do snapshot do registro (ABR)
+        tests: [not_null]
+      - name: abn
+        description: >
+          Número de Empresa Australiano (ABN) da entidade à qual o nome pertence
+        tests: [not_null]
+      - name: name_type
+        description: >
+          Tipo do nome: nome fantasia/comercial (TRD), nome de negócio (BN) ou
+          outro nome (OTN)
+      - name: name
+        description: >
+          Nome fantasia, comercial ou outro nome sob o qual a entidade opera
+  - name: au_ato_abr__dgr
+    description: >
+      Endossos de beneficiária de doações dedutíveis (Deductible Gift Recipient,
+      DGR) das entidades do ABR. Uma linha por endosso; relaciona-se à tabela
+      entity pela coluna abn.
+    tests:
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values: [dgr_name]
+    columns:
+      - name: extraction_date
+        description: >
+          Data de extração do snapshot do registro (ABR)
+        tests: [not_null]
+      - name: abn
+        description: >
+          Número de Empresa Australiano (ABN) da entidade endossada como DGR
+        tests: [not_null]
+      - name: dgr_status_from_date
+        description: >
+          Data a partir da qual a entidade foi endossada como DGR
+      - name: dgr_name
+        description: >
+          Nome do fundo ou instituição endossada como DGR, quando informado
+  - name: au_ato_abr__dicionario
+    description: >
+      Dicionário de códigos e categorias das colunas codificadas do conjunto
+      au_ato_abr.
+    columns:
+      - name: id_tabela
+        description: >
+          Nome da tabela à qual a chave se refere
+      - name: nome_coluna
+        description: >
+          Nome da coluna à qual a chave se refere
+      - name: chave
+        description: >
+          Chave (valor codificado) presente na coluna original
+      - name: cobertura_temporal
+        description: >
+          Cobertura temporal da chave
+      - name: valor
+        description: >-
+          Valor traduzido correspondente à chave


### PR DESCRIPTION
# feat(au_ato_abr): onboard Australian Business Register (ABN Bulk Extract)

Onboards **au_ato_abr** — the Australian Business Register "ABN Bulk Extract" published on data.gov.au by the Australian Taxation Office (ATO). The Australian analog of Brazil's CNPJ (`br_rf_cnpj`), France's SIRENE, and Mexico's DENUE.

## Source
- **Data**: https://data.gov.au/data/dataset/abn-bulk-extract — two split XML ZIPs, 20 files, one `<ABR>` record per business (~20.4M records).
- **License**: CC BY 3.0 AU (redistribution + commercial use permitted).
- **Cadence**: weekly full snapshot. Snapshot onboarded: `extraction_date = 2026-08-12`.

## Data model (CNPJ-style stacked snapshots)
Each weekly extract is a full photograph of the register; extracts stack, partitioned by `extraction_date` (DATE), `materialized="incremental"`.

| Table | Grain (OL `company`) | Rows |
|-------|----------------------|------|
| `entity` | one row per ABN per snapshot | 20,438,500 |
| `other_name` | trading/business/other names (`<OtherEntity>`) | 7,535,394 |
| `dgr` | Deductible Gift Recipient endorsements (`<DGR>`) | 34,981 |
| `dicionario` | code → label | 108 |

- Individuals (sole traders) included; `entity_name` carries the assembled name and is flagged `has_sensitive_data`.
- Coded columns are STRING + `dicionario` (abn_status, entity_type, gst_status, state_code, asic_number_type, replaced, name_type).
- `state_code`/`postcode` kept STRING; directory FKs to `br_bd_diretorios_au` to be wired once it lands in prod.
- No ANZSIC/industry code exists in the source.

## Verification (dev / staging backend)
- `dbt run` + `dbt test` green on all 4 models in `basedosdados-dev.au_ato_abr.*`.
- Metadata registered and dataset **published on the staging backend** (dev backend was down during onboarding); prod metadata registered `under_review`, cloud tables point at `basedosdados.au_ato_abr.*` (materialized by this merge's table-approve).

## Notes
- Cleaning streams `<ABR>` records directly from the ZIPs (no full extraction); code under `models/au_ato_abr/code/` reads scratch data outside the repo. No data committed.
- Staging tables carry a 0-row `00_header.parquet` first (guards table-approve against the large-first-file OOM).
- **Deferred**: BD-Pro rolling paywall (PartBdpro) and the recurring weekly Prefect pipeline are a follow-up — this PR is the static onboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
