### PR TITLE
fix(us_fed_fred): build series before observation (FK order)

### DIFF
--- a/pipelines/datasets/us_fed_fred/constants.py
+++ b/pipelines/datasets/us_fed_fred/constants.py
@@ -129,8 +129,15 @@ class constants(Enum):
         "notes",
     ]
 
-    DATA_TABLES = ["observation", "series"]
-    ALL_TABLES = ["observation", "series"]
+    # Build order is load-bearing: `series` (the catalog) must be materialized
+    # BEFORE `observation`, because observation carries a dbt relationships test
+    # on series_id -> series. Each prod `dbt run` here replaces its table (the
+    # overwrite upload deletes the prod table first), so if observation were
+    # built first its FK test would run while series is momentarily absent and
+    # fail with "Table basedosdados.us_fed_fred.series was not found". Parent
+    # before child keeps every run green.
+    DATA_TABLES = ["series", "observation"]
+    ALL_TABLES = ["series", "observation"]
 
     ARCHITECTURE_DIR = (
         _REPO_ROOT / "models" / "us_fed_fred" / "code" / "architecture"


### PR DESCRIPTION
## Problem

Every prod run of the `us_fed_fred` daily pipeline failed at observation's prod `dbt test`:

```
Not found: Table basedosdados:us_fed_fred.series was not found in location US
```

…leaving prod with only `observation` (series dropped).

## Root cause

`_upload_to_gcs` in `dump_mode="overwrite"` calls `tb.delete(mode="all")`, and on the worker bd resolves **"prod" → the `basedosdados` production project** — so each table is deleted from prod before its `dbt run` rebuilds it. The flow looped `ALL_TABLES = ["observation", "series"]` (**observation first**), but `observation` carries a dbt relationships test on `series_id → series`. Its prod test ran while `series` was deleted-and-not-yet-rebuilt (series came later in the loop) → failure, and the run died before ever rebuilding series.

Other overwrite pipelines (e.g. `us_bls_cpi`) have the same delete-then-rebuild behavior but no cross-table FK, so it's silently self-healing there.

## Fix

Reorder `ALL_TABLES` / `DATA_TABLES` to `["series", "observation"]` — materialize the parent catalog **before** the child that references it, so observation's FK test always finds `series`. One-line change (plus an explanatory comment); ruff + import verified.

## Note (not addressed here)

The `overwrite` upload deleting the *prod* table each run means a brief per-run window where the prod tables are absent. That's shared `_upload_to_gcs` behavior (`mode="all"`) common to all overwrite pipelines; out of scope for this dataset-local fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data processing reliability by ensuring series information is prepared before related observations.
  * Prevented relationship validation issues caused by processing dependent data before its parent data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->