### PR TITLE
fix(br_me_rais): declara a base como aberta em vez de BD Pro

### DIFF
--- a/pipelines/crawler/me_rais/flows.py
+++ b/pipelines/crawler/me_rais/flows.py
@@ -9,9 +9,8 @@ from pipelines.crawler.me_rais.tasks import (
     resolve_vinculos_table_id,
 )
 from pipelines.utils.metadata.domain import (
+    AllFree,
     DateFormat,
-    FreeLag,
-    PartBdpro,
     YearOnly,
 )
 from pipelines.utils.metadata.tasks import (
@@ -94,10 +93,9 @@ def _run_rais(
         register_table_materialization_task(
             dataset_id=dataset_id,
             table_id=effective_table_id,
-            coverage=PartBdpro(
+            coverage=AllFree(
                 date_column=YearOnly(col="ano"),
                 date_format=DateFormat.YEAR,
-                free_lag=FreeLag(unit="years", value=1),
             ),
             env="prod",
             bq_project="basedosdados",

--- a/pipelines/datasets/br_me_rais/flows.py
+++ b/pipelines/datasets/br_me_rais/flows.py
@@ -4,6 +4,9 @@ Flows for br_me_rais — Prefect 3.
 Each run processes a single year, passed in `year`. These flows have no source
 poll guard, so `force_run` is accepted for signature compatibility and never
 read — nothing gates the download.
+
+RAIS is fully open data: both tables register an `AllFree` coverage, with no BD
+Pro window and no row access policies.
 """
 
 from prefect import flow


### PR DESCRIPTION
## O que aconteceu?

O flow da RAIS declarava as duas tabelas como BD Pro parcial, com o ano mais recente pago.
Isso nunca correspondeu à realidade: a base é toda gratuita, e em produção nenhuma das duas
tabelas tem o registro de BD Pro — só o de dado aberto, cobrindo 1985 a 2025.

O efeito é que todo run com `update_metadata=True` falhava no fim:

```
ValueError: part_bdpro exige Coverage free + pro;
encontrado: CoverageIds(free='714614bc-40f4-46fa-a759-5defdf1db90d', pro=None)
```

## O que foi feito para resolver?

Troca de `PartBdpro` por `AllFree` em `_run_rais`, que atende as duas tabelas, e remoção dos
imports que ficaram sem uso.

## Verificação

- Teste estabelecimentos: https://prefect3.basedosdados.org/runs/flow-run/06e3f575-6670-4a15-9f78-8ec333298f68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RAIS data coverage information to reflect that the dataset is fully open.
  * Clarified that RAIS tables have no BD Pro access window or row-level access restrictions.

* **Bug Fixes**
  * Corrected RAIS coverage metadata to provide unrestricted access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->