### PR TITLE
fix(us_fed_fred): run all tables before testing (cross-table FK)

### DIFF
--- a/pipelines/datasets/us_fed_fred/flows.py
+++ b/pipelines/datasets/us_fed_fred/flows.py
@@ -128,7 +128,11 @@ def us_fed_fred_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload staging + materialize/test.
+        # Dev: upload + run ALL tables first, THEN test. The observation<->series
+        # relationships test runs during each table's test phase and needs BOTH
+        # tables present. Since the overwrite upload deletes each table before its
+        # run, a per-table run/test would test one table while the other is still
+        # absent — so run and test are split into separate passes.
         for table in tables:
             upload_to_gcs(
                 data_path=result[table],
@@ -141,14 +145,21 @@ def us_fed_fred_flow(
             run_dbt(
                 dataset_id=DATASET_ID,
                 table_id=table,
-                dbt_command="run/test",
+                dbt_command="run",
+                target="dev",
+            )
+        for table in tables:
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="test",
                 target="dev",
             )
 
         if not materialize_to_prod:
             return
 
-        # Prod: upload staging + materialize/test.
+        # Prod: upload + run ALL tables first, THEN test (see the dev-phase note).
         for table in tables:
             upload_to_gcs(
                 data_path=result[table],
@@ -161,7 +172,14 @@ def us_fed_fred_flow(
             run_dbt(
                 dataset_id=DATASET_ID,
                 table_id=table,
-                dbt_command="run/test",
+                dbt_command="run",
+                target="prod",
+            )
+        for table in tables:
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="test",
                 target="prod",
             )
 


### PR DESCRIPTION
## Problem

Prod runs of the `us_fed_fred` daily pipeline kept failing at a `dbt test`:

```
Database Error in test relationships ... observation.series_id -> series
Not found: Table basedosdados:us_fed_fred.<other table> was not found in location US
```

The failing side flipped depending on table order (observation-first failed on `series`; series-first failed on `observation`), which pointed at the real mechanism rather than ordering.

## Root cause

The `observation.series_id -> series` relationships test is attached to **both** models, so dbt runs it during **both** `observation`'s and `series`'s `dbt test` phase. `_upload_to_gcs` in `overwrite` mode calls `tb.delete(mode="all")`, which on the worker deletes the **prod** table before its own `dbt run` rebuilds it. With per-table `run/test`, whichever table is tested first finds the other one deleted-and-not-yet-rebuilt → the relationship test errors. No table order can satisfy a cross-table test while the tables are rebuilt one at a time.

## Fix

Split each phase (dev and prod) into a **run pass** over all tables, then a **test pass** — so both tables are present before any relationship test runs. (The earlier `["series","observation"]` reorder from #1823 is retained; it's harmless and good practice, but this is the actual fix.)

Verified: ruff, pyrefly, and deploy-discovery (`us_fed_fred_flow`) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)