### PR TITLE
feat(us_fed_fred): add recurring daily Prefect pipeline

### DIFF
--- a/models/us_fed_fred/ONBOARDING_PLAN.md
+++ b/models/us_fed_fred/ONBOARDING_PLAN.md
@@ -54,8 +54,21 @@ Never under the repo or Dropbox. Deleted at step 14.
 - [x] committed onboarding code (67b9ed8f); branch renamed claude/… → data/us_fed_fred
 - [x] 11. PR — user pushed branch; PAT couldn't create PR (403) → opened via `gh`:
       https://github.com/basedosdados/pipelines/pull/1810 (OPEN, MERGEABLE, `table-approve` label ✓)
-- [ ] 12. recurring daily pipeline — separate PR AFTER merge (user approved)
-- [ ] 13. publish prod (after merge + table-approve + verify): create_update_dataset id=4aa6290b… status=published env=prod
+- [~] 11b. table-approve (post-merge, commit 2d4f814): staging transfer OK, but prod
+      `dbt run` FAILED on BigQuery **QueryUsagePerDay** custom quota (project-wide,
+      transient — table is tiny). Reset ~00:00 Pacific / 07:00 UTC. Fix = re-run the
+      job: `gh run rerun 31769158632` (re-copies staging + runs dbt to prod) after reset.
+- [~] 12. recurring daily pipeline — BUILT + committed on branch `pipeline/us_fed_fred`
+      (commit local; push gated → user pushes). Files: pipelines/datasets/us_fed_fred/
+      {constants,utils,tasks,flows}.py; download_clean.py now imports the shared transform.
+      observation=PartBdpro(6mo), series=NonHistorical(AllFree); daily 21:00 BRT; dump overwrite.
+      Local checks PASS (imports, deploy discovery, limit=3 transform parity, ruff+pyrefly).
+      PENDING: (a) push + open PR to main **with `deploy-flow` label**; (b) FRED_API_KEY in
+      Vault secret `fred` (worker cred — user/admin, I cannot write Vault); (c) dev-pool run
+      {materialize_to_prod:False,update_metadata:False,force_run:True} = definition of done;
+      (d) after prod tables exist: create pro Coverage (is_closed=True) on observation +
+      source Update record, before arming.
+- [ ] 13. publish prod (after 11b re-run + verify): create_update_dataset id=4aa6290b… status=published env=prod
 - [ ] 14. delete ~/Downloads/us_fed_fred_data/ (rm blocked in-session → user runs, or retry)
 
 - [ ] [PAUSE — verification checkpoint]

--- a/models/us_fed_fred/code/download_clean.py
+++ b/models/us_fed_fred/code/download_clean.py
@@ -1,470 +1,66 @@
 """
-us_fed_fred — download + clean (one-shot onboarding).
+us_fed_fred — download + clean (one-shot onboarding CLI).
+
+Thin wrapper over the shared transform in
+``pipelines/datasets/us_fed_fred/utils.py`` — the SAME code the recurring daily
+pipeline runs, so the bootstrap and the pipeline cannot drift. This file only
+wires the scratch data location and a CLI; the fetch, the license gate, and the
+parquet writers all live in ``utils.py``.
 
 Pulls the curated public-domain seed series (see ../SEED_SERIES.md) from the FRED
-REST API and writes two partitioned/typed parquet outputs conforming to the
+REST API and writes two all-STRING partitioned parquet outputs conforming to the
 architecture CSVs:
 
+  input/<series_id>.json                      raw fetched series (kept only)
   output/observation/year=YYYY/data.parquet   long: year, date, series_id, value
   output/series/data.parquet                  catalog: one row per series
 
-License gate (both applied):
+License gate (both applied at download, in utils.download_all):
   1. Source allowlist  — keep only U.S.-federal-agency sources (public domain).
   2. "Copyright" in /series notes — FRED's own marker for restricted series.
-Every dropped series is logged to code/excluded_series.csv.
+Every dropped series is logged to input/_excluded.csv.
 
 Credential: FRED_API_KEY from the environment ONLY (or a gitignored .env at the
 scratch dir). Never hard-coded, never committed.
-
-Pure functions here are relocated to pipelines/datasets/us_fed_fred/utils.py at
-the recurring-pipeline step and imported back — do not duplicate the transform.
 """
 
 from __future__ import annotations
 
 import argparse
-import csv
+import logging
 import os
-import time
 from pathlib import Path
 
-import pyarrow as pa
-import pyarrow.parquet as pq
-import requests
+from pipelines.datasets.us_fed_fred.utils import clean_all, download_all
 
-BASE = "https://api.stlouisfed.org/fred"
 DATA_ROOT = Path(
     os.environ.get(
         "US_FED_FRED_DATA", Path.home() / "Downloads" / "us_fed_fred_data"
     )
 )
-CODE_DIR = Path(__file__).resolve().parent
-
-# U.S. federal-agency sources whose works are public domain (17 U.S.C. §105).
-SOURCE_ALLOWLIST = {
-    "Board of Governors of the Federal Reserve System (US)",
-    "U.S. Bureau of Labor Statistics",
-    "U.S. Bureau of Economic Analysis",
-    "U.S. Census Bureau",
-    "U.S. Department of the Treasury. Fiscal Service",
-    "U.S. Office of Management and Budget",
-    "U.S. Employment and Training Administration",
-    "Federal Reserve Bank of St. Louis",
-}
-
-# The seed set. Kept inline so the script is self-contained; mirrors SEED_SERIES.md.
-SEED_SERIES = [
-    # Board of Governors of the Federal Reserve System
-    "FEDFUNDS",
-    "DFF",
-    "DGS10",
-    "DGS2",
-    "DGS3MO",
-    "DTB3",
-    "T10Y2Y",
-    "T10Y3M",
-    "WALCL",
-    "M2SL",
-    "M1SL",
-    "BOGMBASE",
-    "INDPRO",
-    "TCU",
-    "TOTALSL",
-    "DEXUSEU",
-    "DEXJPUS",
-    "DEXCHUS",
-    # U.S. Bureau of Labor Statistics
-    "CPIAUCSL",
-    "CPILFESL",
-    "UNRATE",
-    "U6RATE",
-    "CIVPART",
-    "EMRATIO",
-    "PAYEMS",
-    "MANEMP",
-    "CES0500000003",
-    "JTSJOL",
-    "PPIACO",
-    # U.S. Bureau of Economic Analysis
-    "GDP",
-    "GDPC1",
-    "A191RL1Q225SBEA",
-    "PCE",
-    "PCEPI",
-    "PCEPILFE",
-    "DSPIC96",
-    "PSAVERT",
-    "CP",
-    # U.S. Census Bureau
-    "HOUST",
-    "PERMIT",
-    "RSAFS",
-    "DGORDER",
-    "TTLCONS",
-    "BUSINV",
-    # U.S. Treasury / Fiscal Service
-    "GFDEBTN",
-    "GFDEGDQ188S",
-    "MTSDS133FMS",
-    "FYFSD",
-    # U.S. Employment and Training Administration (DOL)
-    "ICSA",
-    # Federal Reserve Bank of St. Louis (derived, public)
-    "USREC",
-]
 
 
-# --------------------------------------------------------------------------- #
-# API client
-# --------------------------------------------------------------------------- #
-def get_api_key() -> str:
-    """Return the FRED API key from the environment or the scratch ``.env``.
-
-    Returns:
-        The FRED API key.
-
-    Raises:
-        SystemExit: If no key is found in ``FRED_API_KEY`` or the ``.env``.
-    """
-    key = os.environ.get("FRED_API_KEY", "").strip()
-    if not key:
-        env_file = DATA_ROOT / ".env"
-        if env_file.exists():
-            for line in env_file.read_text().splitlines():
-                if line.strip().startswith("FRED_API_KEY"):
-                    key = line.split("=", 1)[1].strip().strip("'\"")
-                    break
-    if not key:
-        raise SystemExit(
-            "FRED_API_KEY not set. Export it in the environment "
-            "(export FRED_API_KEY=...) or put it in "
-            f"{DATA_ROOT / '.env'} (gitignored). Free key: "
-            "https://fredaccount.stlouisfed.org/apikeys"
-        )
-    return key
-
-
-_SESSION = requests.Session()
-_LAST_CALL = [0.0]
-_MIN_INTERVAL = 0.6  # ~100 req/min, safely under the 120/min FRED limit
-
-
-def fred_get(
-    endpoint: str, api_key: str, **params: str | int
-) -> dict[str, object]:
-    """Call a FRED REST endpoint, rate-limited, and return parsed JSON.
-
-    Sleeps to stay under the 120 requests/minute limit and retries on HTTP
-    429 with linear backoff.
-
-    Args:
-        endpoint: Path under the FRED base URL (e.g. ``"series"``).
-        api_key: The FRED API key.
-        **params: Extra query parameters (e.g. ``series_id``, ``release_id``).
-
-    Returns:
-        The decoded JSON response body.
-
-    Raises:
-        RuntimeError: If the endpoint stays rate-limited after retries.
-    """
-    params.update({"api_key": api_key, "file_type": "json"})
-    for attempt in range(5):
-        wait = _MIN_INTERVAL - (time.time() - _LAST_CALL[0])
-        if wait > 0:
-            time.sleep(wait)
-        _LAST_CALL[0] = time.time()
-        r = _SESSION.get(f"{BASE}/{endpoint}", params=params, timeout=60)
-        if r.status_code == 429:
-            time.sleep(5 * (attempt + 1))
-            continue
-        r.raise_for_status()
-        return r.json()
-    raise RuntimeError(f"FRED API repeatedly rate-limited on {endpoint}")
-
-
-# --------------------------------------------------------------------------- #
-# Metadata + license resolution
-# --------------------------------------------------------------------------- #
-_RELEASE_SOURCE_CACHE: dict[str, str] = {}
-
-
-def resolve_source_name(series_id: str, api_key: str) -> tuple[str, str]:
-    """Return (release_name, source_name) via series -> release -> sources."""
-    rel = fred_get("series/release", api_key, series_id=series_id)
-    releases = rel.get("releases", [])
-    if not releases:
-        return "", ""
-    release = releases[0]
-    release_id = str(release["id"])
-    release_name = release.get("name", "")
-    if release_id not in _RELEASE_SOURCE_CACHE:
-        src = fred_get("release/sources", api_key, release_id=release_id)
-        names = [s.get("name", "") for s in src.get("sources", [])]
-        _RELEASE_SOURCE_CACHE[release_id] = names[0] if names else ""
-    return release_name, _RELEASE_SOURCE_CACHE[release_id]
-
-
-def fetch_series_meta(
-    series_id: str, api_key: str
-) -> dict[str, object] | None:
-    """Return the ``/series`` metadata object for a series, or None.
-
-    Args:
-        series_id: The FRED series identifier.
-        api_key: The FRED API key.
-
-    Returns:
-        The series metadata dict, or ``None`` if the series does not exist.
-    """
-    resp = fred_get("series", api_key, series_id=series_id)
-    seriess = resp.get("seriess", [])
-    return seriess[0] if seriess else None
-
-
-def is_copyrighted(notes: str) -> bool:
-    """Return whether the series notes flag it as copyrighted.
-
-    FRED marks restricted third-party series with the word "Copyright" in
-    their notes; such series are excluded from this public-domain dataset.
-
-    Args:
-        notes: The series ``notes`` text.
-
-    Returns:
-        True if the notes contain "copyright" (case-insensitive).
-    """
-    return "copyright" in (notes or "").lower()
-
-
-# --------------------------------------------------------------------------- #
-# Observations
-# --------------------------------------------------------------------------- #
-def fetch_observations(
-    series_id: str, api_key: str
-) -> list[tuple[int, str, str, float]]:
-    """Return list of (year, date, series_id, value) for the latest revision."""
-    resp = fred_get(
-        "series/observations", api_key, series_id=series_id, sort_order="asc"
-    )
-    rows = []
-    for o in resp.get("observations", []):
-        raw = o.get("value", ".")
-        if raw in (".", "", None):
-            continue  # FRED missing marker -> NULL, dropped from the long table
-        try:
-            val = float(raw)
-        except ValueError:
-            continue
-        date = o["date"]
-        rows.append((int(date[:4]), date, series_id, val))
-    return rows
-
-
-# --------------------------------------------------------------------------- #
-# Parquet writers — all-STRING staging (us_bls_cpi convention).
-# Values pass through the architecture's REAL types first (so year serializes as
-# "1959" not "1959.0" and dates as "1959-01-01"), then cast to string via arrow
-# — never astype(str), which would render NULL as the literal "nan" and defeat
-# the dbt safe_cast. The dbt model safe_casts every column back to its real type.
-# --------------------------------------------------------------------------- #
-OBS_TYPED = pa.schema(
-    [
-        ("year", pa.int64()),
-        ("date", pa.date32()),
-        ("series_id", pa.string()),
-        ("value", pa.float64()),
-    ]
-)
-OBS_STRING = pa.schema([(f.name, pa.string()) for f in OBS_TYPED])
-
-SERIES_COLS = [
-    "series_id",
-    "title",
-    "units",
-    "units_short",
-    "frequency",
-    "frequency_short",
-    "seasonal_adjustment",
-    "seasonal_adjustment_short",
-    "observation_start",
-    "observation_end",
-    "last_updated",
-    "source_name",
-    "release_name",
-    "notes",
-]
-SERIES_SCHEMA = pa.schema([(c, pa.string()) for c in SERIES_COLS])
-
-
-def write_observations(
-    rows: list[tuple[int, str, str, float]], out_dir: Path
-) -> int:
-    """Write the long observations as year-partitioned all-STRING parquet.
-
-    Args:
-        rows: ``(year, date, series_id, value)`` tuples across all series.
-        out_dir: Output root; files land at
-            ``out_dir/observation/year=<YYYY>/data.parquet``.
-
-    Returns:
-        The total number of observation rows written.
-    """
-    import datetime as dt
-
-    by_year: dict[int, list[tuple[str, str, float]]] = {}
-    for year, date, sid, val in rows:
-        by_year.setdefault(year, []).append((date, sid, val))
-    n = 0
-    for year, recs in sorted(by_year.items()):
-        dates = [dt.date.fromisoformat(d) for d, _, _ in recs]
-        sids = [s for _, s, _ in recs]
-        vals = [v for _, _, v in recs]
-        typed = pa.table(
-            {
-                "year": pa.array([year] * len(recs), pa.int64()),
-                "date": pa.array(dates, pa.date32()),
-                "series_id": pa.array(sids, pa.string()),
-                "value": pa.array(vals, pa.float64()),
-            },
-            schema=OBS_TYPED,
-        )
-        tbl = typed.cast(OBS_STRING)  # all-STRING staging, NULLs preserved
-        pdir = out_dir / "observation" / f"year={year}"
-        pdir.mkdir(parents=True, exist_ok=True)
-        pq.write_table(tbl, pdir / "data.parquet", compression="snappy")
-        n += len(recs)
-    return n
-
-
-def write_series(catalog: list[dict[str, str]], out_dir: Path) -> int:
-    """Write the series metadata catalog as a single all-STRING parquet.
-
-    Args:
-        catalog: One dict per kept series, keyed by ``SERIES_COLS``.
-        out_dir: Output root; the file lands at
-            ``out_dir/series/data.parquet``.
-
-    Returns:
-        The number of series written.
-    """
-    cols = SERIES_SCHEMA.names
-    arrays = {
-        c: pa.array([r.get(c, "") or "" for r in catalog], pa.string())
-        for c in cols
-    }
-    tbl = pa.table(arrays, schema=SERIES_SCHEMA)
-    sdir = out_dir / "series"
-    sdir.mkdir(parents=True, exist_ok=True)
-    pq.write_table(tbl, sdir / "data.parquet", compression="snappy")
-    return len(catalog)
-
-
-# --------------------------------------------------------------------------- #
-# Orchestration
-# --------------------------------------------------------------------------- #
 def run(limit: int | None = None) -> None:
     """Download the seed series, apply the license gate, and write parquet.
 
-    For each seed series, resolves its source, drops it if copyrighted or
-    outside the public-domain source allowlist (logging the reason), and
-    writes the kept observations and catalog to ``DATA_ROOT/output``.
-
     Args:
-        limit: If given, only process the first ``limit`` seed series
-            (used for smoke tests).
+        limit: If given, only process the first ``limit`` seed series (smoke test).
     """
-    api_key = get_api_key()
-    out_dir = DATA_ROOT / "output"
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    kept_catalog: list[dict[str, str]] = []
-    all_obs: list[tuple[int, str, str, float]] = []
-    excluded: list[dict[str, str]] = []
-    series_ids = SEED_SERIES[:limit] if limit else SEED_SERIES
-
-    for i, sid in enumerate(series_ids, 1):
-        meta = fetch_series_meta(sid, api_key)
-        if meta is None:
-            excluded.append(
-                {"series_id": sid, "source_name": "", "reason": "not found"}
-            )
-            print(f"[{i}/{len(series_ids)}] {sid}: NOT FOUND — skipped")
-            continue
-        notes = meta.get("notes", "") or ""
-        release_name, source_name = resolve_source_name(sid, api_key)
-
-        if is_copyrighted(notes):
-            excluded.append(
-                {
-                    "series_id": sid,
-                    "source_name": source_name,
-                    "reason": "copyright in notes",
-                }
-            )
-            print(
-                f"[{i}/{len(series_ids)}] {sid}: EXCLUDED (copyright in notes)"
-            )
-            continue
-        # Reject an unresolved (empty) source too: it was never verified
-        # against the public-domain allowlist, so it must not be published.
-        if source_name not in SOURCE_ALLOWLIST:
-            excluded.append(
-                {
-                    "series_id": sid,
-                    "source_name": source_name,
-                    "reason": "source missing or not in allowlist",
-                }
-            )
-            shown = source_name or "(unresolved)"
-            print(f"[{i}/{len(series_ids)}] {sid}: EXCLUDED (source: {shown})")
-            continue
-
-        obs = fetch_observations(sid, api_key)
-        all_obs.extend(obs)
-        kept_catalog.append(
-            {
-                "series_id": sid,
-                "title": meta.get("title", ""),
-                "units": meta.get("units", ""),
-                "units_short": meta.get("units_short", ""),
-                "frequency": meta.get("frequency", ""),
-                "frequency_short": meta.get("frequency_short", ""),
-                "seasonal_adjustment": meta.get("seasonal_adjustment", ""),
-                "seasonal_adjustment_short": meta.get(
-                    "seasonal_adjustment_short", ""
-                ),
-                "observation_start": meta.get("observation_start", ""),
-                "observation_end": meta.get("observation_end", ""),
-                "last_updated": meta.get("last_updated", ""),
-                "source_name": source_name,
-                "release_name": release_name,
-                "notes": notes,
-            }
-        )
-        print(
-            f"[{i}/{len(series_ids)}] {sid}: {len(obs):>7} obs  ({source_name})"
-        )
-
-    n_obs = write_observations(all_obs, out_dir)
-    n_ser = write_series(kept_catalog, out_dir)
-
-    excl_path = CODE_DIR / "excluded_series.csv"
-    with excl_path.open("w", newline="") as f:
-        w = csv.DictWriter(
-            f, fieldnames=["series_id", "source_name", "reason"]
-        )
-        w.writeheader()
-        w.writerows(excluded)
+    input_dir = DATA_ROOT / "input"
+    output_dir = DATA_ROOT / "output"
+    download_all(input_dir, limit=limit)
+    result = clean_all(input_dir, output_dir)
 
     print("\n=== SUMMARY ===")
-    print(f"series kept   : {n_ser}")
-    print(f"observations  : {n_obs:,}")
-    print(f"series excluded: {len(excluded)}  (see {excl_path})")
-    print(f"output        : {out_dir}")
+    print(f"series kept   : {result['n_series']}")
+    print(f"observations  : {result['n_observation']:,}")
+    print(f"max date      : {result['max_date']}")
+    print(f"excluded log  : {input_dir / '_excluded.csv'}")
+    print(f"output        : {output_dir}")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     ap = argparse.ArgumentParser()
     ap.add_argument(
         "--limit",

--- a/pipelines/datasets/us_fed_fred/constants.py
+++ b/pipelines/datasets/us_fed_fred/constants.py
@@ -1,0 +1,137 @@
+"""Constants for the us_fed_fred recurring pipeline (Prefect 3).
+
+FRED (Federal Reserve Bank of St. Louis) public-domain seed series. The curated
+list and the two-filter license gate are documented in
+``models/us_fed_fred/SEED_SERIES.md``; the full design is in
+``models/us_fed_fred/ONBOARDING_PLAN.md``. The cleaning transform is shared with
+the one-shot bootstrap in ``models/us_fed_fred/code/`` — see ``utils.py``.
+"""
+
+from enum import Enum
+from pathlib import Path
+
+# Repo root, then the committed architecture CSVs (the single schema source of
+# truth — column order + bigquery_type per table).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class constants(Enum):
+    """Constants for the us_fed_fred pipeline.
+
+    Lowercase class name follows the repo-wide convention for dataset constant
+    enums. ``ARCHITECTURE_DIR`` points at the architecture CSVs under
+    ``models/us_fed_fred/code/``, which are the schema source of truth for both
+    this pipeline and the one-shot bootstrap.
+    """
+
+    DATASET_ID = "us_fed_fred"
+
+    BASE_URL = "https://api.stlouisfed.org/fred"
+    # ~100 req/min, safely under FRED's 120/min limit.
+    MIN_INTERVAL = 0.6
+
+    # FRED API key on the deployed worker: Vault secret path + key inside it.
+    # Local/bootstrap runs read FRED_API_KEY from the environment instead.
+    VAULT_SECRET_PATH = "fred"
+    VAULT_SECRET_KEY = "FRED_API_KEY"
+
+    # U.S. federal-agency sources whose works are public domain (17 U.S.C. §105).
+    # Tuple (hashable) so it is a valid Enum value; used as a set at call sites.
+    SOURCE_ALLOWLIST = (
+        "Board of Governors of the Federal Reserve System (US)",
+        "U.S. Bureau of Labor Statistics",
+        "U.S. Bureau of Economic Analysis",
+        "U.S. Census Bureau",
+        "U.S. Department of the Treasury. Fiscal Service",
+        "U.S. Office of Management and Budget",
+        "U.S. Employment and Training Administration",
+        "Federal Reserve Bank of St. Louis",
+    )
+
+    # The curated seed set — mirrors SEED_SERIES.md. Each is verified against the
+    # license gate at download; any entry failing a filter is dropped and logged.
+    SEED_SERIES = [
+        # Board of Governors of the Federal Reserve System
+        "FEDFUNDS",
+        "DFF",
+        "DGS10",
+        "DGS2",
+        "DGS3MO",
+        "DTB3",
+        "T10Y2Y",
+        "T10Y3M",
+        "WALCL",
+        "M2SL",
+        "M1SL",
+        "BOGMBASE",
+        "INDPRO",
+        "TCU",
+        "TOTALSL",
+        "DEXUSEU",
+        "DEXJPUS",
+        "DEXCHUS",
+        # U.S. Bureau of Labor Statistics
+        "CPIAUCSL",
+        "CPILFESL",
+        "UNRATE",
+        "U6RATE",
+        "CIVPART",
+        "EMRATIO",
+        "PAYEMS",
+        "MANEMP",
+        "CES0500000003",
+        "JTSJOL",
+        "PPIACO",
+        # U.S. Bureau of Economic Analysis
+        "GDP",
+        "GDPC1",
+        "A191RL1Q225SBEA",
+        "PCE",
+        "PCEPI",
+        "PCEPILFE",
+        "DSPIC96",
+        "PSAVERT",
+        "CP",
+        # U.S. Census Bureau
+        "HOUST",
+        "PERMIT",
+        "RSAFS",
+        "DGORDER",
+        "TTLCONS",
+        "BUSINV",
+        # U.S. Treasury / Fiscal Service (GFDEGDQ188S, FYFSD resolve to OMB)
+        "GFDEBTN",
+        "GFDEGDQ188S",
+        "MTSDS133FMS",
+        "FYFSD",
+        # U.S. Employment and Training Administration (DOL)
+        "ICSA",
+        # Federal Reserve Bank of St. Louis (derived, public)
+        "USREC",
+    ]
+
+    # series catalog column order (architecture order). Kept here so the raw
+    # download JSON and the parquet writer agree without re-reading the CSV.
+    SERIES_COLS = [
+        "series_id",
+        "title",
+        "units",
+        "units_short",
+        "frequency",
+        "frequency_short",
+        "seasonal_adjustment",
+        "seasonal_adjustment_short",
+        "observation_start",
+        "observation_end",
+        "last_updated",
+        "source_name",
+        "release_name",
+        "notes",
+    ]
+
+    DATA_TABLES = ["observation", "series"]
+    ALL_TABLES = ["observation", "series"]
+
+    ARCHITECTURE_DIR = (
+        _REPO_ROOT / "models" / "us_fed_fred" / "code" / "architecture"
+    )

--- a/pipelines/datasets/us_fed_fred/flows.py
+++ b/pipelines/datasets/us_fed_fred/flows.py
@@ -1,0 +1,188 @@
+"""
+Flows for us_fed_fred — Prefect 3.
+
+FRED (Federal Reserve Bank of St. Louis) public-domain economic series. FRED
+serves the full history of each series on every call (latest revision only), so
+each run is a **full replace** (``dump_mode="overwrite"``), not an incremental
+append. A single flow downloads the seed series, rebuilds both tables, and
+materializes them. The source poll short-circuits the run when no series has a
+newer observation, making a scheduled daily run a cheap no-op between releases.
+
+``observation`` is high-frequency (daily/weekly series), so it carries the BD Pro
+rolling window: the most recent 6 months are pro-only, everything older is free.
+``series`` is a metadata catalog and stays fully free (``NonHistorical`` coverage
+from the table's last-modified time).
+
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``us_fed_fred_flow``;
+the dev pool ignores the schedule, the prod pool activates it.
+"""
+
+import shutil
+import tempfile
+
+from prefect import flow
+
+from pipelines.datasets.us_fed_fred.constants import constants
+from pipelines.datasets.us_fed_fred.tasks import clean_fred, download_fred
+from pipelines.utils.metadata.domain import (
+    DateFormat,
+    DateOnly,
+    FreeLag,
+    NonHistorical,
+    PartBdpro,
+)
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+
+# Coverage spec per table.
+#
+# `observation` is the high-frequency table, so it carries the BD Pro rolling
+# window: the most recent 6 months are pro-only, everything older is free. Each
+# run recomputes free_end = source_end - free_lag, rewrites both DateTimeRanges,
+# and re-issues the BigQuery Row Access Policies, so the window slides forward on
+# its own. part_bdpro requires BOTH a free (is_closed=False) and a pro
+# (is_closed=True) Coverage to already exist on the table, or
+# assert_coverage_topology raises before anything is written — the pro Coverage is
+# created once at onboarding (the table was first registered AllFree).
+#
+# `series` is a metadata catalog with no time dimension, so its coverage is a
+# single NonHistorical range from the table's last-modified time — fully free.
+_COVERAGE = {
+    "observation": PartBdpro(
+        date_column=DateOnly(col="date"),
+        date_format=DateFormat.YEAR_MD,
+        free_lag=FreeLag(unit="months", value=6),
+    ),
+    "series": NonHistorical(),
+}
+
+
+@flow(name="us_fed_fred", log_prints=True)
+def us_fed_fred_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+) -> None:
+    """Download the FRED seed series, rebuild both tables, materialize them.
+
+    FRED serves the full history of each series on every call, so each run is a
+    full replace (``dump_mode="overwrite"``) rather than an incremental append.
+    The source poll short-circuits the run when no series has a newer observation,
+    which makes a scheduled daily run a cheap no-op between releases.
+
+    Args:
+        materialize_to_prod: Continue past the dev materialization to write the
+            prod staging bucket and run dbt against ``target="prod"``. Set False
+            to exercise only the dev half — required for a safe test run, since
+            the default writes production.
+        update_metadata: After a successful prod materialization, register table
+            coverage and commit the source update. Has no effect when
+            ``materialize_to_prod`` is False.
+        force_run: Materialize even when the source poll reports no new data.
+    """
+    # pyrefly: ignore [unused-coroutine]
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id="observation"
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="us_fed_fred_")
+    try:
+        input_dir = download_fred(work_dir=work_dir)
+        result = clean_fred(work_dir=work_dir, input_dir=input_dir)
+        max_date = result["max_date"]
+
+        # Skip the run when no series has a newer observation than what the
+        # observation coverage already spans (unless forced).
+        has_new_data = poll_source_for_update_task(
+            dataset_id=DATASET_ID,
+            table_id="observation",
+            source_max_date=max_date,
+            env="prod",
+            date_format="%Y-%m-%d",
+            compare_against="coverage",
+        )
+        if not has_new_data and not force_run:
+            return
+
+        # Commit the source Update here, before materializing: if the flow fails
+        # midway, the source metadata still reflects that new data was published.
+        commit_source_update_task(
+            dataset_id=DATASET_ID,
+            table_id="observation",
+            source_max_date=max_date,
+            env="prod",
+            date_format="%Y-%m-%d",
+            update_metadata=update_metadata,
+            materialize_after_dump=materialize_to_prod,
+        )
+
+        tables = constants.ALL_TABLES.value
+
+        # Dev: upload staging + materialize/test.
+        for table in tables:
+            upload_to_gcs(
+                data_path=result[table],
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados-dev",
+                dump_mode="overwrite",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="dev",
+            )
+
+        if not materialize_to_prod:
+            return
+
+        # Prod: upload staging + materialize/test.
+        for table in tables:
+            upload_to_gcs(
+                data_path=result[table],
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados",
+                dump_mode="overwrite",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="prod",
+            )
+
+        if update_metadata:
+            for table, coverage in _COVERAGE.items():
+                register_table_materialization_task(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    coverage=coverage,
+                    env="prod",
+                    bq_project="basedosdados",
+                )
+    finally:
+        # Covers both early returns (no new data, dev-only) and any exception.
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# FRED updates on US business days through the afternoon (ET). Poll once daily at
+# 21:00 BRT (~19:00-20:00 ET); the source-poll guard no-ops on days with no new
+# observation, so a plain daily cron is cheap.
+# pyrefly: ignore [missing-attribute]
+us_fed_fred_flow.deploy_schedules = [
+    {"cron": "0 21 * * *", "timezone": "America/Sao_Paulo"}
+]

--- a/pipelines/datasets/us_fed_fred/tasks.py
+++ b/pipelines/datasets/us_fed_fred/tasks.py
@@ -1,0 +1,46 @@
+"""Prefect 3 tasks for us_fed_fred — thin wrappers over utils.py."""
+
+from pathlib import Path
+
+from prefect import task
+
+from pipelines.datasets.us_fed_fred.utils import clean_all, download_all
+
+
+@task(retries=2, retry_delay_seconds=30)
+def download_fred(work_dir: str, limit: int | None = None) -> str:
+    """Fetch the seed series from FRED and persist the kept ones as raw JSON.
+
+    Retries twice: the FRED API intermittently rate-limits or drops a connection
+    across the ~150 calls a full run makes.
+
+    Args:
+        work_dir: Directory to download into; JSON lands in ``<work_dir>/input``.
+        limit: If given, only process the first ``limit`` seed series (smoke test).
+
+    Returns:
+        The input directory path, as a string (Prefect serializes task results).
+    """
+    input_dir = Path(work_dir) / "input"
+    download_all(input_dir, limit=limit)
+    return str(input_dir)
+
+
+@task
+def clean_fred(work_dir: str, input_dir: str) -> dict:
+    """Build the observation and series tables from the downloaded raw JSON.
+
+    Args:
+        work_dir: Directory to write into; tables land under ``<work_dir>/output``.
+        input_dir: Directory holding the raw JSON, from :func:`download_fred`.
+
+    Returns:
+        A mapping of table slug to its partitioned output directory, plus
+        ``"max_date"`` — the latest ``YYYY-MM-DD`` observation date, which drives
+        the source-update poll — and the per-table row counts.
+    """
+    output_dir = Path(work_dir) / "output"
+    result = clean_all(Path(input_dir), output_dir)
+    return {
+        k: (str(v) if isinstance(v, Path) else v) for k, v in result.items()
+    }

--- a/pipelines/datasets/us_fed_fred/utils.py
+++ b/pipelines/datasets/us_fed_fred/utils.py
@@ -1,0 +1,484 @@
+"""Download + cleaning transform for us_fed_fred (shared by the pipeline and the
+one-shot bootstrap in ``models/us_fed_fred/code/``).
+
+Pure functions (no Prefect) so they are importable and unit-testable. The
+recurring pipeline wraps them in ``@task`` (see ``tasks.py``); the bootstrap CLI
+imports ``download_all``/``clean_all`` directly. Schema/column order come from the
+architecture CSVs (the single source of truth).
+
+The work splits in two:
+
+  ``download_all(input_dir)``  fetch each seed series' metadata + observations,
+                               apply the public-domain license gate, and persist
+                               the kept series as raw JSON under ``input_dir``.
+  ``clean_all(input_dir, out)``  read that raw JSON and write the two tables as
+                               all-STRING partitioned parquet under ``out``.
+
+Splitting them lets ``clean_all`` be re-run (and transform-parity-tested) against
+a cached ``input/`` without re-hitting the FRED API.
+
+License gate (both applied at download):
+  1. Source allowlist — keep only U.S.-federal-agency sources (public domain).
+  2. "Copyright" in ``/series`` notes — FRED's own marker for restricted series.
+Every dropped series is logged to ``input_dir/_excluded.csv``.
+
+Credential: the FRED API key comes from ``FRED_API_KEY`` in the environment, a
+gitignored ``.env`` at the scratch dir, or — on the deployed worker — the Vault
+secret named by ``constants.VAULT_SECRET_PATH``. Never hard-coded, never committed.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+
+from pipelines.datasets.us_fed_fred.constants import constants
+
+log = logging.getLogger("us_fed_fred")
+
+BASE = constants.BASE_URL.value
+MIN_INTERVAL = constants.MIN_INTERVAL.value
+SEED_SERIES = constants.SEED_SERIES.value
+SOURCE_ALLOWLIST = set(constants.SOURCE_ALLOWLIST.value)
+SERIES_COLS = constants.SERIES_COLS.value
+_ARCH = constants.ARCHITECTURE_DIR.value
+
+# BigQuery type -> pyarrow type, for building the typed staging schema.
+PA = {
+    "STRING": pa.string(),
+    "INT64": pa.int64(),
+    "FLOAT64": pa.float64(),
+    "DATE": pa.date32(),
+}
+
+
+# ── schema (architecture CSVs are the source of truth) ───────────────────────
+def read_arch(table: str) -> list[dict]:
+    """Read a table's architecture CSV — the schema source of truth.
+
+    Column order and BigQuery types come from here, never from the API response,
+    so the pipeline and the one-shot bootstrap cannot drift apart.
+
+    Args:
+        table: Table slug (``"observation"`` or ``"series"``), matching the CSV
+            filename.
+
+    Returns:
+        One dict per column, in architecture order.
+    """
+    with open(_ARCH / f"{table}.csv", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def _typed_schema(table: str) -> pa.Schema:
+    """Architecture-typed pyarrow schema for a table."""
+    return pa.schema(
+        [pa.field(a["name"], PA[a["bigquery_type"]]) for a in read_arch(table)]
+    )
+
+
+def _string_schema(table: str) -> pa.Schema:
+    """All-STRING pyarrow schema for a table (staging convention)."""
+    return pa.schema(
+        [pa.field(a["name"], pa.string()) for a in read_arch(table)]
+    )
+
+
+# ── credential ───────────────────────────────────────────────────────────────
+def get_api_key() -> str:
+    """Return the FRED API key from the environment, scratch ``.env``, or Vault.
+
+    Resolution order: ``FRED_API_KEY`` in the environment (local/bootstrap runs),
+    then a gitignored ``.env`` at the scratch dir, then — on the deployed worker —
+    the Vault secret named by ``constants.VAULT_SECRET_PATH``. The Vault import is
+    lazy so local runs need no ``VAULT_ADDRESS``/``VAULT_TOKEN``.
+
+    Returns:
+        The FRED API key.
+
+    Raises:
+        RuntimeError: If no key is found in any source.
+    """
+    key = os.environ.get("FRED_API_KEY", "").strip()
+    if key:
+        return key
+
+    scratch = Path(
+        os.environ.get(
+            "US_FED_FRED_DATA", Path.home() / "Downloads" / "us_fed_fred_data"
+        )
+    )
+    env_file = scratch / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            if line.strip().startswith("FRED_API_KEY"):
+                return line.split("=", 1)[1].strip().strip("'\"")
+
+    try:  # deployed worker: read from Vault
+        from pipelines.utils.vault import get_credentials_from_secret
+
+        secret = get_credentials_from_secret(constants.VAULT_SECRET_PATH.value)
+        key = str(secret.get(constants.VAULT_SECRET_KEY.value, "")).strip()
+    except Exception as e:
+        log.warning(f"Vault lookup for the FRED key failed: {e}")
+        key = ""
+
+    if not key:
+        raise RuntimeError(
+            "FRED_API_KEY not found. Set it in the environment, in the scratch "
+            f"{env_file}, or in the Vault secret "
+            f"'{constants.VAULT_SECRET_PATH.value}'. Free key: "
+            "https://fredaccount.stlouisfed.org/apikeys"
+        )
+    return key
+
+
+# ── API client ───────────────────────────────────────────────────────────────
+_SESSION = requests.Session()
+_LAST_CALL = [0.0]
+
+
+def fred_get(
+    endpoint: str, api_key: str, **params: str | int
+) -> dict[str, Any]:
+    """Call a FRED REST endpoint, rate-limited, and return parsed JSON.
+
+    Sleeps to stay under the 120 requests/minute limit and retries on HTTP 429
+    with linear backoff.
+
+    Args:
+        endpoint: Path under the FRED base URL (e.g. ``"series"``).
+        api_key: The FRED API key.
+        **params: Extra query parameters (e.g. ``series_id``, ``release_id``).
+
+    Returns:
+        The decoded JSON response body.
+
+    Raises:
+        RuntimeError: If the endpoint stays rate-limited after retries.
+    """
+    params.update({"api_key": api_key, "file_type": "json"})
+    for attempt in range(5):
+        wait = MIN_INTERVAL - (time.time() - _LAST_CALL[0])
+        if wait > 0:
+            time.sleep(wait)
+        _LAST_CALL[0] = time.time()
+        r = _SESSION.get(f"{BASE}/{endpoint}", params=params, timeout=60)
+        if r.status_code == 429:
+            time.sleep(5 * (attempt + 1))
+            continue
+        r.raise_for_status()
+        return r.json()
+    raise RuntimeError(f"FRED API repeatedly rate-limited on {endpoint}")
+
+
+# ── metadata + license resolution ────────────────────────────────────────────
+_RELEASE_SOURCE_CACHE: dict[str, str] = {}
+
+
+def resolve_source_name(series_id: str, api_key: str) -> tuple[str, str]:
+    """Return ``(release_name, source_name)`` via series -> release -> sources.
+
+    Args:
+        series_id: The FRED series identifier.
+        api_key: The FRED API key.
+
+    Returns:
+        The release name and the originating source name (both ``""`` if
+        unresolved).
+    """
+    rel = fred_get("series/release", api_key, series_id=series_id)
+    releases = rel.get("releases", [])
+    if not releases:
+        return "", ""
+    release = releases[0]
+    release_id = str(release["id"])
+    release_name = release.get("name", "")
+    if release_id not in _RELEASE_SOURCE_CACHE:
+        src = fred_get("release/sources", api_key, release_id=release_id)
+        names = [s.get("name", "") for s in src.get("sources", [])]
+        _RELEASE_SOURCE_CACHE[release_id] = names[0] if names else ""
+    return release_name, _RELEASE_SOURCE_CACHE[release_id]
+
+
+def fetch_series_meta(series_id: str, api_key: str) -> dict[str, Any] | None:
+    """Return the ``/series`` metadata object for a series, or ``None``.
+
+    Args:
+        series_id: The FRED series identifier.
+        api_key: The FRED API key.
+
+    Returns:
+        The series metadata dict, or ``None`` if the series does not exist.
+    """
+    resp = fred_get("series", api_key, series_id=series_id)
+    seriess = resp.get("seriess", [])
+    return seriess[0] if seriess else None
+
+
+def is_copyrighted(notes: str) -> bool:
+    """Return whether the series notes flag it as copyrighted.
+
+    FRED marks restricted third-party series with the word "Copyright" in their
+    notes; such series are excluded from this public-domain dataset.
+
+    Args:
+        notes: The series ``notes`` text.
+
+    Returns:
+        True if the notes contain "copyright" (case-insensitive).
+    """
+    return "copyright" in (notes or "").lower()
+
+
+def fetch_observations(
+    series_id: str, api_key: str
+) -> list[tuple[str, float]]:
+    """Return ``(date, value)`` pairs for a series' latest revision.
+
+    FRED's missing marker ``.`` (and blank/unparseable values) are dropped so the
+    long table carries only real observations.
+
+    Args:
+        series_id: The FRED series identifier.
+        api_key: The FRED API key.
+
+    Returns:
+        Observations as ``(date, value)`` pairs, ascending by date.
+    """
+    resp = fred_get(
+        "series/observations", api_key, series_id=series_id, sort_order="asc"
+    )
+    rows: list[tuple[str, float]] = []
+    for o in resp.get("observations", []):
+        raw = o.get("value", ".")
+        if raw in (".", "", None):
+            continue
+        try:
+            val = float(raw)
+        except ValueError:
+            continue
+        rows.append((o["date"], val))
+    return rows
+
+
+# ── download (fetch + license gate -> raw JSON) ──────────────────────────────
+def download_all(
+    input_dir: Path, limit: int | None = None, api_key: str | None = None
+) -> Path:
+    """Fetch the seed series, apply the license gate, and persist raw JSON.
+
+    For each seed series, resolves its source, drops it if copyrighted or outside
+    the public-domain source allowlist (logging the reason), and writes each kept
+    series to ``input_dir/<series_id>.json`` as ``{"meta": {...}, "observations":
+    [[date, value], ...]}``. The kept order and the exclusion log are written to
+    ``_kept.json`` and ``_excluded.csv``.
+
+    Args:
+        input_dir: Directory to write raw JSON into; created if absent.
+        limit: If given, only process the first ``limit`` seed series (smoke test).
+        api_key: FRED API key; resolved via :func:`get_api_key` when ``None``.
+
+    Returns:
+        The same ``input_dir``, for chaining.
+    """
+    api_key = api_key or get_api_key()
+    input_dir.mkdir(parents=True, exist_ok=True)
+    series_ids = SEED_SERIES[:limit] if limit else SEED_SERIES
+
+    kept: list[str] = []
+    excluded: list[dict[str, str]] = []
+    for i, sid in enumerate(series_ids, 1):
+        meta = fetch_series_meta(sid, api_key)
+        if meta is None:
+            excluded.append(
+                {"series_id": sid, "source_name": "", "reason": "not found"}
+            )
+            log.info(f"[{i}/{len(series_ids)}] {sid}: NOT FOUND — skipped")
+            continue
+        notes = meta.get("notes", "") or ""
+        release_name, source_name = resolve_source_name(sid, api_key)
+
+        if is_copyrighted(notes):
+            excluded.append(
+                {
+                    "series_id": sid,
+                    "source_name": source_name,
+                    "reason": "copyright in notes",
+                }
+            )
+            log.info(f"[{i}/{len(series_ids)}] {sid}: EXCLUDED (copyright)")
+            continue
+        # Reject an unresolved (empty) source too: it was never verified against
+        # the public-domain allowlist, so it must not be published.
+        if source_name not in SOURCE_ALLOWLIST:
+            excluded.append(
+                {
+                    "series_id": sid,
+                    "source_name": source_name,
+                    "reason": "source missing or not in allowlist",
+                }
+            )
+            shown = source_name or "(unresolved)"
+            log.info(
+                f"[{i}/{len(series_ids)}] {sid}: EXCLUDED (source: {shown})"
+            )
+            continue
+
+        obs = fetch_observations(sid, api_key)
+        record = {
+            "meta": {
+                "series_id": sid,
+                "title": meta.get("title", ""),
+                "units": meta.get("units", ""),
+                "units_short": meta.get("units_short", ""),
+                "frequency": meta.get("frequency", ""),
+                "frequency_short": meta.get("frequency_short", ""),
+                "seasonal_adjustment": meta.get("seasonal_adjustment", ""),
+                "seasonal_adjustment_short": meta.get(
+                    "seasonal_adjustment_short", ""
+                ),
+                "observation_start": meta.get("observation_start", ""),
+                "observation_end": meta.get("observation_end", ""),
+                "last_updated": meta.get("last_updated", ""),
+                "source_name": source_name,
+                "release_name": release_name,
+                "notes": notes,
+            },
+            "observations": obs,
+        }
+        (input_dir / f"{sid}.json").write_text(json.dumps(record))
+        kept.append(sid)
+        log.info(
+            f"[{i}/{len(series_ids)}] {sid}: {len(obs):>7} obs ({source_name})"
+        )
+
+    (input_dir / "_kept.json").write_text(json.dumps(kept))
+    with (input_dir / "_excluded.csv").open("w", newline="") as f:
+        w = csv.DictWriter(
+            f, fieldnames=["series_id", "source_name", "reason"]
+        )
+        w.writeheader()
+        w.writerows(excluded)
+    log.info(
+        f"download: {len(kept)} kept, {len(excluded)} excluded -> {input_dir}"
+    )
+    return input_dir
+
+
+# ── clean (raw JSON -> all-STRING partitioned parquet) ───────────────────────
+def _write_observation(
+    kept: list[str], input_dir: Path, out_dir: Path
+) -> tuple[int, str | None]:
+    """Write the long observations as year-partitioned all-STRING parquet.
+
+    Values pass through the architecture's real types first (so ``year``
+    serializes as ``"1959"`` not ``"1959.0"`` and ``date`` as ``"1959-01-01"``),
+    then cast to string via arrow — never ``astype(str)``, which would render a
+    NULL as the literal ``"nan"`` and defeat the dbt ``safe_cast``.
+
+    Args:
+        kept: Ordered kept series ids.
+        input_dir: Directory of raw per-series JSON.
+        out_dir: Output root; files land at
+            ``out_dir/observation/year=<YYYY>/data.parquet``.
+
+    Returns:
+        ``(row_count, max_date)`` where ``max_date`` is the latest ``YYYY-MM-DD``
+        observation date across all series (``None`` if there are no rows).
+    """
+    typed, string = _typed_schema("observation"), _string_schema("observation")
+    by_year: dict[int, list[tuple[str, str, float]]] = {}
+    max_date: str | None = None
+    for sid in kept:
+        record = json.loads((input_dir / f"{sid}.json").read_text())
+        for date, val in record["observations"]:
+            by_year.setdefault(int(date[:4]), []).append((date, sid, val))
+            if max_date is None or date > max_date:
+                max_date = date
+
+    n = 0
+    tdir = out_dir / "observation"
+    for year, recs in sorted(by_year.items()):
+        dates = [dt.date.fromisoformat(d) for d, _, _ in recs]
+        table = pa.table(
+            {
+                "year": pa.array([year] * len(recs), pa.int64()),
+                "date": pa.array(dates, pa.date32()),
+                "series_id": pa.array([s for _, s, _ in recs], pa.string()),
+                "value": pa.array([v for _, _, v in recs], pa.float64()),
+            },
+            schema=typed,
+        ).cast(string)
+        pdir = tdir / f"year={year}"
+        pdir.mkdir(parents=True, exist_ok=True)
+        pq.write_table(table, pdir / "data.parquet", compression="snappy")
+        n += len(recs)
+    log.info(f"observation: {n:,} rows -> {tdir}")
+    return n, max_date
+
+
+def _write_series(kept: list[str], input_dir: Path, out_dir: Path) -> int:
+    """Write the series metadata catalog as a single all-STRING parquet.
+
+    Args:
+        kept: Ordered kept series ids.
+        input_dir: Directory of raw per-series JSON.
+        out_dir: Output root; the file lands at ``out_dir/series/data.parquet``.
+
+    Returns:
+        The number of series written.
+    """
+    metas = [
+        json.loads((input_dir / f"{sid}.json").read_text())["meta"]
+        for sid in kept
+    ]
+    arrays = {
+        c: pa.array([str(m.get(c, "") or "") for m in metas], pa.string())
+        for c in SERIES_COLS
+    }
+    table = pa.table(arrays, schema=_string_schema("series"))
+    sdir = out_dir / "series"
+    sdir.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, sdir / "data.parquet", compression="snappy")
+    log.info(f"series: {len(metas):,} rows -> {sdir}")
+    return len(metas)
+
+
+def clean_all(input_dir: Path, output_dir: Path) -> dict:
+    """Build both tables from the raw JSON downloaded by :func:`download_all`.
+
+    The single entry point shared by the recurring pipeline (via
+    :func:`pipelines.datasets.us_fed_fred.tasks.clean_fred`) and the one-shot
+    bootstrap in ``models/us_fed_fred/code/``.
+
+    Args:
+        input_dir: Directory of raw per-series JSON (from :func:`download_all`).
+        output_dir: Root output directory.
+
+    Returns:
+        Mapping of table slug to output directory, plus ``"max_date"`` — the
+        latest ``YYYY-MM-DD`` observation date, used to poll whether the source
+        has newer data — and the row counts ``"n_observation"``/``"n_series"``.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    kept = json.loads((input_dir / "_kept.json").read_text())
+    n_obs, max_date = _write_observation(kept, input_dir, output_dir)
+    n_ser = _write_series(kept, input_dir, output_dir)
+    return {
+        "observation": output_dir / "observation",
+        "series": output_dir / "series",
+        "max_date": max_date,
+        "n_observation": n_obs,
+        "n_series": n_ser,
+    }


### PR DESCRIPTION
## What

Adds the recurring **daily** Prefect 3 pipeline for `us_fed_fred`, refreshing the
already-onboarded dataset (PR #1810) from the FRED REST API.

## Design

- **DRY with the onboarding.** The pure download/clean transform lives once in
  `pipelines/datasets/us_fed_fred/utils.py` (license gate + all-STRING partitioned
  parquet, schema driven by the architecture CSVs). The one-shot bootstrap
  `models/us_fed_fred/code/download_clean.py` now **imports** it instead of
  duplicating the logic.
- **Full replace each run.** FRED serves the full history of each series on every
  call (latest revision only), so `dump_mode="overwrite"`, not append.
- **Source poll** on `observation` (`%Y-%m-%d`, `compare_against="coverage"`)
  short-circuits days with no new observation, so a scheduled daily run is a cheap
  no-op between releases.
- **Coverage:** `observation` = `PartBdpro(free_lag=6 months)` (BD Pro rolling
  window on the high-frequency table); `series` = `NonHistorical` (metadata
  catalog, fully free).
- **Schedule:** daily `0 21 * * *` `America/Sao_Paulo`.
- **Credential:** `FRED_API_KEY` resolved via `get_api_key()` — environment, then a
  gitignored scratch `.env`, then the Vault secret `fred` on the deployed worker.

## Verified locally

- Imports; deploy discovery finds `us_fed_fred_flow`.
- Transform parity (limit=3): all-STRING schema matches the architecture, `year`
  serializes as `"1954"`, dates ISO, NULLs preserved.
- `ruff check` + `ruff format` + `pyrefly` clean.

## Before arming (follow-ups, not in this PR)

- **`FRED_API_KEY` must exist in Vault** (secret `fred`) or the worker download fails.
- A **dev-pool test run** `{materialize_to_prod: False, update_metadata: False,
  force_run: True}` is the definition of done.
- The prod `observation` table needs a **pro Coverage** (`is_closed=True`) created
  before the first armed run, or `assert_coverage_topology` hard-fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
