### PR TITLE
fix(au_ato_abr): drop stray dicionario data.csv from staging output

### DIFF
--- a/pipelines/datasets/au_ato_abr/utils.py
+++ b/pipelines/datasets/au_ato_abr/utils.py
@@ -16,7 +16,6 @@ stay NULL rather than becoming the literal ``"nan"``).
 
 from __future__ import annotations
 
-import csv
 import logging
 import zipfile
 from datetime import date
@@ -447,13 +446,9 @@ def _write_dicionario(
             for i, c in enumerate(cols)
         }
     )
+    # Only parquet: upload_to_gcs uploads the whole dicionario/ dir into a
+    # PARQUET-format external table, so a stray data.csv breaks the staging read.
     pq.write_table(table, d / "data.parquet", compression="snappy")
-
-    # also a CSV alongside, handy for inspection / diffing
-    with open(d / "data.csv", "w", newline="", encoding="utf-8") as fh:
-        w = csv.writer(fh)
-        w.writerow(cols)
-        w.writerows(rows)
     return d
 
 


### PR DESCRIPTION
## What
`_write_dicionario` in `pipelines/datasets/au_ato_abr/utils.py` wrote **both** `data.parquet` and a `data.csv` ("handy for inspection / diffing") into the `dicionario/` output directory.

`upload_to_gcs` uploads the whole directory into a **PARQUET-format** external table, so the stray `data.csv` breaks the staging read on every pipeline run:
```
Database Error in model au_ato_abr__dicionario
  Input file is not in Parquet format.
  File: gs://basedosdados-dev/staging/au_ato_abr/dicionario/data.csv
```
`dicionario` is unpartitioned, so the overwrite never clears the csv and the glob matches both files.

## Fix
Write only `data.parquet` (the pipeline consumes the parquet directly); drop the now-unused `import csv`. 2 insertions / 7 deletions.

## Verification
- `python -m py_compile` OK; no `csv` references remain.
- Blocked `au_ato_abr_flow` at the `dicionario` dev-dbt step on runs 3d3eff7e and 49041ab1; entity/other_name/dgr already pass. Last blocker before prod materialization + BD Pro coverage/RAP registration.
- Pipeline `.py` only, no dbt models; the prefect pod git-clones main at runtime, so merging makes the fix live without a redeploy.