### PR TITLE
fix(br_me_rais): declara a base como aberta em vez de BD Pro

### DIFF
--- a/pipelines/crawler/me_rais/flows.py
+++ b/pipelines/crawler/me_rais/flows.py
@@ -9,9 +9,8 @@ from pipelines.crawler.me_rais.tasks import (
     resolve_vinculos_table_id,
 )
 from pipelines.utils.metadata.domain import (
+    AllFree,
     DateFormat,
-    FreeLag,
-    PartBdpro,
     YearOnly,
 )
 from pipelines.utils.metadata.tasks import (
@@ -94,10 +93,9 @@ def _run_rais(
         register_table_materialization_task(
             dataset_id=dataset_id,
             table_id=effective_table_id,
-            coverage=PartBdpro(
+            coverage=AllFree(
                 date_column=YearOnly(col="ano"),
                 date_format=DateFormat.YEAR,
-                free_lag=FreeLag(unit="years", value=1),
             ),
             env="prod",
             bq_project="basedosdados",


### PR DESCRIPTION
## O que aconteceu?

O flow da RAIS declarava as duas tabelas como BD Pro parcial, com o ano mais recente pago.
Isso nunca correspondeu à realidade: a base é toda gratuita, e em produção nenhuma das duas
tabelas tem o registro de BD Pro — só o de dado aberto, cobrindo 1985 a 2025.

O efeito é que todo run com `update_metadata=True` falhava no fim:

```
ValueError: part_bdpro exige Coverage free + pro;
encontrado: CoverageIds(free='714614bc-40f4-46fa-a759-5defdf1db90d', pro=None)
```
 acesso por linha foi emitida
(`needs_row_access_policy` só vale para `part_bdpro`).

## O que foi feito para resolver?

Troca de `PartBdpro` por `AllFree` em `_run_rais`, que atende as duas tabelas, e remoção dos
imports que ficaram sem uso.
