### PR TITLE
feat(us_bea): add recurring Prefect pipeline

### DIFF
--- a/models/us_bea/code/bea.py
+++ b/models/us_bea/code/bea.py
@@ -1,208 +1,40 @@
-"""BEA API client + pure download/clean transforms for the us_bea dataset.
+"""BEA API client + pure transforms for us_bea — re-export shim.
 
-Pure functions (no Prefect, no side effects beyond HTTP GET and the caller-chosen
-output dir), so the recurring pipeline (step 12) can import them directly.
-
-Row schemas (from beaapi/get_data.py, verified against the live API):
-  NIPA:          TableName, SeriesCode, LineNumber, LineDescription, TimePeriod,
-                 METRIC_NAME, CL_UNIT, UNIT_MULT, DataValue, NoteRef
-  Regional:      Code, GeoFips, GeoName, TimePeriod, CL_UNIT, UNIT_MULT, DataValue, NoteRef
-  GDPbyIndustry: TableID, Frequency, Year, Quarter, Industry, IndustrYDescription,
-                 DataValue, NoteRef
+The implementation moved to ``pipelines.datasets.us_bea.utils`` so the recurring
+pipeline and this one-shot bootstrap share a single copy (DRY). This module
+re-exports the names the bootstrap historically used, so ``from . import bea``
+keeps working unchanged.
 """
 
 from __future__ import annotations
 
-import json
-import os
-import time
-import urllib.error
-import urllib.parse
-import urllib.request
-
-BASE = "https://apps.bea.gov/api/data/"
-MISSING_TOKENS = {"", "(NA)", "(NM)", "(D)", "(L)", "(*)", "NA", "n/a"}
-
-
-def _key() -> str:
-    k = os.environ.get("BEA_API_KEY", "").strip()
-    if not k:
-        raise RuntimeError("BEA_API_KEY not set in environment")
-    return k
-
-
-_MIN_INTERVAL = (
-    0.65  # s between call starts -> ~92/min, under BEA's 100/min cap
+from pipelines.datasets.us_bea.utils import (
+    BASE,
+    MISSING_TOKENS,
+    BEAError,
+    call,
+    clean_value,
+    get_data,
+    line_from_code,
+    norm_gi_quarter,
+    param_values,
+    param_values_filtered,
+    split_time_period,
 )
-_last_call = [0.0]
 
-
-def _throttle():
-    dt = time.monotonic() - _last_call[0]
-    if dt < _MIN_INTERVAL:
-        time.sleep(_MIN_INTERVAL - dt)
-    _last_call[0] = time.monotonic()
-
-
-def call(
-    method: str, dataset: str | None = None, *, max_retries: int = 6, **params
-) -> dict:
-    """One BEA API call. Handles 429/Retry-After and transient errors. Returns Results."""
-    _throttle()
-    q = {"UserID": _key(), "method": method, "ResultFormat": "JSON"}
-    if dataset:
-        q["datasetname"] = dataset
-    q.update({k: v for k, v in params.items() if v is not None})
-    url = BASE + "?" + urllib.parse.urlencode(q)
-    delay = 2.0
-    for attempt in range(max_retries):
-        try:
-            with urllib.request.urlopen(url, timeout=180) as r:
-                body = json.load(r)
-        except urllib.error.HTTPError as e:
-            if e.code == 429:
-                wait = int(e.headers.get("Retry-After", "60")) + 1
-                time.sleep(wait)
-                continue
-            if attempt < max_retries - 1:
-                time.sleep(delay)
-                delay = min(delay * 2, 60)
-                continue
-            raise
-        except (urllib.error.URLError, TimeoutError, ConnectionError):
-            if attempt < max_retries - 1:
-                time.sleep(delay)
-                delay = min(delay * 2, 60)
-                continue
-            raise
-        res = body.get("BEAAPI", {}).get("Results", {})
-        # BEA sometimes wraps Results in a list
-        if isinstance(res, list):
-            res = res[0] if res else {}
-        err = res.get("Error") if isinstance(res, dict) else None
-        if err:
-            code = str(err.get("APIErrorCode", ""))
-            desc = err.get("APIErrorDescription", "") or err.get(
-                "ErrorDetail", {}
-            ).get("Description", "")
-            if code == "7":  # throttled
-                time.sleep(61)
-                continue
-            raise BEAError(code, desc, dataset, params)
-        return res
-    raise RuntimeError(
-        f"BEA call failed after retries: {method} {dataset} {params}"
-    )
-
-
-class BEAError(RuntimeError):
-    def __init__(self, code, desc, dataset, params):
-        self.code, self.desc = code, desc
-        super().__init__(
-            f"BEA APIErrorCode {code}: {desc} [{dataset} {params}]"
-        )
-
-
-def _norm_pv(node: dict, param: str) -> dict:
-    """ParamValue nodes are keyed differently per dataset (NIPA: TableName/Description;
-    Regional/GDPbyIndustry: Key/Desc). Normalize to {'key','desc'}."""
-    key = node.get("Key") if "Key" in node else None
-    if key is None:
-        key = (
-            node.get(param)
-            or node.get("TableName")
-            or node.get("TableID")
-            or node.get("LineCode")
-            or node.get("Industry")
-            or node.get("FrequencyID")
-        )
-    desc = node.get("Desc") or node.get("Description") or ""
-    return {"key": str(key) if key is not None else None, "desc": desc}
-
-
-def param_values(dataset: str, param: str) -> list[dict]:
-    res = call("GetParameterValues", dataset, ParameterName=param)
-    v = res.get("ParamValue", res)
-    v = v if isinstance(v, list) else [v]
-    return [_norm_pv(n, param) for n in v]
-
-
-def param_values_filtered(dataset: str, target: str, **filters) -> list[dict]:
-    res = call(
-        "GetParameterValuesFiltered",
-        dataset,
-        TargetParameter=target,
-        **filters,
-    )
-    v = res.get("ParamValue", res)
-    v = v if isinstance(v, list) else [v]
-    return [_norm_pv(n, target) for n in v]
-
-
-def get_data(dataset: str, **params) -> list[dict]:
-    """GetData -> list of data rows (possibly empty)."""
-    res = call("GetData", dataset, **params)
-    data = res.get("Data", [])
-    if isinstance(data, dict):
-        data = [data]
-    return data
-
-
-# --------------------------------------------------------------------------- #
-# pure cleaning helpers
-# --------------------------------------------------------------------------- #
-def clean_value(raw) -> float | None:
-    if raw is None:
-        return None
-    s = str(raw).strip()
-    if s in MISSING_TOKENS:
-        return None
-    s = s.replace(",", "")
-    # parenthesised negatives -> -x (rare in API payload, but be safe)
-    if (
-        s.startswith("(")
-        and s.endswith(")")
-        and s[1:-1].replace(".", "").isdigit()
-    ):
-        s = "-" + s[1:-1]
-    try:
-        return float(s)
-    except ValueError:
-        return None
-
-
-def split_time_period(
-    tp: str | None,
-) -> tuple[int | None, str | None, str | None]:
-    """TimePeriod -> (year, quarter, month). YYYY / YYYYQn / YYYYMnn."""
-    if tp is None:
-        return None, None, None
-    tp = tp.strip()
-    try:
-        if "Q" in tp:
-            y, q = tp.split("Q")
-            return int(y), q, None
-        if "M" in tp:
-            y, m = tp.split("M")
-            return int(y), None, m.zfill(2)
-        return int(tp[:4]), None, None
-    except (ValueError, IndexError):
-        return None, None, None
-
-
-def line_from_code(code: str) -> str | None:
-    """Regional 'Code' like 'SAGDP2N-1' -> line_code '1'."""
-    if not code:
-        return None
-    return code.rsplit("-", 1)[-1] if "-" in code else None
-
-
-def norm_gi_quarter(frequency: str, quarter) -> str | None:
-    """GDPbyIndustry: annual rows have Quarter==Year; quarterly rows are I..IV."""
-    if frequency == "A":
-        return None
-    roman = {"I": "1", "II": "2", "III": "3", "IV": "4"}
-    return roman.get(str(quarter).strip(), str(quarter).strip() or None)
+__all__ = [
+    "BASE",
+    "MISSING_TOKENS",
+    "BEAError",
+    "call",
+    "clean_value",
+    "get_data",
+    "line_from_code",
+    "norm_gi_quarter",
+    "param_values",
+    "param_values_filtered",
+    "split_time_period",
+]
 
 
 if __name__ == "__main__":

--- a/models/us_bea/code/clean.py
+++ b/models/us_bea/code/clean.py
@@ -1,16 +1,18 @@
-"""Download + clean all six us_bea tables into partitioned Parquet.
+"""Download + clean all six us_bea tables into partitioned Parquet (bootstrap).
 
-Pull strategy (verified against the live API):
-  - NIPA: one GetData per TableName, Frequency='A,Q,M', Year='ALL'
-          (rows carry no Frequency field; derive from TimePeriod).
+One-shot onboarding bootstrap. The download + row-building transform lives in
+``pipelines.datasets.us_bea.utils`` and is imported here rather than duplicated,
+so this bootstrap and the recurring flow cannot diverge (DRY). This module keeps
+only what is bootstrap-specific: the TYPED parquet writer (the one-shot upload
+accepts typed parquet, unlike the pipeline path), and per-BEA-table resume so a
+multi-hour county pull can restart where it left off.
+
+Pull strategy (verified against the live API), all in utils:
+  - NIPA: one GetData per TableName, Frequency='A,Q,M', Year='ALL'.
   - GDPbyIndustry: per TableID, Frequency A then Q, Industry='ALL', Year='ALL'.
-  - Regional: LineCode='ALL' is UNSUPPORTED -> loop specific line codes,
-              wildcard the geography (GeoFips = STATE / COUNTY / MSA).
-      regional_state  = SA*/SQ*/PR*/TA* tables, GeoFips=STATE
-      regional_county = CA* tables,           GeoFips=COUNTY
-      regional_metro  = MA* tables,           GeoFips=MSA
+  - Regional: LineCode='ALL' is UNSUPPORTED -> loop line codes, wildcard geo.
 
-Output: <outdir>/<db_table>/year=<YYYY>/<part>.parquet  (typed pa.Schema).
+Output: <outdir>/<db_table>/year=<YYYY>/<part>.parquet  (typed staging schema).
 Resume: a table is skipped if <outdir>/.done/<db_table> exists.
 
 Run:  python -m models.us_bea.code.clean [table ...]   (default: all)
@@ -18,9 +20,9 @@ Run:  python -m models.us_bea.code.clean [table ...]   (default: all)
 
 from __future__ import annotations
 
+import glob
 import json
 import os
-import re
 import shutil
 import sys
 import time
@@ -29,222 +31,35 @@ import pyarrow as pa
 import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 
-from . import bea
+from pipelines.datasets.us_bea.constants import constants
+from pipelines.datasets.us_bea.utils import (
+    STAGING_SCHEMAS,
+    build_dicionario_rows,
+    fetch_gi_table,
+    fetch_nipa_table,
+    fetch_regional_table,
+    gi_tables,
+    nipa_table_names,
+    regional_table_names,
+)
 
 OUTDIR = os.environ.get(
     "US_BEA_OUT", os.path.expanduser("~/Downloads/us_bea_data/output")
 )
 
-
-# ------------------------------------------------------------------ schemas --
-def _schema(cols: list[tuple[str, pa.DataType]]) -> pa.Schema:
-    return pa.schema([pa.field(n, t) for n, t in cols])
-
-
-STR = pa.string()
-INT = pa.int64()
-FLT = pa.float64()
-SCHEMAS = {
-    "nipa": _schema(
-        [
-            ("year", INT),
-            ("quarter", STR),
-            ("month", STR),
-            ("frequency", STR),
-            ("table_name", STR),
-            ("line_number", STR),
-            ("series_code", STR),
-            ("line_description", STR),
-            ("metric_name", STR),
-            ("unit", STR),
-            ("unit_mult", STR),
-            ("value", FLT),
-            ("note_ref", STR),
-        ]
-    ),
-    "gdp_by_industry": _schema(
-        [
-            ("year", INT),
-            ("quarter", STR),
-            ("frequency", STR),
-            ("table_id", STR),
-            ("table_description", STR),
-            ("industry", STR),
-            ("industry_description", STR),
-            ("value", FLT),
-            ("note_ref", STR),
-        ]
-    ),
-    "regional_state": _schema(
-        [
-            ("year", INT),
-            ("quarter", STR),
-            ("frequency", STR),
-            ("geo_fips", STR),
-            ("id_state", STR),
-            ("geo_name", STR),
-            ("table_name", STR),
-            ("line_code", STR),
-            ("series_code", STR),
-            ("line_description", STR),
-            ("unit", STR),
-            ("unit_mult", STR),
-            ("value", FLT),
-            ("note_ref", STR),
-        ]
-    ),
-    "regional_county": _schema(
-        [
-            ("year", INT),
-            ("geo_fips", STR),
-            ("id_county", STR),
-            ("id_state", STR),
-            ("geo_name", STR),
-            ("table_name", STR),
-            ("line_code", STR),
-            ("series_code", STR),
-            ("line_description", STR),
-            ("unit", STR),
-            ("unit_mult", STR),
-            ("value", FLT),
-            ("note_ref", STR),
-        ]
-    ),
-    "regional_metro": _schema(
-        [
-            ("year", INT),
-            ("geo_fips", STR),
-            ("id_cbsa", STR),
-            ("geo_name", STR),
-            ("table_name", STR),
-            ("line_code", STR),
-            ("series_code", STR),
-            ("line_description", STR),
-            ("unit", STR),
-            ("unit_mult", STR),
-            ("value", FLT),
-            ("note_ref", STR),
-        ]
-    ),
-}
-
-
-# ------------------------------------------------------------------ helpers --
-def _freq(year, quarter, month):
-    return "M" if month else ("Q" if quarter else "A")
-
-
-_REGION_PREFIX = {"91", "92", "93", "94", "95", "96", "97", "98"}
-
-
-def _id_state(geo_fips: str):
-    """NN000 -> NN for real states/territories; None for US(00000) and BEA regions."""
-    if not geo_fips or len(geo_fips) != 5 or not geo_fips.endswith("000"):
-        return None
-    st = geo_fips[:2]
-    if st == "00" or st in _REGION_PREFIX:
-        return None
-    return st
-
-
-def _strip_tag(desc: str) -> str:
-    # "[SAGDP2] Gross domestic product" -> "Gross domestic product"
-    return re.sub(r"^\[[^\]]*\]\s*", "", desc or "").strip()
-
-
-def _line_desc_map(dataset: str, table: str) -> dict:
-    out = {}
-    for x in bea.param_values_filtered(dataset, "LineCode", TableName=table):
-        if x["key"] is not None:
-            out[x["key"]] = _strip_tag(x["desc"])
-    return out
-
-
-# --------------------------------------------------------------- row builders --
-def _rows_nipa(api_rows):
-    for r in api_rows:
-        y, q, m = bea.split_time_period(r.get("TimePeriod"))
-        if y is None:
-            continue
-        yield {
-            "year": y,
-            "quarter": q,
-            "month": m,
-            "frequency": _freq(y, q, m),
-            "table_name": r.get("TableName"),
-            "line_number": r.get("LineNumber"),
-            "series_code": r.get("SeriesCode"),
-            "line_description": r.get("LineDescription"),
-            "metric_name": r.get("METRIC_NAME"),
-            "unit": r.get("CL_UNIT"),
-            "unit_mult": r.get("UNIT_MULT"),
-            "value": bea.clean_value(r.get("DataValue")),
-            "note_ref": r.get("NoteRef"),
-        }
-
-
-def _rows_gi(api_rows, table_desc):
-    for r in api_rows:
-        try:
-            y = int(r.get("Year"))
-        except (TypeError, ValueError):
-            continue
-        freq = r.get("Frequency")
-        yield {
-            "year": y,
-            "quarter": bea.norm_gi_quarter(freq, r.get("Quarter")),
-            "frequency": freq,
-            "table_id": str(r.get("TableID")),
-            "table_description": table_desc,
-            "industry": r.get("Industry"),
-            "industry_description": r.get("IndustrYDescription"),
-            "value": bea.clean_value(r.get("DataValue")),
-            "note_ref": r.get("NoteRef"),
-        }
-
-
-def _rows_regional(api_rows, table, line_code, line_desc, level):
-    for r in api_rows:
-        y, q, _ = bea.split_time_period(r.get("TimePeriod"))
-        if y is None:
-            continue
-        gf = r.get("GeoFips")
-        base = {
-            "year": y,
-            "geo_fips": gf,
-            "geo_name": r.get("GeoName"),
-            "table_name": table,
-            "line_code": line_code,
-            "series_code": r.get("Code"),
-            "line_description": line_desc,
-            "unit": r.get("CL_UNIT"),
-            "unit_mult": r.get("UNIT_MULT"),
-            "value": bea.clean_value(r.get("DataValue")),
-            "note_ref": r.get("NoteRef"),
-        }
-        if level == "state":
-            base.update(
-                quarter=q, frequency=_freq(y, q, None), id_state=_id_state(gf)
-            )
-        elif level == "county":
-            base.update(
-                id_county=gf,
-                id_state=(gf[:2] if gf and len(gf) == 5 else None),
-            )
-        elif level == "metro":
-            base.update(id_cbsa=gf)
-        yield base
+# Staging schema is the single source of truth (shared with the pipeline).
+SCHEMAS = STAGING_SCHEMAS
 
 
 # ----------------------------------------------------------------- writers ---
-FLUSH_ROWS = 500_000
+FLUSH_ROWS = constants.FLUSH_ROWS.value
 
 
 class Writer:
-    """Buffers rows for one db-table, flushing in chunks to bound memory and
-    keep the part-file count reasonable (county would otherwise emit ~20k files).
-    `tag` (the source BEA table) is embedded in each part-file name so a partial
-    BEA table can be purged and re-run on resume."""
+    """Buffers rows for one db-table, flushing TYPED parquet in chunks to bound
+    memory and keep the part-file count reasonable. ``tag`` (the source BEA
+    table) is embedded in each part-file name so a partial BEA table can be
+    purged and re-run on resume."""
 
     def __init__(self, table: str):
         self.table = table
@@ -275,8 +90,6 @@ class Writer:
 
 
 def _purge_tag(table: str, tag: str):
-    import glob
-
     for f in glob.glob(
         os.path.join(OUTDIR, table, "**", f"part-{tag}-*.parquet"),
         recursive=True,
@@ -320,13 +133,8 @@ def _is_done(table: str) -> bool:
 
 
 # ------------------------------------------------------------- table runners --
-def _regional_tables(prefixes) -> list[str]:
-    tabs = [x["key"] for x in bea.param_values("Regional", "TableName")]
-    return [t for t in tabs if any(t.startswith(p) for p in prefixes)]
-
-
 def run_nipa():
-    tabs = [x["key"] for x in bea.param_values("NIPA", "TableName")]
+    tabs = nipa_table_names()
     done = _progress_load("nipa")
     print(f"[nipa] {len(tabs)} tables ({len(done)} already done)")
     w = Writer("nipa")
@@ -335,17 +143,7 @@ def run_nipa():
             continue
         _purge_tag("nipa", t)
         w.tag = t
-        try:
-            w.add(
-                _rows_nipa(
-                    bea.get_data(
-                        "NIPA", TableName=t, Frequency="A,Q,M", Year="ALL"
-                    )
-                )
-            )
-        except bea.BEAError as e:
-            print(f"  [nipa] {t} skipped: {e.desc}")
-            continue
+        w.add(fetch_nipa_table(t))
         w.flush()
         _progress_add("nipa", t)
         if i % 25 == 0:
@@ -356,8 +154,7 @@ def run_nipa():
 
 
 def run_gdp_by_industry():
-    tids = bea.param_values("GDPbyIndustry", "TableID")
-    desc = {x["key"]: (x["desc"] or "").strip() for x in tids}
+    tids = gi_tables()
     done = _progress_load("gdp_by_industry")
     print(f"[gdp_by_industry] {len(tids)} tables")
     w = Writer("gdp_by_industry")
@@ -367,23 +164,7 @@ def run_gdp_by_industry():
             continue
         _purge_tag("gdp_by_industry", tid)
         w.tag = tid
-        for freq in ("A", "Q"):
-            try:
-                w.add(
-                    _rows_gi(
-                        bea.get_data(
-                            "GDPbyIndustry",
-                            TableID=tid,
-                            Industry="ALL",
-                            Frequency=freq,
-                            Year="ALL",
-                        ),
-                        desc.get(tid, ""),
-                    )
-                )
-            except bea.BEAError as e:
-                print(f"  [gi] T{tid} {freq} skipped: {e.desc}")
-                continue
+        w.add(fetch_gi_table(tid, (x["desc"] or "").strip()))
         w.flush()
         _progress_add("gdp_by_industry", tid)
     w.flush()
@@ -392,7 +173,7 @@ def run_gdp_by_industry():
 
 
 def _run_regional(table_key, prefixes, geofips, level):
-    tabs = _regional_tables(prefixes)
+    tabs = regional_table_names(prefixes)
     done = _progress_load(table_key)
     print(
         f"[{table_key}] {len(tabs)} BEA tables ({','.join(prefixes)}) @ GeoFips={geofips} "
@@ -405,95 +186,42 @@ def _run_regional(table_key, prefixes, geofips, level):
             continue
         _purge_tag(table_key, t)
         w.tag = t
-        ldesc = _line_desc_map("Regional", t)
-        codes = list(ldesc.keys())
         before = w.total + len(w.buf)
-        for lc in codes:
-            try:
-                api = bea.get_data(
-                    "Regional",
-                    TableName=t,
-                    LineCode=lc,
-                    GeoFips=geofips,
-                    Year="ALL",
-                )
-            except bea.BEAError as e:
-                if e.code in ("204", "100"):  # no data / invalid line
-                    continue
-                print(f"  [{table_key}] {t} line {lc}: {e.desc}")
-                continue
-            w.add(_rows_regional(api, t, lc, ldesc.get(lc, ""), level))
+        for batch in fetch_regional_table(t, geofips, level):
+            w.add(batch)
         got = w.total + len(w.buf) - before
         w.flush()
         _progress_add(table_key, t)
-        print(
-            f"  [{table_key}] {ti}/{len(tabs)} {t}: {got:,} rows ({len(codes)} lines)"
-        )
+        print(f"  [{table_key}] {ti}/{len(tabs)} {t}: {got:,} rows")
     w.flush()
     _mark_done(table_key, w.total)
     print(f"[{table_key}] done: {w.total:,} rows")
 
 
 def run_regional_state():
-    _run_regional("regional_state", ("SA", "SQ", "PR", "TA"), "STATE", "state")
+    fam = constants.REGIONAL_FAMILIES.value["regional_state"]
+    _run_regional(
+        "regional_state", fam["prefixes"], fam["geofips"], fam["level"]
+    )
 
 
 def run_regional_county():
-    _run_regional("regional_county", ("CA",), "COUNTY", "county")
+    fam = constants.REGIONAL_FAMILIES.value["regional_county"]
+    _run_regional(
+        "regional_county", fam["prefixes"], fam["geofips"], fam["level"]
+    )
 
 
 def run_regional_metro():
-    _run_regional("regional_metro", ("MA",), "MSA", "metro")
-
-
-_FREQ_LABELS = {"A": "Annual", "Q": "Quarterly", "M": "Monthly"}
+    fam = constants.REGIONAL_FAMILIES.value["regional_metro"]
+    _run_regional(
+        "regional_metro", fam["prefixes"], fam["geofips"], fam["level"]
+    )
 
 
 def run_dicionario():
     """Code->label maps for the dictionary-covered columns across all tables."""
-    rows: list[dict] = []
-
-    def add(id_tabela, nome_coluna, chave, valor):
-        rows.append(
-            {
-                "id_tabela": id_tabela,
-                "nome_coluna": nome_coluna,
-                "chave": str(chave),
-                "cobertura_temporal": "",
-                "valor": valor,
-            }
-        )
-
-    # table_name -> description, per db table
-    nipa_tabs = bea.param_values("NIPA", "TableName")
-    for x in nipa_tabs:
-        add("nipa", "table_id", x["key"], x["desc"])
-    reg_tabs = {
-        x["key"]: x["desc"] for x in bea.param_values("Regional", "TableName")
-    }
-    fam = {
-        "regional_state": ("SA", "SQ", "PR", "TA"),
-        "regional_county": ("CA",),
-        "regional_metro": ("MA",),
-    }
-    for dbt_tbl, prefs in fam.items():
-        for code, desc in reg_tabs.items():
-            if any(code.startswith(p) for p in prefs):
-                add(dbt_tbl, "table_id", code, desc)
-    # gdp_by_industry: table_id + industry
-    for x in bea.param_values("GDPbyIndustry", "TableID"):
-        add("gdp_by_industry", "table_id", x["key"], x["desc"])
-    for x in bea.param_values("GDPbyIndustry", "Industry"):
-        add("gdp_by_industry", "industry", x["key"], x["desc"])
-    # frequency labels, per table that has the column
-    for dbt_tbl, freqs in {
-        "nipa": "AQM",
-        "gdp_by_industry": "AQ",
-        "regional_state": "AQ",
-    }.items():
-        for f in freqs:
-            add(dbt_tbl, "frequency", f, _FREQ_LABELS[f])
-
+    rows = build_dicionario_rows()
     outdir = os.path.join(OUTDIR, "dicionario")
     os.makedirs(outdir, exist_ok=True)
     tbl = pa.Table.from_pylist(rows, schema=SCHEMAS["dicionario"])
@@ -501,16 +229,6 @@ def run_dicionario():
     _mark_done("dicionario", len(rows))
     print(f"[dicionario] done: {len(rows):,} rows")
 
-
-SCHEMAS["dicionario"] = _schema(
-    [
-        ("id_tabela", STR),
-        ("nome_coluna", STR),
-        ("chave", STR),
-        ("cobertura_temporal", STR),
-        ("valor", STR),
-    ]
-)
 
 RUNNERS = {
     "nipa": run_nipa,

--- a/pipelines/datasets/us_bea/constants.py
+++ b/pipelines/datasets/us_bea/constants.py
@@ -1,0 +1,91 @@
+"""Constants for the us_bea recurring pipeline (Prefect 3).
+
+US Bureau of Economic Analysis (BEA) economic accounts, pulled directly from the
+BEA REST API (https://apps.bea.gov/api/). Six tables: nipa, gdp_by_industry,
+regional_state, regional_county, regional_metro, dicionario.
+
+The API key is read from the ``BEA_API_KEY`` environment variable when present
+(local development), and otherwise from HashiCorp Vault on the deployed worker —
+see ``pipelines.datasets.us_bea.utils._key``.
+"""
+
+from enum import Enum
+from pathlib import Path
+
+# Repo root, then the committed architecture CSVs. These describe the FINAL
+# (post-dbt) schema; the raw STAGING schema this pipeline writes differs
+# (table_name/series_code, quarter/month as STRING) and lives in utils.py as
+# ``STAGING_SCHEMAS`` — the dbt models rename/recast into the architecture shape.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class constants(Enum):
+    """Constants for the us_bea pipeline.
+
+    Lowercase class name follows the repo-wide convention for dataset constant
+    enums.
+    """
+
+    DATASET_ID = "us_bea"
+
+    # BEA REST API.
+    BASE_URL = "https://apps.bea.gov/api/data/"
+    # Min seconds between call starts -> ~92/min, under BEA's 100/min cap.
+    MIN_INTERVAL = 0.65
+
+    # API key resolution. When BEA_API_KEY is absent from the environment (the
+    # deployed worker), the key is read from Vault at VAULT_SECRET_PATH under
+    # VAULT_KEY. The user must provision that secret before arming the schedule.
+    ENV_KEY = "BEA_API_KEY"
+    VAULT_SECRET_PATH = "us_bea"
+    VAULT_KEY = "BEA_API_KEY"
+
+    # Tokens the API uses for missing/suppressed values -> NULL.
+    MISSING_TOKENS = ["", "(NA)", "(NM)", "(D)", "(L)", "(*)", "NA", "n/a"]
+
+    # Data tables (partitioned parquet) + the static dictionary.
+    DATA_TABLES = [
+        "nipa",
+        "gdp_by_industry",
+        "regional_state",
+        "regional_county",
+        "regional_metro",
+    ]
+    ALL_TABLES = [
+        "nipa",
+        "gdp_by_industry",
+        "regional_state",
+        "regional_county",
+        "regional_metro",
+        "dicionario",
+    ]
+
+    # Regional families: the BEA "Regional" dataset holds many TableName codes;
+    # each db-table pulls a prefix family at a fixed geographic wildcard.
+    #   regional_state  = SA*/SQ*/PR*/TA* tables, GeoFips=STATE
+    #   regional_county = CA* tables,             GeoFips=COUNTY
+    #   regional_metro  = MA* tables,             GeoFips=MSA
+    REGIONAL_FAMILIES = {
+        "regional_state": {
+            "prefixes": ["SA", "SQ", "PR", "TA"],
+            "geofips": "STATE",
+            "level": "state",
+        },
+        "regional_county": {
+            "prefixes": ["CA"],
+            "geofips": "COUNTY",
+            "level": "county",
+        },
+        "regional_metro": {
+            "prefixes": ["MA"],
+            "geofips": "MSA",
+            "level": "metro",
+        },
+    }
+
+    # Rows buffered per table before a flush (bounds peak RAM; county is ~50M).
+    FLUSH_ROWS = 500_000
+
+    ARCHITECTURE_DIR = (
+        _REPO_ROOT / "models" / "us_bea" / "code" / "architecture"
+    )

--- a/pipelines/datasets/us_bea/flows.py
+++ b/pipelines/datasets/us_bea/flows.py
@@ -1,0 +1,195 @@
+"""Flows for us_bea — Prefect 3.
+
+US Bureau of Economic Analysis (BEA) economic accounts, pulled from the BEA REST
+API. BEA benchmark revisions rewrite historical values, so each run re-fetches
+the full history and overwrites staging (``dump_mode="overwrite"``), rather than
+appending. A single flow downloads once and rebuilds all six tables.
+
+Coverage tier: all six tables are ``AllFree``. ``nipa`` is a mixed-frequency
+table (annual/quarterly rows have a NULL ``month``), so a monthly Row Access
+Policy would paywall those rows forever (``DATE(year, month, 1)`` is NULL) — it
+is therefore NOT paywalled. ``nipa``'s ``(year, month)`` coverage still drives
+the monthly source poll; it just does not gate access. ``dicionario`` has no
+date column, so it takes no coverage spec. If a rolling BD Pro paywall is wanted
+later, add an end-of-period ``date`` column to ``nipa`` and key the policy on it.
+
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``us_bea_flow``; the
+dev pool ignores the schedule, the prod pool activates it (paused).
+"""
+
+import shutil
+import tempfile
+
+from prefect import flow
+
+from pipelines.datasets.us_bea.constants import constants
+from pipelines.datasets.us_bea.tasks import clean_bea
+from pipelines.utils.metadata.domain import (
+    AllFree,
+    DateFormat,
+    YearMonth,
+    YearOnly,
+)
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+
+# The table whose coverage drives the source poll: nipa is the high-frequency
+# (monthly) table.
+POLL_TABLE = "nipa"
+
+# Coverage spec per table (see module docstring). `dicionario` is intentionally
+# absent — no date column, no coverage.
+_COVERAGE = {
+    # nipa mixes A/Q/M frequencies (annual/quarterly rows have NULL month), so a
+    # monthly Row Access Policy would paywall those rows forever. Kept AllFree;
+    # the YearMonth date column still drives the monthly source poll.
+    "nipa": AllFree(
+        date_column=YearMonth(year="year", month="month"),
+        date_format=DateFormat.YEAR_MONTH,
+    ),
+    "gdp_by_industry": AllFree(
+        date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
+    ),
+    "regional_state": AllFree(
+        date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
+    ),
+    "regional_county": AllFree(
+        date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
+    ),
+    "regional_metro": AllFree(
+        date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
+    ),
+}
+
+
+@flow(name="us_bea", log_prints=True)
+def us_bea_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+) -> None:
+    """Download the BEA economic accounts, rebuild all six tables, materialize.
+
+    BEA benchmark revisions rewrite history, so each run is a full replace
+    (``dump_mode="overwrite"``) rather than an incremental append. The source
+    poll short-circuits the run when BEA has not published a newer month, which
+    makes a scheduled run a cheap no-op between releases.
+
+    Args:
+        materialize_to_prod: Continue past the dev materialization to write the
+            prod staging bucket and run dbt against ``target="prod"``. Set False
+            to exercise only the dev half — required for a safe test run, since
+            the default writes production.
+        update_metadata: After a successful prod materialization, register table
+            coverage and commit the source update. Has no effect when
+            ``materialize_to_prod`` is False.
+        force_run: Materialize even when the source poll reports no new month.
+    """
+    # pyrefly: ignore [unused-coroutine]
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id="us_bea"
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="us_bea_")
+    try:
+        result = clean_bea(work_dir=work_dir)
+        max_ym = result["max_year_month"]
+
+        # Skip the run when BEA has not published a newer month (unless forced).
+        has_new_data = poll_source_for_update_task(
+            dataset_id=DATASET_ID,
+            table_id=POLL_TABLE,
+            source_max_date=max_ym,
+            env="prod",
+            date_format="%Y-%m",
+            compare_against="coverage",
+        )
+        if not has_new_data and not force_run:
+            return
+
+        # Commit the source Update up front: if the flow fails mid-way, the
+        # source metadata still records that new data had been published.
+        commit_source_update_task(
+            dataset_id=DATASET_ID,
+            table_id=POLL_TABLE,
+            source_max_date=max_ym,
+            env="prod",
+            date_format="%Y-%m",
+            update_metadata=update_metadata,
+            materialize_after_dump=materialize_to_prod,
+        )
+
+        tables = constants.ALL_TABLES.value
+
+        # Dev: upload staging + materialize/test.
+        for table in tables:
+            upload_to_gcs(
+                data_path=result[table],
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados-dev",
+                dump_mode="overwrite",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="dev",
+            )
+
+        if not materialize_to_prod:
+            return
+
+        # Prod: upload staging + materialize/test.
+        for table in tables:
+            upload_to_gcs(
+                data_path=result[table],
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados",
+                dump_mode="overwrite",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run/test",
+                target="prod",
+            )
+
+        if update_metadata:
+            for table, coverage in _COVERAGE.items():
+                register_table_materialization_task(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    coverage=coverage,
+                    env="prod",
+                    bq_project="basedosdados",
+                )
+    finally:
+        # Covers both early returns (no new data, dev-only) and any exception.
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# BEA refreshes NIPA monthly (personal income near month-end; benchmark and GDP
+# revisions land irregularly). Poll across a few late-month days at 16:00 BRT;
+# the source-poll guard no-ops until a new month actually appears.
+# pyrefly: ignore [missing-attribute]
+us_bea_flow.deploy_schedules = [
+    {"cron": "0 16 25,26,27,28 * *", "timezone": "America/Sao_Paulo"}
+]
+# The clean step streams the ~50M-row county family through pandas/arrow in
+# 500k-row flushes; give the worker headroom.
+# pyrefly: ignore [missing-attribute]
+us_bea_flow.job_variables = {"memory": "8Gi"}

--- a/pipelines/datasets/us_bea/tasks.py
+++ b/pipelines/datasets/us_bea/tasks.py
@@ -1,0 +1,31 @@
+"""Prefect 3 tasks for us_bea — thin wrappers over utils.py."""
+
+from pathlib import Path
+
+from prefect import task
+
+from pipelines.datasets.us_bea.utils import clean_all
+
+
+@task
+def clean_bea(work_dir: str) -> dict:
+    """Download all six BEA tables from the API and write partitioned parquet.
+
+    The download and the cleaning are one step here: the BEA source is a REST
+    API with no bulk archive to cache, so ``clean_all`` streams each table's
+    rows straight to all-STRING parquet.
+
+    Args:
+        work_dir: Directory to write into; tables land under
+            ``<work_dir>/output``.
+
+    Returns:
+        A mapping of table slug to its partitioned output directory, plus
+        ``"max_year_month"`` — the latest ``"YYYY-MM"`` in the monthly NIPA
+        rows, which drives the source-update poll.
+    """
+    output_dir = Path(work_dir) / "output"
+    result = clean_all(output_dir)
+    return {
+        k: (str(v) if isinstance(v, Path) else v) for k, v in result.items()
+    }

--- a/pipelines/datasets/us_bea/utils.py
+++ b/pipelines/datasets/us_bea/utils.py
@@ -622,8 +622,10 @@ class _StringWriter:
         # all-string via arrow (NULLs preserved, never "nan").
         typed = pa.Table.from_pylist(self.buf, schema=self.typed)
         at = typed.cast(self.string)
-        for y in pc.unique(at.column("year")).to_pylist():
-            sub = at.filter(pc.equal(at.column("year"), y))
+        # pyarrow.compute builds unique/equal dynamically, so static type checkers
+        # (pyrefly) flag them as missing; they exist at runtime.
+        for y in pc.unique(at.column("year")).to_pylist():  # pyrefly: ignore
+            sub = at.filter(pc.equal(at.column("year"), y))  # pyrefly: ignore
             pdir = self.dir / f"year={y}"
             pdir.mkdir(parents=True, exist_ok=True)
             pq.write_table(

--- a/pipelines/datasets/us_bea/utils.py
+++ b/pipelines/datasets/us_bea/utils.py
@@ -1,0 +1,707 @@
+"""BEA API client + download/clean transform for us_bea (shared by the recurring
+pipeline and the one-shot bootstrap in ``models/us_bea/code/``).
+
+Pure functions (no Prefect) so they are importable and unit-testable. The
+recurring pipeline wraps them in @task (see tasks.py); the bootstrap
+``models/us_bea/code/clean.py`` imports the same row-builders and fetch helpers,
+so the two cannot drift apart.
+
+Two schemas are in play and must not be confused:
+
+- ``STAGING_SCHEMAS`` (here) — the RAW STAGING schema this pipeline writes:
+  ``year`` INT64, ``value`` FLOAT64, everything else STRING (including
+  ``quarter``/``month``), with staging column names ``table_name``/``series_code``.
+- the architecture CSVs under ``models/us_bea/code/architecture/`` — the FINAL
+  post-dbt schema (``table_id``/``series_id``, ``quarter``/``month`` INT64). The
+  dbt models rename and recast staging into that shape.
+
+The bootstrap uploads STAGING_SCHEMAS as TYPED parquet (the one-shot onboarding
+path accepts it). The recurring pipeline instead writes ALL-STRING parquet: the
+``dump_header`` parquet bug makes ``upload_to_gcs`` infer every staging column as
+STRING, so typed parquet is rejected on read. Values pass through the typed
+staging schema FIRST (so ``year`` serializes as ``"1959"`` not ``"1959.0"``) and
+are only then cast to string via arrow — never ``astype(str)``, which would turn
+NULL into the literal ``"nan"`` and defeat the dbt ``safe_cast``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
+from pipelines.datasets.us_bea.constants import constants
+
+log = logging.getLogger("us_bea")
+
+BASE = constants.BASE_URL.value
+MISSING_TOKENS = set(constants.MISSING_TOKENS.value)
+
+
+# --------------------------------------------------------------------------- #
+# API key: env var locally, Vault on the deployed worker
+# --------------------------------------------------------------------------- #
+def _key() -> str:
+    """Return the BEA API key: ``BEA_API_KEY`` env var if set, else Vault.
+
+    Locally the key is provided via the environment. On the deployed Prefect
+    worker there is no such env var, so it is read from HashiCorp Vault at
+    ``constants.VAULT_SECRET_PATH`` under ``constants.VAULT_KEY``.
+
+    Raises:
+        RuntimeError: If the key is found in neither the environment nor Vault.
+    """
+    k = os.environ.get(constants.ENV_KEY.value, "").strip()
+    if k:
+        return k
+    # Deployed worker: read from Vault. Imported lazily so local use (and unit
+    # tests) never require hvac / Vault connectivity.
+    from pipelines.utils.vault import get_credentials_from_secret
+
+    tokens = get_credentials_from_secret(constants.VAULT_SECRET_PATH.value)
+    k = str(tokens.get(constants.VAULT_KEY.value, "")).strip()
+    if not k:
+        raise RuntimeError(
+            "BEA_API_KEY not set in environment and not found in Vault "
+            f"at {constants.VAULT_SECRET_PATH.value!r}"
+        )
+    return k
+
+
+_last_call = [0.0]
+
+
+def _throttle() -> None:
+    interval = constants.MIN_INTERVAL.value
+    dt = time.monotonic() - _last_call[0]
+    if dt < interval:
+        time.sleep(interval - dt)
+    _last_call[0] = time.monotonic()
+
+
+class BEAError(RuntimeError):
+    def __init__(self, code, desc, dataset, params):
+        self.code, self.desc = code, desc
+        super().__init__(
+            f"BEA APIErrorCode {code}: {desc} [{dataset} {params}]"
+        )
+
+
+def call(
+    method: str, dataset: str | None = None, *, max_retries: int = 6, **params
+) -> dict:
+    """One BEA API call. Handles 429/Retry-After and transient errors.
+
+    Args:
+        method: BEA API method (``GetData``, ``GetParameterValues`` …).
+        dataset: BEA dataset name, or None for methods that take no dataset.
+        max_retries: Attempts before giving up on transient failures.
+        **params: Method parameters; None values are dropped.
+
+    Returns:
+        The ``Results`` node of the response.
+
+    Raises:
+        BEAError: On a non-throttle API error.
+        RuntimeError: If all retries are exhausted.
+    """
+    _throttle()
+    q = {"UserID": _key(), "method": method, "ResultFormat": "JSON"}
+    if dataset:
+        q["datasetname"] = dataset
+    q.update({k: v for k, v in params.items() if v is not None})
+    url = BASE + "?" + urllib.parse.urlencode(q)
+    delay = 2.0
+    for attempt in range(max_retries):
+        try:
+            with urllib.request.urlopen(url, timeout=180) as r:
+                body = json.load(r)
+        except urllib.error.HTTPError as e:
+            if e.code == 429:
+                wait = int(e.headers.get("Retry-After", "60")) + 1
+                time.sleep(wait)
+                continue
+            if attempt < max_retries - 1:
+                time.sleep(delay)
+                delay = min(delay * 2, 60)
+                continue
+            raise
+        except (urllib.error.URLError, TimeoutError, ConnectionError):
+            if attempt < max_retries - 1:
+                time.sleep(delay)
+                delay = min(delay * 2, 60)
+                continue
+            raise
+        res = body.get("BEAAPI", {}).get("Results", {})
+        if isinstance(res, list):
+            res = res[0] if res else {}
+        err = res.get("Error") if isinstance(res, dict) else None
+        if err:
+            code = str(err.get("APIErrorCode", ""))
+            desc = err.get("APIErrorDescription", "") or err.get(
+                "ErrorDetail", {}
+            ).get("Description", "")
+            if code == "7":  # throttled
+                time.sleep(61)
+                continue
+            raise BEAError(code, desc, dataset, params)
+        return res
+    raise RuntimeError(
+        f"BEA call failed after retries: {method} {dataset} {params}"
+    )
+
+
+def _norm_pv(node: dict, param: str) -> dict:
+    """ParamValue nodes are keyed differently per dataset. Normalize to
+    ``{'key','desc'}``."""
+    key = node.get("Key") if "Key" in node else None
+    if key is None:
+        key = (
+            node.get(param)
+            or node.get("TableName")
+            or node.get("TableID")
+            or node.get("LineCode")
+            or node.get("Industry")
+            or node.get("FrequencyID")
+        )
+    desc = node.get("Desc") or node.get("Description") or ""
+    return {"key": str(key) if key is not None else None, "desc": desc}
+
+
+def param_values(dataset: str, param: str) -> list[dict]:
+    res = call("GetParameterValues", dataset, ParameterName=param)
+    v = res.get("ParamValue", res)
+    v = v if isinstance(v, list) else [v]
+    return [_norm_pv(n, param) for n in v]
+
+
+def param_values_filtered(dataset: str, target: str, **filters) -> list[dict]:
+    res = call(
+        "GetParameterValuesFiltered",
+        dataset,
+        TargetParameter=target,
+        **filters,
+    )
+    v = res.get("ParamValue", res)
+    v = v if isinstance(v, list) else [v]
+    return [_norm_pv(n, target) for n in v]
+
+
+def get_data(dataset: str, **params) -> list[dict]:
+    """GetData -> list of data rows (possibly empty)."""
+    res = call("GetData", dataset, **params)
+    data = res.get("Data", [])
+    if isinstance(data, dict):
+        data = [data]
+    return data
+
+
+# --------------------------------------------------------------------------- #
+# pure cleaning helpers
+# --------------------------------------------------------------------------- #
+def clean_value(raw) -> float | None:
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    if s in MISSING_TOKENS:
+        return None
+    s = s.replace(",", "")
+    if (
+        s.startswith("(")
+        and s.endswith(")")
+        and s[1:-1].replace(".", "").isdigit()
+    ):
+        s = "-" + s[1:-1]
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def split_time_period(
+    tp: str | None,
+) -> tuple[int | None, str | None, str | None]:
+    """TimePeriod -> (year, quarter, month). YYYY / YYYYQn / YYYYMnn."""
+    if tp is None:
+        return None, None, None
+    tp = tp.strip()
+    try:
+        if "Q" in tp:
+            y, q = tp.split("Q")
+            return int(y), q, None
+        if "M" in tp:
+            y, m = tp.split("M")
+            return int(y), None, m.zfill(2)
+        return int(tp[:4]), None, None
+    except (ValueError, IndexError):
+        return None, None, None
+
+
+def line_from_code(code: str) -> str | None:
+    """Regional 'Code' like 'SAGDP2N-1' -> line_code '1'."""
+    if not code:
+        return None
+    return code.rsplit("-", 1)[-1] if "-" in code else None
+
+
+def norm_gi_quarter(frequency: str, quarter) -> str | None:
+    """GDPbyIndustry: annual rows have Quarter==Year; quarterly rows are I..IV."""
+    if frequency == "A":
+        return None
+    roman = {"I": "1", "II": "2", "III": "3", "IV": "4"}
+    return roman.get(str(quarter).strip(), str(quarter).strip() or None)
+
+
+def _freq(year, quarter, month) -> str:
+    return "M" if month else ("Q" if quarter else "A")
+
+
+_REGION_PREFIX = {"91", "92", "93", "94", "95", "96", "97", "98"}
+
+
+def _id_state(geo_fips: str) -> str | None:
+    """NN000 -> NN for real states/territories; None for US(00000) and BEA regions."""
+    if not geo_fips or len(geo_fips) != 5 or not geo_fips.endswith("000"):
+        return None
+    st = geo_fips[:2]
+    if st == "00" or st in _REGION_PREFIX:
+        return None
+    return st
+
+
+def _strip_tag(desc: str) -> str:
+    # "[SAGDP2] Gross domestic product" -> "Gross domestic product"
+    return re.sub(r"^\[[^\]]*\]\s*", "", desc or "").strip()
+
+
+def line_desc_map(dataset: str, table: str) -> dict:
+    out = {}
+    for x in param_values_filtered(dataset, "LineCode", TableName=table):
+        if x["key"] is not None:
+            out[x["key"]] = _strip_tag(x["desc"])
+    return out
+
+
+# --------------------------------------------------------------- row builders --
+def rows_nipa(api_rows):
+    for r in api_rows:
+        y, q, m = split_time_period(r.get("TimePeriod"))
+        if y is None:
+            continue
+        yield {
+            "year": y,
+            "quarter": q,
+            "month": m,
+            "frequency": _freq(y, q, m),
+            "table_name": r.get("TableName"),
+            "line_number": r.get("LineNumber"),
+            "series_code": r.get("SeriesCode"),
+            "line_description": r.get("LineDescription"),
+            "metric_name": r.get("METRIC_NAME"),
+            "unit": r.get("CL_UNIT"),
+            "unit_mult": r.get("UNIT_MULT"),
+            "value": clean_value(r.get("DataValue")),
+            "note_ref": r.get("NoteRef"),
+        }
+
+
+def rows_gi(api_rows, table_desc):
+    for r in api_rows:
+        try:
+            y = int(r.get("Year"))
+        except (TypeError, ValueError):
+            continue
+        freq = r.get("Frequency")
+        yield {
+            "year": y,
+            "quarter": norm_gi_quarter(freq, r.get("Quarter")),
+            "frequency": freq,
+            "table_id": str(r.get("TableID")),
+            "table_description": table_desc,
+            "industry": r.get("Industry"),
+            "industry_description": r.get("IndustrYDescription"),
+            "value": clean_value(r.get("DataValue")),
+            "note_ref": r.get("NoteRef"),
+        }
+
+
+def rows_regional(api_rows, table, line_code, line_desc, level):
+    for r in api_rows:
+        y, q, _ = split_time_period(r.get("TimePeriod"))
+        if y is None:
+            continue
+        gf = r.get("GeoFips")
+        base = {
+            "year": y,
+            "geo_fips": gf,
+            "geo_name": r.get("GeoName"),
+            "table_name": table,
+            "line_code": line_code,
+            "series_code": r.get("Code"),
+            "line_description": line_desc,
+            "unit": r.get("CL_UNIT"),
+            "unit_mult": r.get("UNIT_MULT"),
+            "value": clean_value(r.get("DataValue")),
+            "note_ref": r.get("NoteRef"),
+        }
+        if level == "state":
+            base.update(
+                quarter=q, frequency=_freq(y, q, None), id_state=_id_state(gf)
+            )
+        elif level == "county":
+            base.update(
+                id_county=gf,
+                id_state=(gf[:2] if gf and len(gf) == 5 else None),
+            )
+        elif level == "metro":
+            base.update(id_cbsa=gf)
+        yield base
+
+
+# ----------------------------------------------------- table listing + fetch --
+def nipa_table_names() -> list[str]:
+    return [x["key"] for x in param_values("NIPA", "TableName")]
+
+
+def gi_tables() -> list[dict]:
+    """GDPbyIndustry TableIDs as ``[{'key','desc'}, …]``."""
+    return param_values("GDPbyIndustry", "TableID")
+
+
+def regional_table_names(prefixes) -> list[str]:
+    tabs = [x["key"] for x in param_values("Regional", "TableName")]
+    return [t for t in tabs if any(t.startswith(p) for p in prefixes)]
+
+
+def fetch_nipa_table(t: str) -> list[dict]:
+    """All rows for one NIPA TableName (A/Q/M, full history). [] on API error."""
+    try:
+        api = get_data("NIPA", TableName=t, Frequency="A,Q,M", Year="ALL")
+    except BEAError as e:
+        log.info("[nipa] %s skipped: %s", t, e.desc)
+        return []
+    return list(rows_nipa(api))
+
+
+def fetch_gi_table(tid: str, desc: str) -> list[dict]:
+    """All rows for one GDPbyIndustry TableID (annual then quarterly)."""
+    out: list[dict] = []
+    for freq in ("A", "Q"):
+        try:
+            api = get_data(
+                "GDPbyIndustry",
+                TableID=tid,
+                Industry="ALL",
+                Frequency=freq,
+                Year="ALL",
+            )
+        except BEAError as e:
+            log.info("[gi] T%s %s skipped: %s", tid, freq, e.desc)
+            continue
+        out.extend(rows_gi(api, desc))
+    return out
+
+
+def fetch_regional_table(t: str, geofips: str, level: str):
+    """Yield row batches (one per LineCode) for one regional BEA TableName.
+
+    Yielded per line code so the caller can flush between codes and keep peak
+    RAM bounded — the county family alone is ~50M rows.
+    """
+    ldesc = line_desc_map("Regional", t)
+    for lc in ldesc:
+        try:
+            api = get_data(
+                "Regional",
+                TableName=t,
+                LineCode=lc,
+                GeoFips=geofips,
+                Year="ALL",
+            )
+        except BEAError as e:
+            if e.code in ("204", "100"):  # no data / invalid line
+                continue
+            log.info("[%s] %s line %s: %s", level, t, lc, e.desc)
+            continue
+        yield list(rows_regional(api, t, lc, ldesc.get(lc, ""), level))
+
+
+# ----------------------------------------------------------- dicionario rows --
+_FREQ_LABELS = {"A": "Annual", "Q": "Quarterly", "M": "Monthly"}
+
+
+def build_dicionario_rows() -> list[dict]:
+    """Code->label maps for the dictionary-covered columns across all tables."""
+    rows: list[dict] = []
+
+    def add(id_tabela, nome_coluna, chave, valor):
+        rows.append(
+            {
+                "id_tabela": id_tabela,
+                "nome_coluna": nome_coluna,
+                "chave": str(chave),
+                "cobertura_temporal": "",
+                "valor": valor,
+            }
+        )
+
+    for x in param_values("NIPA", "TableName"):
+        add("nipa", "table_id", x["key"], x["desc"])
+    reg_tabs = {
+        x["key"]: x["desc"] for x in param_values("Regional", "TableName")
+    }
+    for dbt_tbl, fam in constants.REGIONAL_FAMILIES.value.items():
+        prefs = fam["prefixes"]
+        for code, desc in reg_tabs.items():
+            if any(code.startswith(p) for p in prefs):
+                add(dbt_tbl, "table_id", code, desc)
+    for x in param_values("GDPbyIndustry", "TableID"):
+        add("gdp_by_industry", "table_id", x["key"], x["desc"])
+    for x in param_values("GDPbyIndustry", "Industry"):
+        add("gdp_by_industry", "industry", x["key"], x["desc"])
+    for dbt_tbl, freqs in {
+        "nipa": "AQM",
+        "gdp_by_industry": "AQ",
+        "regional_state": "AQ",
+    }.items():
+        for f in freqs:
+            add(dbt_tbl, "frequency", f, _FREQ_LABELS[f])
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# staging schemas (TYPED). The bootstrap writes these as typed parquet; the
+# pipeline casts them to all-string (see module docstring).
+# --------------------------------------------------------------------------- #
+_STR = pa.string()
+_INT = pa.int64()
+_FLT = pa.float64()
+
+
+def _schema(cols) -> pa.Schema:
+    return pa.schema([pa.field(n, t) for n, t in cols])
+
+
+STAGING_SCHEMAS = {
+    "nipa": _schema(
+        [
+            ("year", _INT),
+            ("quarter", _STR),
+            ("month", _STR),
+            ("frequency", _STR),
+            ("table_name", _STR),
+            ("line_number", _STR),
+            ("series_code", _STR),
+            ("line_description", _STR),
+            ("metric_name", _STR),
+            ("unit", _STR),
+            ("unit_mult", _STR),
+            ("value", _FLT),
+            ("note_ref", _STR),
+        ]
+    ),
+    "gdp_by_industry": _schema(
+        [
+            ("year", _INT),
+            ("quarter", _STR),
+            ("frequency", _STR),
+            ("table_id", _STR),
+            ("table_description", _STR),
+            ("industry", _STR),
+            ("industry_description", _STR),
+            ("value", _FLT),
+            ("note_ref", _STR),
+        ]
+    ),
+    "regional_state": _schema(
+        [
+            ("year", _INT),
+            ("quarter", _STR),
+            ("frequency", _STR),
+            ("geo_fips", _STR),
+            ("id_state", _STR),
+            ("geo_name", _STR),
+            ("table_name", _STR),
+            ("line_code", _STR),
+            ("series_code", _STR),
+            ("line_description", _STR),
+            ("unit", _STR),
+            ("unit_mult", _STR),
+            ("value", _FLT),
+            ("note_ref", _STR),
+        ]
+    ),
+    "regional_county": _schema(
+        [
+            ("year", _INT),
+            ("geo_fips", _STR),
+            ("id_county", _STR),
+            ("id_state", _STR),
+            ("geo_name", _STR),
+            ("table_name", _STR),
+            ("line_code", _STR),
+            ("series_code", _STR),
+            ("line_description", _STR),
+            ("unit", _STR),
+            ("unit_mult", _STR),
+            ("value", _FLT),
+            ("note_ref", _STR),
+        ]
+    ),
+    "regional_metro": _schema(
+        [
+            ("year", _INT),
+            ("geo_fips", _STR),
+            ("id_cbsa", _STR),
+            ("geo_name", _STR),
+            ("table_name", _STR),
+            ("line_code", _STR),
+            ("series_code", _STR),
+            ("line_description", _STR),
+            ("unit", _STR),
+            ("unit_mult", _STR),
+            ("value", _FLT),
+            ("note_ref", _STR),
+        ]
+    ),
+    "dicionario": _schema(
+        [
+            ("id_tabela", _STR),
+            ("nome_coluna", _STR),
+            ("chave", _STR),
+            ("cobertura_temporal", _STR),
+            ("valor", _STR),
+        ]
+    ),
+}
+
+# All-STRING variants (staging schema cast to string, column order preserved).
+STRING_SCHEMAS = {
+    t: pa.schema([pa.field(f.name, _STR) for f in s])
+    for t, s in STAGING_SCHEMAS.items()
+}
+
+
+# --------------------------------------------------------------------------- #
+# all-string partitioned writer (pipeline)
+# --------------------------------------------------------------------------- #
+class _StringWriter:
+    """Buffers rows for one table and flushes all-STRING Snappy Parquet,
+    hive-partitioned by ``year`` (kept in the file too, matching the reference
+    ``us_bls_cpi`` writer). Flushing in chunks bounds peak RAM."""
+
+    def __init__(self, table: str, output_dir: Path):
+        self.table = table
+        self.dir = output_dir / table
+        self.typed = STAGING_SCHEMAS[table]
+        self.string = STRING_SCHEMAS[table]
+        self.buf: list[dict] = []
+        self.total = 0
+        self.seq = 0
+
+    def add(self, rows) -> None:
+        self.buf.extend(rows)
+        if len(self.buf) >= constants.FLUSH_ROWS.value:
+            self.flush()
+
+    def flush(self) -> None:
+        if not self.buf:
+            return
+        # Types-first: build with the typed staging schema so year is an int
+        # (serializes "1959", not "1959.0") and value a float, THEN cast to
+        # all-string via arrow (NULLs preserved, never "nan").
+        typed = pa.Table.from_pylist(self.buf, schema=self.typed)
+        at = typed.cast(self.string)
+        for y in pc.unique(at.column("year")).to_pylist():
+            sub = at.filter(pc.equal(at.column("year"), y))
+            pdir = self.dir / f"year={y}"
+            pdir.mkdir(parents=True, exist_ok=True)
+            pq.write_table(
+                sub, pdir / f"data-{self.seq}.parquet", compression="snappy"
+            )
+            self.seq += 1
+        self.total += len(self.buf)
+        self.buf = []
+
+
+def _write_dicionario(rows: list[dict], output_dir: Path) -> Path:
+    tdir = output_dir / "dicionario"
+    tdir.mkdir(parents=True, exist_ok=True)
+    at = pa.Table.from_pylist(rows, schema=STAGING_SCHEMAS["dicionario"])
+    at = at.cast(STRING_SCHEMAS["dicionario"])
+    pq.write_table(at, tdir / "data.parquet", compression="snappy")
+    log.info("dicionario: %s rows -> %s", f"{len(rows):,}", tdir)
+    return tdir
+
+
+def clean_all(output_dir: Path) -> dict:
+    """Download all six tables from the BEA API and write all-STRING parquet.
+
+    The single entry point the recurring pipeline uses (via
+    :func:`pipelines.datasets.us_bea.tasks.clean_bea`). Streams and flushes in
+    chunks to bound RAM (county alone is ~50M rows).
+
+    Args:
+        output_dir: Root output directory; each table lands under
+            ``<output_dir>/<table>/year=<YYYY>/data-<n>.parquet``.
+
+    Returns:
+        Mapping of table slug to output directory, plus ``"max_year_month"`` —
+        the latest ``"YYYY-MM"`` among monthly (frequency M) NIPA rows, which
+        drives the source-update poll. None if no monthly rows are present.
+    """
+    output_dir = Path(output_dir)
+    result: dict = {}
+    max_ym: tuple[int, int] | None = None
+
+    # nipa
+    w = _StringWriter("nipa", output_dir)
+    for t in nipa_table_names():
+        rows = fetch_nipa_table(t)
+        for r in rows:
+            if r["month"] is not None:
+                ym = (r["year"], int(r["month"]))
+                if max_ym is None or ym > max_ym:
+                    max_ym = ym
+        w.add(rows)
+    w.flush()
+    log.info("nipa: %s rows -> %s", f"{w.total:,}", w.dir)
+    result["nipa"] = str(w.dir)
+
+    # gdp_by_industry
+    w = _StringWriter("gdp_by_industry", output_dir)
+    for x in gi_tables():
+        w.add(fetch_gi_table(x["key"], (x["desc"] or "").strip()))
+    w.flush()
+    log.info("gdp_by_industry: %s rows -> %s", f"{w.total:,}", w.dir)
+    result["gdp_by_industry"] = str(w.dir)
+
+    # regional_state / regional_county / regional_metro
+    for table, fam in constants.REGIONAL_FAMILIES.value.items():
+        w = _StringWriter(table, output_dir)
+        for t in regional_table_names(fam["prefixes"]):
+            for batch in fetch_regional_table(t, fam["geofips"], fam["level"]):
+                w.add(batch)
+        w.flush()
+        log.info("%s: %s rows -> %s", table, f"{w.total:,}", w.dir)
+        result[table] = str(w.dir)
+
+    # dicionario
+    result["dicionario"] = str(
+        _write_dicionario(build_dicionario_rows(), output_dir)
+    )
+
+    result["max_year_month"] = (
+        f"{max_ym[0]}-{max_ym[1]:02d}" if max_ym else None
+    )
+    return result


### PR DESCRIPTION
## Recurring pipeline: `us_bea` (Bureau of Economic Analysis)

Adds a Prefect 3 refresh pipeline for the `us_bea` dataset onboarded in #1822 (already live on prod).

### Design
- **Monthly** cadence — polls a few late-month days; the source-poll guard no-ops until a new NIPA period lands.
- **`dump_mode="overwrite"`** — BEA benchmark revisions rewrite historical values, so each run re-fetches the full history and overwrites staging.
- **All-STRING staging parquet** (arrow-cast, types-first) to satisfy the `dump_header` staging-schema inference; hive-partitioned by `year`, `source_format="parquet"`.
- **All 6 tables `AllFree`.** `nipa` mixes A/Q/M frequencies (annual/quarterly rows have NULL `month`), so a monthly Row Access Policy would paywall those rows forever — it is deliberately not paywalled. `nipa`'s `(year, month)` coverage still drives the monthly source poll.

### DRY
The download + row-building transform now lives in `pipelines/datasets/us_bea/utils.py`; the onboarding bootstrap (`models/us_bea/code/clean.py`, `bea.py`) imports from it — the pipeline and bootstrap share the same function objects, so they cannot diverge. The bootstrap keeps only its typed-parquet writer + resume logic.

### Files
- `pipelines/datasets/us_bea/{__init__,constants,utils,tasks,flows}.py` — `us_bea_flow` at module level.

### Local verification
- Imports resolve (`us_bea_flow`); `deploy_flows.load_flows_from_file(...)` → `['us_bea_flow']`.
- Transform parity via the shared code path: `regional_metro` 39,474 rows exact, all-STRING schema.
- ruff clean.

### Deploy checklist (post-label)
- [x] `deploy-flow` label → `cd-prefect3 (staging)` logs `registrado`
- [ ] dev-pool run with prod off: `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}` → `dbt run OK` + `dbt test OK` per table in logs
- [ ] `BEA_API_KEY` provisioned in Vault
- [ ] merge → arm via Django admin (`/admin/admin_data_tools/disabledflowschedule/` → `us_bea` → `is_schedule_active`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
