### PR TITLE
feat(br_cgu_sancoes): onboard CGU sanction registries (CEIS, CNEP, CEPIM, leniency agreements)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -223,6 +223,9 @@ models:
     br_cgu_receitas_publicas:
       +materialized: table
       +schema: br_cgu_receitas_publicas
+    br_cgu_sancoes:
+      +materialized: table
+      +schema: br_cgu_sancoes
     br_cgu_servidores_executivo_federal:
       +materialized: table
       +schema: br_cgu_servidores_executivo_federal

--- a/models/br_cgu_sancoes/br_cgu_sancoes__acordos_leniencia.sql
+++ b/models/br_cgu_sancoes/br_cgu_sancoes__acordos_leniencia.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        schema="br_cgu_sancoes",
+        alias="acordos_leniencia",
+        materialized="table",
+        partition_by={
+            "field": "data_extracao",
+            "data_type": "date",
+            "granularity": "day",
+        },
+    )
+}}
+
+
+select
+    safe_cast(data_extracao as date) data_extracao,
+    safe_cast(id_acordo as string) id_acordo,
+    safe_cast(cnpj_sancionado as string) cnpj_sancionado,
+    safe_cast(razao_social_receita as string) razao_social_receita,
+    safe_cast(nome_fantasia_receita as string) nome_fantasia_receita,
+    safe_cast(data_inicio_acordo as date) data_inicio_acordo,
+    safe_cast(data_fim_acordo as date) data_fim_acordo,
+    safe_cast(situacao_acordo as string) situacao_acordo,
+    safe_cast(data_informacao as date) data_informacao,
+    safe_cast(numero_processo as string) numero_processo,
+    safe_cast(termos_acordo as string) termos_acordo,
+    safe_cast(orgao_sancionador as string) orgao_sancionador
+from {{ set_datalake_project("br_cgu_sancoes_staging.acordos_leniencia") }} as t

--- a/models/br_cgu_sancoes/br_cgu_sancoes__acordos_leniencia_efeitos.sql
+++ b/models/br_cgu_sancoes/br_cgu_sancoes__acordos_leniencia_efeitos.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        schema="br_cgu_sancoes",
+        alias="acordos_leniencia_efeitos",
+        materialized="table",
+        partition_by={
+            "field": "data_extracao",
+            "data_type": "date",
+            "granularity": "day",
+        },
+    )
+}}
+
+
+select
+    safe_cast(data_extracao as date) data_extracao,
+    safe_cast(id_acordo as string) id_acordo,
+    safe_cast(efeito as string) efeito,
+    safe_cast(complemento as string) complemento
+from {{ set_datalake_project("br_cgu_sancoes_staging.acordos_leniencia_efeitos") }} as t

--- a/models/br_cgu_sancoes/br_cgu_sancoes__ceis.sql
+++ b/models/br_cgu_sancoes/br_cgu_sancoes__ceis.sql
@@ -1,0 +1,41 @@
+{{
+    config(
+        schema="br_cgu_sancoes",
+        alias="ceis",
+        materialized="table",
+        partition_by={
+            "field": "data_extracao",
+            "data_type": "date",
+            "granularity": "day",
+        },
+    )
+}}
+
+
+select
+    safe_cast(data_extracao as date) data_extracao,
+    safe_cast(cadastro as string) cadastro,
+    safe_cast(codigo_sancao as string) codigo_sancao,
+    safe_cast(tipo_pessoa as string) tipo_pessoa,
+    safe_cast(cpf_cnpj_sancionado as string) cpf_cnpj_sancionado,
+    safe_cast(nome_sancionado as string) nome_sancionado,
+    safe_cast(nome_informado_orgao as string) nome_informado_orgao,
+    safe_cast(razao_social_receita as string) razao_social_receita,
+    safe_cast(nome_fantasia_receita as string) nome_fantasia_receita,
+    safe_cast(numero_processo as string) numero_processo,
+    safe_cast(categoria_sancao as string) categoria_sancao,
+    safe_cast(data_inicio_sancao as date) data_inicio_sancao,
+    safe_cast(data_final_sancao as date) data_final_sancao,
+    safe_cast(data_publicacao as date) data_publicacao,
+    safe_cast(publicacao as string) publicacao,
+    safe_cast(detalhamento_meio_publicacao as string) detalhamento_meio_publicacao,
+    safe_cast(data_transito_julgado as date) data_transito_julgado,
+    safe_cast(abrangencia_sancao as string) abrangencia_sancao,
+    safe_cast(orgao_sancionador as string) orgao_sancionador,
+    safe_cast(sigla_uf_orgao as string) sigla_uf_orgao,
+    safe_cast(esfera_orgao as string) esfera_orgao,
+    safe_cast(fundamentacao_legal as string) fundamentacao_legal,
+    safe_cast(data_origem_informacao as date) data_origem_informacao,
+    safe_cast(origem_informacao as string) origem_informacao,
+    safe_cast(observacoes as string) observacoes
+from {{ set_datalake_project("br_cgu_sancoes_staging.ceis") }} as t

--- a/models/br_cgu_sancoes/br_cgu_sancoes__cepim.sql
+++ b/models/br_cgu_sancoes/br_cgu_sancoes__cepim.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        schema="br_cgu_sancoes",
+        alias="cepim",
+        materialized="table",
+        partition_by={
+            "field": "data_extracao",
+            "data_type": "date",
+            "granularity": "day",
+        },
+    )
+}}
+
+
+select
+    safe_cast(data_extracao as date) data_extracao,
+    safe_cast(cnpj_entidade as string) cnpj_entidade,
+    safe_cast(nome_entidade as string) nome_entidade,
+    safe_cast(numero_convenio as string) numero_convenio,
+    safe_cast(orgao_concedente as string) orgao_concedente,
+    safe_cast(motivo_impedimento as string) motivo_impedimento
+from {{ set_datalake_project("br_cgu_sancoes_staging.cepim") }} as t

--- a/models/br_cgu_sancoes/br_cgu_sancoes__cnep.sql
+++ b/models/br_cgu_sancoes/br_cgu_sancoes__cnep.sql
@@ -1,0 +1,42 @@
+{{
+    config(
+        schema="br_cgu_sancoes",
+        alias="cnep",
+        materialized="table",
+        partition_by={
+            "field": "data_extracao",
+            "data_type": "date",
+            "granularity": "day",
+        },
+    )
+}}
+
+
+select
+    safe_cast(data_extracao as date) data_extracao,
+    safe_cast(cadastro as string) cadastro,
+    safe_cast(codigo_sancao as string) codigo_sancao,
+    safe_cast(tipo_pessoa as string) tipo_pessoa,
+    safe_cast(cpf_cnpj_sancionado as string) cpf_cnpj_sancionado,
+    safe_cast(nome_sancionado as string) nome_sancionado,
+    safe_cast(nome_informado_orgao as string) nome_informado_orgao,
+    safe_cast(razao_social_receita as string) razao_social_receita,
+    safe_cast(nome_fantasia_receita as string) nome_fantasia_receita,
+    safe_cast(numero_processo as string) numero_processo,
+    safe_cast(categoria_sancao as string) categoria_sancao,
+    safe_cast(valor_multa as float64) valor_multa,
+    safe_cast(data_inicio_sancao as date) data_inicio_sancao,
+    safe_cast(data_final_sancao as date) data_final_sancao,
+    safe_cast(data_publicacao as date) data_publicacao,
+    safe_cast(publicacao as string) publicacao,
+    safe_cast(detalhamento_meio_publicacao as string) detalhamento_meio_publicacao,
+    safe_cast(data_transito_julgado as date) data_transito_julgado,
+    safe_cast(abrangencia_sancao as string) abrangencia_sancao,
+    safe_cast(orgao_sancionador as string) orgao_sancionador,
+    safe_cast(sigla_uf_orgao as string) sigla_uf_orgao,
+    safe_cast(esfera_orgao as string) esfera_orgao,
+    safe_cast(fundamentacao_legal as string) fundamentacao_legal,
+    safe_cast(data_origem_informacao as date) data_origem_informacao,
+    safe_cast(origem_informacao as string) origem_informacao,
+    safe_cast(observacoes as string) observacoes
+from {{ set_datalake_project("br_cgu_sancoes_staging.cnep") }} as t

--- a/models/br_cgu_sancoes/br_cgu_sancoes__dicionario.sql
+++ b/models/br_cgu_sancoes/br_cgu_sancoes__dicionario.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        schema="br_cgu_sancoes",
+        alias="dicionario",
+        materialized="table",
+    )
+}}
+
+
+select
+    safe_cast(id_tabela as string) id_tabela,
+    safe_cast(nome_coluna as string) nome_coluna,
+    safe_cast(chave as string) chave,
+    safe_cast(cobertura_temporal as string) cobertura_temporal,
+    safe_cast(valor as string) valor
+from {{ set_datalake_project("br_cgu_sancoes_staging.dicionario") }} as t

--- a/models/br_cgu_sancoes/code/clean.py
+++ b/models/br_cgu_sancoes/code/clean.py
@@ -1,0 +1,363 @@
+"""Cleaning code for br_cgu_sancoes (CGU sanctions registries).
+
+Reads the raw CGU CSV extracts (ISO-8859-1, ';'-delimited, '"'-quoted, with
+embedded newlines inside quoted fields) and writes partitioned Snappy Parquet
+that conforms exactly to the architecture tables.
+
+Raw input  : $BR_CGU_SANCOES_INPUT  (default ~/Downloads/br_cgu_sancoes_data/input)
+Parquet out: $BR_CGU_SANCOES_OUTPUT (default ~/Downloads/br_cgu_sancoes_data/output)
+
+Output layout (hive-partitioned by snapshot date):
+    output/<table>/data_extracao=YYYY-MM-DD/data.parquet
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+# --------------------------------------------------------------------------- #
+# Paths
+# --------------------------------------------------------------------------- #
+INPUT_DIR = Path(
+    os.environ.get(
+        "BR_CGU_SANCOES_INPUT",
+        os.path.expanduser("~/Downloads/br_cgu_sancoes_data/input"),
+    )
+)
+OUTPUT_DIR = Path(
+    os.environ.get(
+        "BR_CGU_SANCOES_OUTPUT",
+        os.path.expanduser("~/Downloads/br_cgu_sancoes_data/output"),
+    )
+)
+
+# --------------------------------------------------------------------------- #
+# Table specifications
+# Each spec: raw filename, snapshot date, and the ordered list of
+# (output_column, kind) AFTER the leading data_extracao column.
+# kind ∈ {"str", "date", "float"}.  Columns are mapped POSITIONALLY against the
+# raw header (which has been verified to match), skipping the data_extracao
+# column that we synthesise.
+# --------------------------------------------------------------------------- #
+CEIS_COLS = [
+    ("cadastro", "str"),
+    ("codigo_sancao", "str"),
+    ("tipo_pessoa", "str"),
+    ("cpf_cnpj_sancionado", "str"),
+    ("nome_sancionado", "str"),
+    ("nome_informado_orgao", "str"),
+    ("razao_social_receita", "str"),
+    ("nome_fantasia_receita", "str"),
+    ("numero_processo", "str"),
+    ("categoria_sancao", "str"),
+    ("data_inicio_sancao", "date"),
+    ("data_final_sancao", "date"),
+    ("data_publicacao", "date"),
+    ("publicacao", "str"),
+    ("detalhamento_meio_publicacao", "str"),
+    ("data_transito_julgado", "date"),
+    ("abrangencia_sancao", "str"),
+    ("orgao_sancionador", "str"),
+    ("sigla_uf_orgao", "str"),
+    ("esfera_orgao", "str"),
+    ("fundamentacao_legal", "str"),
+    ("data_origem_informacao", "date"),
+    ("origem_informacao", "str"),
+    ("observacoes", "str"),
+]
+
+CNEP_COLS = [
+    ("cadastro", "str"),
+    ("codigo_sancao", "str"),
+    ("tipo_pessoa", "str"),
+    ("cpf_cnpj_sancionado", "str"),
+    ("nome_sancionado", "str"),
+    ("nome_informado_orgao", "str"),
+    ("razao_social_receita", "str"),
+    ("nome_fantasia_receita", "str"),
+    ("numero_processo", "str"),
+    ("categoria_sancao", "str"),
+    ("valor_multa", "float"),
+    ("data_inicio_sancao", "date"),
+    ("data_final_sancao", "date"),
+    ("data_publicacao", "date"),
+    ("publicacao", "str"),
+    ("detalhamento_meio_publicacao", "str"),
+    ("data_transito_julgado", "date"),
+    ("abrangencia_sancao", "str"),
+    ("orgao_sancionador", "str"),
+    ("sigla_uf_orgao", "str"),
+    ("esfera_orgao", "str"),
+    ("fundamentacao_legal", "str"),
+    ("data_origem_informacao", "date"),
+    ("origem_informacao", "str"),
+    ("observacoes", "str"),
+]
+
+CEPIM_COLS = [
+    ("cnpj_entidade", "str"),
+    ("nome_entidade", "str"),
+    ("numero_convenio", "str"),
+    ("orgao_concedente", "str"),
+    ("motivo_impedimento", "str"),
+]
+
+ACORDOS_COLS = [
+    ("id_acordo", "str"),
+    ("cnpj_sancionado", "str"),
+    ("razao_social_receita", "str"),
+    ("nome_fantasia_receita", "str"),
+    ("data_inicio_acordo", "date"),
+    ("data_fim_acordo", "date"),
+    ("situacao_acordo", "str"),
+    ("data_informacao", "date"),
+    ("numero_processo", "str"),
+    ("termos_acordo", "str"),
+    ("orgao_sancionador", "str"),
+]
+
+EFEITOS_COLS = [
+    ("id_acordo", "str"),
+    ("efeito", "str"),
+    ("complemento", "str"),
+]
+
+TABLES = {
+    "ceis": {
+        "file": "20260813_CEIS.csv",
+        "snapshot": date(2026, 8, 13),
+        "cols": CEIS_COLS,
+    },
+    "cnep": {
+        "file": "20260813_CNEP.csv",
+        "snapshot": date(2026, 8, 13),
+        "cols": CNEP_COLS,
+    },
+    "cepim": {
+        "file": "20260812_CEPIM.csv",
+        "snapshot": date(2026, 8, 12),
+        "cols": CEPIM_COLS,
+    },
+    "acordos_leniencia": {
+        "file": "20260813_Acordos.csv",
+        "snapshot": date(2026, 8, 13),
+        "cols": ACORDOS_COLS,
+    },
+    "acordos_leniencia_efeitos": {
+        "file": "20260813_Efeitos.csv",
+        "snapshot": date(2026, 8, 13),
+        "cols": EFEITOS_COLS,
+    },
+}
+
+
+# --------------------------------------------------------------------------- #
+# Cleaning helpers
+# --------------------------------------------------------------------------- #
+def clean_string(s: pd.Series) -> pd.Series:
+    """Trim whitespace; empty string -> NA. 'Sem Informação' is preserved."""
+    out = s.astype(str).str.strip()
+    out = out.replace({"": pd.NA})
+    return out
+
+
+def clean_date(s: pd.Series) -> pd.Series:
+    """DD/MM/YYYY -> python date; invalid/empty -> NaT."""
+    stripped = s.astype(str).str.strip().replace({"": pd.NA})
+    parsed = pd.to_datetime(stripped, format="%d/%m/%Y", errors="coerce")
+    return parsed
+
+
+def clean_float_brl(s: pd.Series) -> pd.Series:
+    """'1.234,56' -> 1234.56; empty -> NaN."""
+    stripped = s.astype(str).str.strip()
+    stripped = stripped.replace({"": pd.NA})
+    normalized = stripped.str.replace(".", "", regex=False).str.replace(
+        ",", ".", regex=False
+    )
+    return pd.to_numeric(normalized, errors="coerce")
+
+
+def build_schema(cols: list[tuple[str, str]]) -> pa.Schema:
+    """Explicit pyarrow schema. data_extracao is the partition column and is
+    NOT part of the file schema written by pyarrow.dataset (it becomes the
+    directory), but we build the full logical schema for the in-memory table."""
+    fields = [pa.field("data_extracao", pa.date32())]
+    for name, kind in cols:
+        if kind == "date":
+            fields.append(pa.field(name, pa.date32()))
+        elif kind == "float":
+            fields.append(pa.field(name, pa.float64()))
+        else:
+            fields.append(pa.field(name, pa.string()))
+    return pa.schema(fields)
+
+
+# --------------------------------------------------------------------------- #
+# Per-table processing
+# --------------------------------------------------------------------------- #
+def process_table(name: str, spec: dict) -> pd.DataFrame:
+    path = INPUT_DIR / spec["file"]
+    cols = spec["cols"]
+    snapshot = spec["snapshot"]
+
+    # Read every field as raw string; keep_default_na=False so we handle
+    # emptiness ourselves. The C parser handles embedded newlines within
+    # quoted fields correctly.
+    raw = pd.read_csv(
+        path,
+        sep=";",
+        encoding="latin-1",
+        quotechar='"',
+        dtype=str,
+        keep_default_na=False,
+    )
+
+    n_raw_fields = raw.shape[1]
+    if n_raw_fields != len(cols):
+        raise ValueError(
+            f"{name}: raw file has {n_raw_fields} columns, "
+            f"architecture expects {len(cols)}"
+        )
+
+    # Positional mapping: rename raw columns to architecture names in order.
+    rename = {raw.columns[i]: cols[i][0] for i in range(len(cols))}
+    df = raw.rename(columns=rename)
+
+    # Apply per-column cleaning.
+    for out_name, kind in cols:
+        if kind == "date":
+            df[out_name] = clean_date(df[out_name])
+        elif kind == "float":
+            df[out_name] = clean_float_brl(df[out_name])
+        else:
+            df[out_name] = clean_string(df[out_name])
+
+    # Leading snapshot column.
+    df.insert(0, "data_extracao", snapshot)
+
+    # Enforce final column order.
+    ordered = ["data_extracao"] + [c[0] for c in cols]
+    df = df[ordered]
+
+    print(f"[{name}] parsed rows = {len(df):,} (raw file, C-parser)")
+    return df
+
+
+def to_arrow(df: pd.DataFrame, cols: list[tuple[str, str]]) -> pa.Table:
+    schema = build_schema(cols)
+    arrays = {}
+    # data_extracao
+    arrays["data_extracao"] = pa.array(df["data_extracao"], type=pa.date32())
+    for name, kind in cols:
+        if kind == "date":
+            # pandas datetime64 -> date32
+            arrays[name] = pa.array(df[name].dt.date, type=pa.date32())
+        elif kind == "float":
+            arrays[name] = pa.array(
+                df[name].astype("float64"), type=pa.float64()
+            )
+        else:
+            arrays[name] = pa.array(
+                df[name].where(df[name].notna(), None).astype(object),
+                type=pa.string(),
+            )
+    return pa.Table.from_pydict(
+        {f.name: arrays[f.name] for f in schema}, schema=schema
+    )
+
+
+def write_partitioned(table: pa.Table, name: str, snapshot: date) -> Path:
+    out_root = OUTPUT_DIR / name / f"data_extracao={snapshot.isoformat()}"
+    out_root.mkdir(parents=True, exist_ok=True)
+    # Drop the partition column from the file itself (hive style).
+    file_table = table.drop(["data_extracao"])
+    dest = out_root / "data.parquet"
+    pq.write_table(file_table, dest, compression="snappy")
+    return dest
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+def validate(name: str, spec: dict, dest: Path) -> None:
+    cols = spec["cols"]
+    expected_order = ["data_extracao"] + [c[0] for c in cols]
+
+    # Read the bare file schema (partition column lives in the directory, not
+    # the file — hive style).
+    file_schema = pq.read_schema(dest)
+
+    # Read via the dataset API so the partition column is reconstructed, then
+    # reorder to the architecture order (partition column first).
+    reloaded = pq.read_table(dest)
+    df = reloaded.to_pandas()
+    df = df[[c for c in expected_order if c in df.columns]]
+
+    print(f"\n===== VALIDATE {name} =====")
+    print(f"path       : {dest}")
+    print(f"row count  : {len(df):,}")
+    full_order = ["data_extracao", *file_schema.names]
+    print(f"columns    : {full_order}")
+    order_ok = full_order == expected_order
+    print(f"order match: {order_ok}")
+    if not order_ok:
+        print(f"  EXPECTED : {expected_order}")
+
+    print("dtypes (partition data_extracao: date32 [from directory]):")
+    for f in file_schema:
+        print(f"  {f.name}: {f.type}")
+
+    print("null fraction per column:")
+    for c in expected_order:
+        frac = df[c].isna().mean()
+        print(f"  {c}: {frac:.4f}")
+
+    if "valor_multa" in df.columns:
+        vm = pd.to_numeric(df["valor_multa"], errors="coerce")
+        print(
+            f"valor_multa -> dtype={df['valor_multa'].dtype}, "
+            f"max={vm.max():,.2f}, min={vm.min():,.2f}, "
+            f"non-null={vm.notna().sum():,}"
+        )
+
+    if "sigla_uf_orgao" in df.columns:
+        uf = df["sigla_uf_orgao"].dropna()
+        non_uf = sorted(uf[~uf.str.fullmatch(r"[A-Z]{2}")].unique().tolist())
+        print(f"sigla_uf_orgao non-2-letter values: {non_uf}")
+
+    print("sample (head 3):")
+    with pd.option_context("display.max_columns", None, "display.width", 200):
+        print(df.head(3).to_string())
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    summary = {}
+    for name, spec in TABLES.items():
+        df = process_table(name, spec)
+        table = to_arrow(df, spec["cols"])
+        dest = write_partitioned(table, name, spec["snapshot"])
+        summary[name] = (len(df), dest)
+
+    for name, spec in TABLES.items():
+        dest = summary[name][1]
+        validate(name, spec, dest)
+
+    print("\n===== SUMMARY =====")
+    for name, (n, dest) in summary.items():
+        print(f"{name:28s} rows={n:>8,}  -> {dest}")
+    print(f"\noutput root: {OUTPUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/br_cgu_sancoes/code/clean.py
+++ b/models/br_cgu_sancoes/code/clean.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import os
 from datetime import date
 from pathlib import Path
+from typing import TypedDict
 
 import pandas as pd
 import pyarrow as pa
@@ -45,6 +46,23 @@ OUTPUT_DIR = Path(
 # raw header (which has been verified to match), skipping the data_extracao
 # column that we synthesise.
 # --------------------------------------------------------------------------- #
+
+
+class TableSpec(TypedDict):
+    """Specification for one raw CGU registry table.
+
+    Attributes:
+        file: Raw CSV filename under the input directory.
+        snapshot: Extraction date used as the ``data_extracao`` partition.
+        cols: Ordered ``(output_column, kind)`` pairs after ``data_extracao``,
+            where ``kind`` is one of ``"str"``, ``"date"``, or ``"float"``.
+    """
+
+    file: str
+    snapshot: date
+    cols: list[tuple[str, str]]
+
+
 CEIS_COLS = [
     ("cadastro", "str"),
     ("codigo_sancao", "str"),
@@ -128,7 +146,7 @@ EFEITOS_COLS = [
     ("complemento", "str"),
 ]
 
-TABLES = {
+TABLES: dict[str, TableSpec] = {
     "ceis": {
         "file": "20260813_CEIS.csv",
         "snapshot": date(2026, 8, 13),
@@ -155,6 +173,23 @@ TABLES = {
         "cols": EFEITOS_COLS,
     },
 }
+
+# Static dictionary decoding the coded `tipo_pessoa` column (F/J) that appears
+# in the ceis and cnep tables. Authored here (not sourced from a CSV) so the
+# staging `dicionario` table is reproducible from this script.
+DICIONARIO_COLS = [
+    "id_tabela",
+    "nome_coluna",
+    "chave",
+    "cobertura_temporal",
+    "valor",
+]
+DICIONARIO_ROWS: list[tuple[str, str, str, str, str]] = [
+    ("ceis", "tipo_pessoa", "F", "", "Pessoa física"),
+    ("ceis", "tipo_pessoa", "J", "", "Pessoa jurídica"),
+    ("cnep", "tipo_pessoa", "F", "", "Pessoa física"),
+    ("cnep", "tipo_pessoa", "J", "", "Pessoa jurídica"),
+]
 
 
 # --------------------------------------------------------------------------- #
@@ -202,7 +237,17 @@ def build_schema(cols: list[tuple[str, str]]) -> pa.Schema:
 # --------------------------------------------------------------------------- #
 # Per-table processing
 # --------------------------------------------------------------------------- #
-def process_table(name: str, spec: dict) -> pd.DataFrame:
+def process_table(name: str, spec: TableSpec) -> pd.DataFrame:
+    """Read one raw CSV, map columns positionally, clean, and prepend snapshot.
+
+    Args:
+        name: Table slug (used for logging and error messages).
+        spec: The table's :class:`TableSpec`.
+
+    Returns:
+        A frame with ``data_extracao`` first, then the architecture columns in
+        order, each cleaned per its ``kind``.
+    """
     path = INPUT_DIR / spec["file"]
     cols = spec["cols"]
     snapshot = spec["snapshot"]
@@ -251,6 +296,15 @@ def process_table(name: str, spec: dict) -> pd.DataFrame:
 
 
 def to_arrow(df: pd.DataFrame, cols: list[tuple[str, str]]) -> pa.Table:
+    """Build a typed Arrow table (date32/float64/string) from a cleaned frame.
+
+    Args:
+        df: Cleaned frame from :func:`process_table`.
+        cols: The table's ordered ``(output_column, kind)`` pairs.
+
+    Returns:
+        An Arrow table whose schema matches the architecture types.
+    """
     schema = build_schema(cols)
     arrays = {}
     # data_extracao
@@ -274,6 +328,16 @@ def to_arrow(df: pd.DataFrame, cols: list[tuple[str, str]]) -> pa.Table:
 
 
 def write_partitioned(table: pa.Table, name: str, snapshot: date) -> Path:
+    """Write hive-partitioned Snappy Parquet, dropping the partition column.
+
+    Args:
+        table: Typed Arrow table including ``data_extracao``.
+        name: Table slug (directory name under the output root).
+        snapshot: Extraction date used as the hive partition value.
+
+    Returns:
+        Path to the written ``data.parquet`` file.
+    """
     out_root = OUTPUT_DIR / name / f"data_extracao={snapshot.isoformat()}"
     out_root.mkdir(parents=True, exist_ok=True)
     # Drop the partition column from the file itself (hive style).
@@ -283,10 +347,45 @@ def write_partitioned(table: pa.Table, name: str, snapshot: date) -> Path:
     return dest
 
 
+def build_dicionario() -> Path:
+    """Write the static dicionario parquet (decodes ``tipo_pessoa`` F/J).
+
+    The dicionario is not sourced from a CSV; its rows are defined in
+    ``DICIONARIO_ROWS`` so the staging table is reproducible from this script.
+
+    Returns:
+        Path to the written (unpartitioned) ``data.parquet`` file.
+    """
+    schema = pa.schema([(c, pa.string()) for c in DICIONARIO_COLS])
+    table = pa.Table.from_pydict(
+        {
+            c: [row[i] for row in DICIONARIO_ROWS]
+            for i, c in enumerate(DICIONARIO_COLS)
+        },
+        schema=schema,
+    )
+    out_root = OUTPUT_DIR / "dicionario"
+    out_root.mkdir(parents=True, exist_ok=True)
+    dest = out_root / "data.parquet"
+    pq.write_table(table, dest, compression="snappy")
+    print(f"[dicionario] rows = {len(DICIONARIO_ROWS)} -> {dest}")
+    return dest
+
+
 # --------------------------------------------------------------------------- #
 # Validation
 # --------------------------------------------------------------------------- #
-def validate(name: str, spec: dict, dest: Path) -> None:
+def validate(name: str, spec: TableSpec, dest: Path) -> None:
+    """Reload the written parquet and print integrity diagnostics.
+
+    Reads the hive-partitioned directory so ``data_extracao`` is reconstructed,
+    then prints row count, column order, dtypes, null fractions, and a sample.
+
+    Args:
+        name: Table slug.
+        spec: The table's :class:`TableSpec`.
+        dest: Path to the written ``data.parquet`` file.
+    """
     cols = spec["cols"]
     expected_order = ["data_extracao"] + [c[0] for c in cols]
 
@@ -294,9 +393,9 @@ def validate(name: str, spec: dict, dest: Path) -> None:
     # the file — hive style).
     file_schema = pq.read_schema(dest)
 
-    # Read via the dataset API so the partition column is reconstructed, then
-    # reorder to the architecture order (partition column first).
-    reloaded = pq.read_table(dest)
+    # Read the partition root so the hive partition column (data_extracao) is
+    # reconstructed, then reorder to the architecture order (partition first).
+    reloaded = pq.read_table(dest.parent.parent, partitioning="hive")
     df = reloaded.to_pandas()
     df = df[[c for c in expected_order if c in df.columns]]
 
@@ -341,6 +440,11 @@ def validate(name: str, spec: dict, dest: Path) -> None:
 # Main
 # --------------------------------------------------------------------------- #
 def main() -> None:
+    """Clean every registry in ``TABLES`` to parquet, then validate.
+
+    Also writes the static ``dicionario`` table. Output goes under
+    ``OUTPUT_DIR``; nothing is uploaded here (see ``upload.py``).
+    """
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     summary = {}
     for name, spec in TABLES.items():
@@ -348,6 +452,9 @@ def main() -> None:
         table = to_arrow(df, spec["cols"])
         dest = write_partitioned(table, name, spec["snapshot"])
         summary[name] = (len(df), dest)
+
+    dic_dest = build_dicionario()
+    summary["dicionario"] = (len(DICIONARIO_ROWS), dic_dest)
 
     for name, spec in TABLES.items():
         dest = summary[name][1]

--- a/models/br_cgu_sancoes/code/upload.py
+++ b/models/br_cgu_sancoes/code/upload.py
@@ -26,7 +26,8 @@ BILLING_PROJECT = "basedosdados-dev"  # DEV ONLY — never prod
 DATASET_ID = "br_cgu_sancoes"
 DATA_ROOT = Path(
     os.environ.get(
-        "BR_CGU_SANCOES_DATA", Path.home() / "Downloads" / "br_cgu_sancoes_data"
+        "BR_CGU_SANCOES_DATA",
+        Path.home() / "Downloads" / "br_cgu_sancoes_data",
     )
 )
 OUTPUT_ROOT = DATA_ROOT / "output"
@@ -36,7 +37,9 @@ _orig_bucket = gcs.Client.bucket
 
 
 def _patched_bucket(self, bucket_name, user_project=None, **kwargs):
-    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT, **kwargs)
+    return _orig_bucket(
+        self, bucket_name, user_project=BILLING_PROJECT, **kwargs
+    )
 
 
 gcs.Client.bucket = _patched_bucket
@@ -75,7 +78,9 @@ def upload_table(slug: str, expected_rows: int) -> int:
 
     client = bigquery.Client(project=BILLING_PROJECT)
     fqn = f"{BILLING_PROJECT}.{DATASET_ID}_staging.{slug}"
-    n = next(iter(client.query(f"select count(*) as n from `{fqn}`").result())).n
+    n = next(
+        iter(client.query(f"select count(*) as n from `{fqn}`").result())
+    ).n
     status = "OK" if n == expected_rows else "MISMATCH"
     print(f"  {slug}: {n:,} rows (expected {expected_rows:,}) — {status}")
     print(f"  staging: {fqn}")

--- a/models/br_cgu_sancoes/code/upload.py
+++ b/models/br_cgu_sancoes/code/upload.py
@@ -46,6 +46,7 @@ gcs.Client.bucket = _patched_bucket
 
 # (table_slug, expected_rows) — smallest first
 TABLES = [
+    ("dicionario", 4),
     ("acordos_leniencia", 151),
     ("acordos_leniencia_efeitos", 173),
     ("cnep", 1_757),
@@ -94,6 +95,11 @@ def main() -> None:
     parser.add_argument("--table", default=None, help="Upload only this table")
     args = parser.parse_args()
 
+    known = {t[0] for t in TABLES}
+    if args.table is not None and args.table not in known:
+        raise SystemExit(
+            f"Unknown --table {args.table!r}; choose from {sorted(known)}"
+        )
     targets = [args.table] if args.table else [t[0] for t in TABLES]
     print(f"env=dev billing={BILLING_PROJECT} dataset={DATASET_ID}")
     results = {}

--- a/models/br_cgu_sancoes/code/upload.py
+++ b/models/br_cgu_sancoes/code/upload.py
@@ -1,0 +1,106 @@
+"""Upload cleaned typed Parquet for br_cgu_sancoes to BigQuery dev staging.
+
+Usage:
+    uv run python models/br_cgu_sancoes/code/upload.py [--table <slug>]
+
+Dev only: billing/target project is basedosdados-dev. Point
+GOOGLE_APPLICATION_CREDENTIALS at the dev service account. Reads the cleaned
+hive-partitioned parquet from $BR_CGU_SANCOES_DATA/output (default
+~/Downloads/br_cgu_sancoes_data/output), which is NEVER under the repo or Dropbox.
+This is the one-shot onboarding upload path: keep the TYPED parquet schema (do not
+cast to all-STRING). Uploads smallest table first and stops on first failure.
+"""
+
+import argparse
+import os
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+import basedosdados as bd  # noqa: E402
+import google.cloud.storage as gcs  # noqa: E402
+from google.cloud import bigquery  # noqa: E402
+
+BILLING_PROJECT = "basedosdados-dev"  # DEV ONLY — never prod
+DATASET_ID = "br_cgu_sancoes"
+DATA_ROOT = Path(
+    os.environ.get(
+        "BR_CGU_SANCOES_DATA", Path.home() / "Downloads" / "br_cgu_sancoes_data"
+    )
+)
+OUTPUT_ROOT = DATA_ROOT / "output"
+
+# Monkey-patch for requester-pays bucket: force user_project = billing project.
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None, **kwargs):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT, **kwargs)
+
+
+gcs.Client.bucket = _patched_bucket
+
+# (table_slug, expected_rows) — smallest first
+TABLES = [
+    ("acordos_leniencia", 151),
+    ("acordos_leniencia_efeitos", 173),
+    ("cnep", 1_757),
+    ("cepim", 3_537),
+    ("ceis", 23_547),
+]
+
+
+def upload_table(slug: str, expected_rows: int) -> int:
+    path = OUTPUT_ROOT / slug
+    if not path.exists():
+        raise FileNotFoundError(f"Missing output path: {path}")
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=slug)
+
+    # Delete stale GCS staging prefix before upload (avoids BQ partition conflicts).
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=slug)
+    try:
+        st.delete_table(mode="staging", not_found_ok=True)
+    except Exception as e:
+        print(f"  [warn] staging prefix cleanup: {e}")
+
+    tb.create(
+        path=str(path),
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    client = bigquery.Client(project=BILLING_PROJECT)
+    fqn = f"{BILLING_PROJECT}.{DATASET_ID}_staging.{slug}"
+    n = next(iter(client.query(f"select count(*) as n from `{fqn}`").result())).n
+    status = "OK" if n == expected_rows else "MISMATCH"
+    print(f"  {slug}: {n:,} rows (expected {expected_rows:,}) — {status}")
+    print(f"  staging: {fqn}")
+    if n != expected_rows:
+        raise SystemExit(f"  {slug}: row count mismatch — aborting")
+    return n
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--table", default=None, help="Upload only this table")
+    args = parser.parse_args()
+
+    targets = [args.table] if args.table else [t[0] for t in TABLES]
+    print(f"env=dev billing={BILLING_PROJECT} dataset={DATASET_ID}")
+    results = {}
+    for slug, expected in TABLES:
+        if slug in targets:
+            print(f"[upload] {slug}")
+            results[slug] = upload_table(slug, expected)
+
+    print("\n=== UPLOAD COMPLETE: br_cgu_sancoes (env=dev) ===")
+    for slug in results:
+        print(f"  OK {slug}: {results[slug]:,} rows")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/br_cgu_sancoes/schema.yml
+++ b/models/br_cgu_sancoes/schema.yml
@@ -25,26 +25,29 @@ models:
             - observacoes
     columns:
       - name: data_extracao
-        description: Data de extração dos dados da fonte original
+        description: Data de extração do arquivo de dados, correspondente ao snapshot
+          do cadastro
         tests: [not_null]
       - name: cadastro
-        description: Nome do cadastro de origem da sanção
+        description: Nome do cadastro de origem do registro
       - name: codigo_sancao
-        description: Código identificador da sanção
+        description: Código identificador da sanção no cadastro
       - name: tipo_pessoa
-        description: Tipo de pessoa sancionada (física ou jurídica)
+        description: Tipo de pessoa do sancionado, física ou jurídica
       - name: cpf_cnpj_sancionado
-        description: CPF ou CNPJ da pessoa sancionada
+        description: CPF ou CNPJ do sancionado, com dígitos preenchidos com zeros
+          à esquerda
       - name: nome_sancionado
-        description: Nome da pessoa física ou razão social da pessoa jurídica sancionada
+        description: Nome do sancionado, nome civil ou razão social
       - name: nome_informado_orgao
         description: Nome do sancionado conforme informado pelo órgão sancionador
       - name: razao_social_receita
-        description: Razão social do sancionado conforme a Receita Federal
+        description: Razão social do sancionado conforme cadastro da Receita Federal
       - name: nome_fantasia_receita
-        description: Nome fantasia do sancionado conforme a Receita Federal
+        description: Nome fantasia do sancionado conforme cadastro da Receita Federal
       - name: numero_processo
-        description: Número do processo que originou a sanção
+        description: Número do processo administrativo ou judicial que originou a
+          sanção
       - name: categoria_sancao
         description: Categoria da sanção aplicada
       - name: data_inicio_sancao
@@ -54,27 +57,27 @@ models:
       - name: data_publicacao
         description: Data de publicação da sanção
       - name: publicacao
-        description: Descrição da publicação da sanção
+        description: Descrição do meio de publicação da sanção
       - name: detalhamento_meio_publicacao
         description: Detalhamento do meio de publicação da sanção
       - name: data_transito_julgado
         description: Data do trânsito em julgado da decisão
       - name: abrangencia_sancao
-        description: Abrangência territorial da sanção
+        description: Abrangência territorial ou institucional da sanção
       - name: orgao_sancionador
         description: Nome do órgão responsável pela aplicação da sanção
       - name: sigla_uf_orgao
-        description: Sigla da unidade federativa do órgão sancionador
+        description: Sigla da unidade da federação do órgão sancionador
       - name: esfera_orgao
         description: Esfera administrativa do órgão sancionador
       - name: fundamentacao_legal
-        description: Fundamentação legal da sanção
+        description: Fundamentação legal que embasa a sanção
       - name: data_origem_informacao
-        description: Data da origem da informação
+        description: Data de origem da informação registrada
       - name: origem_informacao
-        description: Órgão ou sistema de origem da informação
+        description: Origem das informações do registro
       - name: observacoes
-        description: Observações adicionais sobre a sanção
+        description: Observações adicionais sobre o registro
   - name: br_cgu_sancoes__cnep
     description: >
       Cadastro Nacional de Empresas Punidas (CNEP): pessoas jurídicas e físicas
@@ -99,26 +102,29 @@ models:
             - observacoes
     columns:
       - name: data_extracao
-        description: Data de extração dos dados da fonte original
+        description: Data de extração do arquivo de dados, correspondente ao snapshot
+          do cadastro
         tests: [not_null]
       - name: cadastro
-        description: Nome do cadastro de origem da sanção
+        description: Nome do cadastro de origem do registro
       - name: codigo_sancao
-        description: Código identificador da sanção
+        description: Código identificador da sanção no cadastro
       - name: tipo_pessoa
-        description: Tipo de pessoa sancionada (física ou jurídica)
+        description: Tipo de pessoa do sancionado, física ou jurídica
       - name: cpf_cnpj_sancionado
-        description: CPF ou CNPJ da pessoa sancionada
+        description: CPF ou CNPJ do sancionado, com dígitos preenchidos com zeros
+          à esquerda
       - name: nome_sancionado
-        description: Nome da pessoa física ou razão social da pessoa jurídica sancionada
+        description: Nome do sancionado, nome civil ou razão social
       - name: nome_informado_orgao
         description: Nome do sancionado conforme informado pelo órgão sancionador
       - name: razao_social_receita
-        description: Razão social do sancionado conforme a Receita Federal
+        description: Razão social do sancionado conforme cadastro da Receita Federal
       - name: nome_fantasia_receita
-        description: Nome fantasia do sancionado conforme a Receita Federal
+        description: Nome fantasia do sancionado conforme cadastro da Receita Federal
       - name: numero_processo
-        description: Número do processo que originou a sanção
+        description: Número do processo administrativo ou judicial que originou a
+          sanção
       - name: categoria_sancao
         description: Categoria da sanção aplicada
       - name: valor_multa
@@ -130,27 +136,27 @@ models:
       - name: data_publicacao
         description: Data de publicação da sanção
       - name: publicacao
-        description: Descrição da publicação da sanção
+        description: Descrição do meio de publicação da sanção
       - name: detalhamento_meio_publicacao
         description: Detalhamento do meio de publicação da sanção
       - name: data_transito_julgado
         description: Data do trânsito em julgado da decisão
       - name: abrangencia_sancao
-        description: Abrangência territorial da sanção
+        description: Abrangência territorial ou institucional da sanção
       - name: orgao_sancionador
         description: Nome do órgão responsável pela aplicação da sanção
       - name: sigla_uf_orgao
-        description: Sigla da unidade federativa do órgão sancionador
+        description: Sigla da unidade da federação do órgão sancionador
       - name: esfera_orgao
         description: Esfera administrativa do órgão sancionador
       - name: fundamentacao_legal
-        description: Fundamentação legal da sanção
+        description: Fundamentação legal que embasa a sanção
       - name: data_origem_informacao
-        description: Data da origem da informação
+        description: Data de origem da informação registrada
       - name: origem_informacao
-        description: Órgão ou sistema de origem da informação
+        description: Origem das informações do registro
       - name: observacoes
-        description: Observações adicionais sobre a sanção
+        description: Observações adicionais sobre o registro
   - name: br_cgu_sancoes__cepim
     description: >
       Cadastro de Entidades Privadas Sem Fins Lucrativos Impedidas (CEPIM):
@@ -167,12 +173,13 @@ models:
           at_least: 0.05
     columns:
       - name: data_extracao
-        description: Data de extração dos dados da fonte original
+        description: Data de extração do arquivo de dados, correspondente ao snapshot
+          do cadastro
         tests: [not_null]
       - name: cnpj_entidade
-        description: CNPJ da entidade privada impedida
+        description: CNPJ da entidade privada sem fins lucrativos impedida
       - name: nome_entidade
-        description: Nome da entidade privada impedida
+        description: Nome da entidade privada sem fins lucrativos
       - name: numero_convenio
         description: Número do convênio associado ao impedimento
       - name: orgao_concedente
@@ -200,28 +207,29 @@ models:
             - termos_acordo
     columns:
       - name: data_extracao
-        description: Data de extração dos dados da fonte original
+        description: Data de extração do arquivo de dados, correspondente ao snapshot
+          do cadastro
         tests: [not_null]
       - name: id_acordo
         description: Identificador do acordo de leniência
       - name: cnpj_sancionado
-        description: CNPJ da pessoa jurídica que celebrou o acordo
+        description: CNPJ do sancionado signatário do acordo
       - name: razao_social_receita
-        description: Razão social da pessoa jurídica conforme a Receita Federal
+        description: Razão social do sancionado conforme cadastro da Receita Federal
       - name: nome_fantasia_receita
-        description: Nome fantasia da pessoa jurídica conforme a Receita Federal
+        description: Nome fantasia do sancionado conforme cadastro da Receita Federal
       - name: data_inicio_acordo
         description: Data de início do acordo de leniência
       - name: data_fim_acordo
-        description: Data de término do acordo de leniência
+        description: Data de fim do acordo de leniência
       - name: situacao_acordo
-        description: Situação atual do acordo de leniência
+        description: Situação do acordo de leniência
       - name: data_informacao
-        description: Data da informação do acordo
+        description: Data da informação registrada sobre o acordo
       - name: numero_processo
         description: Número do processo associado ao acordo
       - name: termos_acordo
-        description: Descrição dos termos do acordo
+        description: Termos do acordo de leniência
       - name: orgao_sancionador
         description: Nome do órgão responsável pelo acordo
   - name: br_cgu_sancoes__acordos_leniencia_efeitos
@@ -237,14 +245,15 @@ models:
           ignore_values: [complemento]
     columns:
       - name: data_extracao
-        description: Data de extração dos dados da fonte original
+        description: Data de extração do arquivo de dados, correspondente ao snapshot
+          do cadastro
         tests: [not_null]
       - name: id_acordo
-        description: Identificador do acordo de leniência ao qual o efeito se refere
+        description: Identificador do acordo de leniência
       - name: efeito
-        description: Descrição do efeito do acordo de leniência
+        description: Efeito do acordo de leniência
       - name: complemento
-        description: Complemento ou detalhamento do efeito
+        description: Complemento descritivo do efeito do acordo
   - name: br_cgu_sancoes__dicionario
     description: >
       Dicionário de códigos das colunas codificadas das tabelas do conjunto
@@ -254,16 +263,16 @@ models:
           combination_of_columns: [id_tabela, nome_coluna, chave]
     columns:
       - name: id_tabela
-        description: Nome da tabela à qual a coluna codificada pertence
+        description: Nome da tabela à qual a coluna pertence
         tests: [not_null]
       - name: nome_coluna
-        description: Nome da coluna codificada coberta pelo dicionário
+        description: Nome da coluna cujos valores são traduzidos
         tests: [not_null]
       - name: chave
-        description: Código (chave) presente na coluna codificada
+        description: Código presente na coluna original
         tests: [not_null]
       - name: cobertura_temporal
-        description: Cobertura temporal à qual o par chave-valor se aplica
+        description: Cobertura temporal a que se aplica a chave
       - name: valor
-        description: Valor (rótulo) correspondente à chave na coluna codificada
+        description: Valor traduzido correspondente à chave
         tests: [not_null]

--- a/models/br_cgu_sancoes/schema.yml
+++ b/models/br_cgu_sancoes/schema.yml
@@ -1,0 +1,269 @@
+---
+version: 2
+models:
+  - name: br_cgu_sancoes__ceis
+    description: >
+      Cadastro de Empresas Inidôneas e Suspensas (CEIS): pessoas físicas e
+      jurídicas que sofreram sanções que restringem o direito de participar de
+      licitações ou celebrar contratos com a Administração Pública. Cada
+      snapshot da fonte é empilhado sob data_extracao.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [data_extracao, codigo_sancao]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - nome_informado_orgao
+            - razao_social_receita
+            - nome_fantasia_receita
+            - data_final_sancao
+            - data_publicacao
+            - publicacao
+            - detalhamento_meio_publicacao
+            - data_transito_julgado
+            - data_origem_informacao
+            - observacoes
+    columns:
+      - name: data_extracao
+        description: Data de extração dos dados da fonte original
+        tests: [not_null]
+      - name: cadastro
+        description: Nome do cadastro de origem da sanção
+      - name: codigo_sancao
+        description: Código identificador da sanção
+      - name: tipo_pessoa
+        description: Tipo de pessoa sancionada (física ou jurídica)
+      - name: cpf_cnpj_sancionado
+        description: CPF ou CNPJ da pessoa sancionada
+      - name: nome_sancionado
+        description: Nome da pessoa física ou razão social da pessoa jurídica sancionada
+      - name: nome_informado_orgao
+        description: Nome do sancionado conforme informado pelo órgão sancionador
+      - name: razao_social_receita
+        description: Razão social do sancionado conforme a Receita Federal
+      - name: nome_fantasia_receita
+        description: Nome fantasia do sancionado conforme a Receita Federal
+      - name: numero_processo
+        description: Número do processo que originou a sanção
+      - name: categoria_sancao
+        description: Categoria da sanção aplicada
+      - name: data_inicio_sancao
+        description: Data de início da vigência da sanção
+      - name: data_final_sancao
+        description: Data final da vigência da sanção
+      - name: data_publicacao
+        description: Data de publicação da sanção
+      - name: publicacao
+        description: Descrição da publicação da sanção
+      - name: detalhamento_meio_publicacao
+        description: Detalhamento do meio de publicação da sanção
+      - name: data_transito_julgado
+        description: Data do trânsito em julgado da decisão
+      - name: abrangencia_sancao
+        description: Abrangência territorial da sanção
+      - name: orgao_sancionador
+        description: Nome do órgão responsável pela aplicação da sanção
+      - name: sigla_uf_orgao
+        description: Sigla da unidade federativa do órgão sancionador
+      - name: esfera_orgao
+        description: Esfera administrativa do órgão sancionador
+      - name: fundamentacao_legal
+        description: Fundamentação legal da sanção
+      - name: data_origem_informacao
+        description: Data da origem da informação
+      - name: origem_informacao
+        description: Órgão ou sistema de origem da informação
+      - name: observacoes
+        description: Observações adicionais sobre a sanção
+  - name: br_cgu_sancoes__cnep
+    description: >
+      Cadastro Nacional de Empresas Punidas (CNEP): pessoas jurídicas e físicas
+      que sofreram sanções previstas na Lei Anticorrupção (Lei nº 12.846/2013).
+      Cada snapshot da fonte é empilhado sob data_extracao.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [data_extracao, codigo_sancao]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - nome_informado_orgao
+            - razao_social_receita
+            - nome_fantasia_receita
+            - valor_multa
+            - data_final_sancao
+            - data_publicacao
+            - publicacao
+            - detalhamento_meio_publicacao
+            - data_transito_julgado
+            - data_origem_informacao
+            - observacoes
+    columns:
+      - name: data_extracao
+        description: Data de extração dos dados da fonte original
+        tests: [not_null]
+      - name: cadastro
+        description: Nome do cadastro de origem da sanção
+      - name: codigo_sancao
+        description: Código identificador da sanção
+      - name: tipo_pessoa
+        description: Tipo de pessoa sancionada (física ou jurídica)
+      - name: cpf_cnpj_sancionado
+        description: CPF ou CNPJ da pessoa sancionada
+      - name: nome_sancionado
+        description: Nome da pessoa física ou razão social da pessoa jurídica sancionada
+      - name: nome_informado_orgao
+        description: Nome do sancionado conforme informado pelo órgão sancionador
+      - name: razao_social_receita
+        description: Razão social do sancionado conforme a Receita Federal
+      - name: nome_fantasia_receita
+        description: Nome fantasia do sancionado conforme a Receita Federal
+      - name: numero_processo
+        description: Número do processo que originou a sanção
+      - name: categoria_sancao
+        description: Categoria da sanção aplicada
+      - name: valor_multa
+        description: Valor da multa aplicada
+      - name: data_inicio_sancao
+        description: Data de início da vigência da sanção
+      - name: data_final_sancao
+        description: Data final da vigência da sanção
+      - name: data_publicacao
+        description: Data de publicação da sanção
+      - name: publicacao
+        description: Descrição da publicação da sanção
+      - name: detalhamento_meio_publicacao
+        description: Detalhamento do meio de publicação da sanção
+      - name: data_transito_julgado
+        description: Data do trânsito em julgado da decisão
+      - name: abrangencia_sancao
+        description: Abrangência territorial da sanção
+      - name: orgao_sancionador
+        description: Nome do órgão responsável pela aplicação da sanção
+      - name: sigla_uf_orgao
+        description: Sigla da unidade federativa do órgão sancionador
+      - name: esfera_orgao
+        description: Esfera administrativa do órgão sancionador
+      - name: fundamentacao_legal
+        description: Fundamentação legal da sanção
+      - name: data_origem_informacao
+        description: Data da origem da informação
+      - name: origem_informacao
+        description: Órgão ou sistema de origem da informação
+      - name: observacoes
+        description: Observações adicionais sobre a sanção
+  - name: br_cgu_sancoes__cepim
+    description: >
+      Cadastro de Entidades Privadas Sem Fins Lucrativos Impedidas (CEPIM):
+      entidades privadas sem fins lucrativos impedidas de celebrar convênios,
+      contratos de repasse ou termos de parceria com a Administração Pública
+      Federal. Cada snapshot da fonte é empilhado sob data_extracao.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - data_extracao
+            - cnpj_entidade
+            - numero_convenio
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: data_extracao
+        description: Data de extração dos dados da fonte original
+        tests: [not_null]
+      - name: cnpj_entidade
+        description: CNPJ da entidade privada impedida
+      - name: nome_entidade
+        description: Nome da entidade privada impedida
+      - name: numero_convenio
+        description: Número do convênio associado ao impedimento
+      - name: orgao_concedente
+        description: Nome do órgão concedente do convênio
+      - name: motivo_impedimento
+        description: Motivo do impedimento da entidade
+  - name: br_cgu_sancoes__acordos_leniencia
+    description: >
+      Acordos de leniência celebrados no âmbito da Lei Anticorrupção (Lei nº
+      12.846/2013): um registro por pessoa jurídica participante de cada acordo,
+      com situação e órgão sancionador. Um mesmo id_acordo pode aparecer em
+      várias linhas (uma por CNPJ sancionado), então a chave é a combinação de
+      data_extracao, id_acordo e cnpj_sancionado. Cada snapshot da fonte é
+      empilhado sob data_extracao.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [data_extracao, id_acordo, cnpj_sancionado]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - razao_social_receita
+            - nome_fantasia_receita
+            - data_fim_acordo
+            - data_informacao
+            - termos_acordo
+    columns:
+      - name: data_extracao
+        description: Data de extração dos dados da fonte original
+        tests: [not_null]
+      - name: id_acordo
+        description: Identificador do acordo de leniência
+      - name: cnpj_sancionado
+        description: CNPJ da pessoa jurídica que celebrou o acordo
+      - name: razao_social_receita
+        description: Razão social da pessoa jurídica conforme a Receita Federal
+      - name: nome_fantasia_receita
+        description: Nome fantasia da pessoa jurídica conforme a Receita Federal
+      - name: data_inicio_acordo
+        description: Data de início do acordo de leniência
+      - name: data_fim_acordo
+        description: Data de término do acordo de leniência
+      - name: situacao_acordo
+        description: Situação atual do acordo de leniência
+      - name: data_informacao
+        description: Data da informação do acordo
+      - name: numero_processo
+        description: Número do processo associado ao acordo
+      - name: termos_acordo
+        description: Descrição dos termos do acordo
+      - name: orgao_sancionador
+        description: Nome do órgão responsável pelo acordo
+  - name: br_cgu_sancoes__acordos_leniencia_efeitos
+    description: >
+      Efeitos dos acordos de leniência celebrados no âmbito da Lei
+      Anticorrupção: um ou mais registros por acordo, detalhando cada efeito e
+      seu complemento. Não há chave única natural, pois há uma relação de um
+      para muitos por id_acordo. Cada snapshot da fonte é empilhado sob
+      data_extracao.
+    tests:
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values: [complemento]
+    columns:
+      - name: data_extracao
+        description: Data de extração dos dados da fonte original
+        tests: [not_null]
+      - name: id_acordo
+        description: Identificador do acordo de leniência ao qual o efeito se refere
+      - name: efeito
+        description: Descrição do efeito do acordo de leniência
+      - name: complemento
+        description: Complemento ou detalhamento do efeito
+  - name: br_cgu_sancoes__dicionario
+    description: >
+      Dicionário de códigos das colunas codificadas das tabelas do conjunto
+      br_cgu_sancoes, mapeando cada chave ao seu rótulo (valor).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_tabela, nome_coluna, chave]
+    columns:
+      - name: id_tabela
+        description: Nome da tabela à qual a coluna codificada pertence
+        tests: [not_null]
+      - name: nome_coluna
+        description: Nome da coluna codificada coberta pelo dicionário
+        tests: [not_null]
+      - name: chave
+        description: Código (chave) presente na coluna codificada
+        tests: [not_null]
+      - name: cobertura_temporal
+        description: Cobertura temporal à qual o par chave-valor se aplica
+      - name: valor
+        description: Valor (rótulo) correspondente à chave na coluna codificada
+        tests: [not_null]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,10 @@ project-excludes = [
   # run via uv run; the pure transform is relocated to pipelines/datasets at the
   # pipeline step), so imports are unresolvable from the repo root.
   "models/us_fed_fred/code",
+  # Same policy: br_cgu_sancoes ETL is standalone `.py` (clean.py, upload.py run
+  # via uv run) — one-shot onboarding code outside the typed `pipelines/`
+  # framework, consistent with the model-ETL-not-type-checked policy.
+  "models/br_cgu_sancoes/code",
   "models/br_tse_eleicoes/code/[[]dbt[]]br_tse_eleicoes.ipynb",
   "models/world_wb_mides/code/licitacao_item.ipynb",
   "models/world_olympedia_olympics/code/[[]code[]]world_olympedia_olympics.ipynb",


### PR DESCRIPTION
## Dataset
- `br_cgu_sancoes` (slug `sancoes`) — CGU sanction registries from the Portal da Transparência. Organization: CGU. Themes: government, justice, economics. Product framing: compliance / KYC screening (sanctioned-party lookup by CPF/CNPJ).
- License: **unknown** (Brazilian federal open data under LAI Lei 12.527/2011 + Decreto 8.777/2016; the Portal states no explicit CC/ODbL instrument, so registered as `unknown`).

## Tables (6) — dev row counts (single 2026 snapshot)
- `ceis` — Cadastro de Empresas Inidôneas e Suspensas — 23,547 rows, 25 cols
- `cnep` — Cadastro Nacional de Empresas Punidas — 1,757 rows, 26 cols (incl. `valor_multa` FLOAT64/BRL)
- `cepim` — Entidades Privadas Sem Fins Lucrativos Impedidas — 3,537 rows, 6 cols
- `acordos_leniencia` — Acordos de Leniência — 151 rows, 12 cols
- `acordos_leniencia_efeitos` — effects of leniency agreements (1-to-many child, keyed by `id_acordo`) — 173 rows, 4 cols
- `dicionario` — decodes `tipo_pessoa` (F/J) — 4 rows

## Design decisions
- **Partition = `data_extracao` (DATE), uniform across all tables.** These registries are dated full-state snapshots and CEPIM carries no internal date column, so a single extraction-date partition is the only uniform choice and sets up a future daily refresh pipeline. Snapshot dates: 2026-08-13 (ceis/cnep/acordos/efeitos), 2026-08-12 (cepim — the 13th's CEPIM file 403'd).
- Portuguese snake_case column names; CPF/CNPJ kept as zero-padded STRING (no CPF/CNPJ directory linked); `cpf_cnpj_sancionado` flagged sensitive (CEIS includes individual CPFs).
- Source CSVs are ISO-8859-1, `;`-delimited, `"`-quoted with embedded newlines, DD/MM/YYYY dates, comma decimals — parsed with a real CSV parser.
- Two raw sources recorded: Portal da Transparência bulk download (primary, linked to all tables) and the api-de-dados REST API (secondary, for a future recurring pipeline).

## Validation
- dbt run PASS 6/6; dbt test PASS 19/19 in dev (`basedosdados-dev`).
- Metadata registered on prod backend as `status = under_review` (dataset id `cab78c26-72df-4e0a-be83-c0a0d2126da2`); cloud tables point at `basedosdados.br_cgu_sancoes.*` (materialize on merge via table-approve).

## Onboarding checklist
- [x] Architecture tables (Drive)
- [x] Raw data downloaded + cleaned → partitioned parquet
- [x] Uploaded to BigQuery dev (row counts verified)
- [x] dbt models + schema.yml (run 6/6, test 19/19)
- [x] Metadata dev/staging (published for review)
- [x] Metadata prod (under_review)
- [ ] Merge → table-approve materializes prod tables
- [ ] Verify prod tables + publish prod dataset (post-merge)
- [ ] Recurring pipeline (deferred — source updates daily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CGU sanctions datasets covering CEIS, CNEP, CEPIM, leniency agreements, agreement effects, and a data dictionary.
  * Added daily-partitioned tables with standardized dates, identifiers, text, and financial values.
* **Documentation**
  * Added descriptions for datasets and columns, along with data-quality and uniqueness checks.
* **Data Processing**
  * Added pipelines to clean, validate, convert, and upload sanctions registry data in an optimized format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->