### PR TITLE
docs(rules): run-all-then-test-all + all-STRING staging (onboard + pipeline)

### DIFF
--- a/.claude/rules/bigquery-conventions.md
+++ b/.claude/rules/bigquery-conventions.md
@@ -79,14 +79,21 @@ join basedosdados.<gcp_dataset_id>.<table_slug> on ...
   - Municipal: `output/<table_slug>/ano=<year>/sigla_uf=<uf>/data.parquet`
   - State: `output/<table_slug>/ano=<year>/sigla_uf=<uf>/data.parquet`
   - National: `output/<table_slug>/ano=<year>/data.parquet`
-- Always build an explicit `pa.Schema` to prevent INT64/FLOAT64 type mismatches across partitions.
-- **Exception — parquet uploaded by a Prefect pipeline via `upload_to_gcs`.** There the
-  staging table's schema is inferred from a header that `gcs.py::dump_header` stringifies,
-  so typed parquet is rejected (`has type DOUBLE which does not match the target cpp_type
-  STRING_PIECE`). Build the table with the architecture's real types as above, then **cast
-  to an all-string schema via arrow** (never `astype(str)` — it turns NULL into `"nan"`)
-  before writing. See "Staging parquet must be all-STRING" in `prefect-pipeline-conventions`.
-  This applies only to the pipeline path; the one-shot onboarding upload keeps typed parquet.
+- Build an explicit `pa.Schema` for a stable column order across partitions, but make
+  **every column STRING**. Staging is all-STRING by house convention, and the dbt model
+  `safe_cast`s each column to its architecture type — so the staging schema carries order,
+  not types.
+- **Both upload paths must write all-STRING** — the one-shot onboarding upload *and* the
+  Prefect-pipeline `upload_to_gcs` path. They share one staging dataset, so a typed onboarding
+  external table left behind collides with the pipeline's later all-STRING overwrite: dbt then
+  reads a stale typed table against string files (`has type BYTE_ARRAY which does not match the
+  target cpp_type INT32`) or `safe_cast`s a still-typed column (`Invalid cast from INT64 to
+  DATE`). Keeping both all-STRING removes the divergence. (`gcs.py::dump_header` also stringifies
+  the pipeline's staging header, so typed parquet is rejected there regardless.)
+- **Cast to string via arrow, never `astype(str)`** (which renders NULL as the literal `"nan"`,
+  which `safe_cast` will not turn back into NULL); pass the architecture's real types through
+  first so `year` serializes as `"1959"`, not `"1959.0"`. See "Staging parquet must be
+  all-STRING" in `prefect-pipeline-conventions.md`.
 
 ## Upload prerequisites
 

--- a/.claude/rules/prefect-pipeline-conventions.md
+++ b/.claude/rules/prefect-pipeline-conventions.md
@@ -58,13 +58,17 @@ download → clean                      # your @task wrappers over utils
 max_date = <latest period in source>  # e.g. "YYYY-MM"
 has_new = poll_source_for_update_task(dataset_id, table_id, max_date, env="prod", date_format)
 if not has_new and not force_run: return
-for table in tables:                  # dev first
+for table in tables:                  # dev: upload + RUN every table first
     upload_to_gcs(data_path, dataset_id, table, bucket_name="basedosdados-dev", dump_mode, source_format)
-    run_dbt(dataset_id, table, dbt_command="run/test", target="dev")
+    run_dbt(dataset_id, table, dbt_command="run", target="dev")
+for table in tables:                  # THEN test — every sibling now exists
+    run_dbt(dataset_id, table, dbt_command="test", target="dev")
 if not materialize_to_prod: return
-for table in tables:                  # then prod
+for table in tables:                  # prod: upload + RUN every table first
     upload_to_gcs(..., bucket_name="basedosdados", ...)
-    run_dbt(..., target="prod")
+    run_dbt(..., dbt_command="run", target="prod")
+for table in tables:                  # THEN test
+    run_dbt(..., dbt_command="test", target="prod")
 if update_metadata:
     register_table_materialization_task(dataset_id, table, coverage=<CoverageSpec>, env="prod", bq_project="basedosdados")
     commit_source_update_task(dataset_id, table, max_date, env="prod", date_format)  # ONLY at the very end
@@ -74,6 +78,18 @@ if update_metadata:
 newer than the registered `Update.latest`; `commit_source_update_task` writes the
 new `Update.latest` and must run **last**, only after prod succeeded. The poll
 guard makes a scheduled run a no-op until the source actually publishes.
+
+**Run every table, then test every table — never interleave `run`/`test` per
+table.** Use `dbt_command="run"` in the first loop and `dbt_command="test"` in a
+second loop, per environment (do **not** use the combined `"run/test"` inside a
+per-table loop). Cross-table tests — `relationships`, `dbt_utils` referential
+checks, `custom_dictionary_coverage` with `ref('..._dicionario')` — read *sibling*
+models. Interleaved, the first table's test runs before its referenced sibling is
+built and fails: `Not found: Table ... au_ato_abr.dicionario`. This is silent in a
+re-run where a stale sibling from an earlier build survives (dev), and only bites
+in a clean environment (a freshly-emptied prod) — so it must be structural, not
+left to luck. `us_fed_fred` hit the same class of bug on its `observation`↔`series`
+FK test. → `project_au_ato_abr`
 
 ## Shared building blocks (`pipelines/utils`)
 
@@ -112,8 +128,17 @@ schema. Two details are load-bearing:
 
 This costs nothing downstream: staging is all-STRING by house convention anyway and the
 dbt model `safe_cast`s every column. `us_bls_cpi/utils.py::write_partitioned` is the
-reference. Note `bigquery-conventions.md` tells you to pin an explicit `pa.Schema` —
-correct for the one-shot onboarding upload, wrong here. → `project_dump_header_parquet_bug`
+reference.
+
+**Write all-STRING staging for the one-shot onboarding upload too, not only the pipeline.**
+Both paths share one staging dataset, so their external-table schemas must match. A dataset
+onboarded with *typed* parquet gets a *typed* external table; add a pipeline later and its
+all-STRING overwrite leaves dbt reading the stale typed table against string files
+(`Parquet column ... has type BYTE_ARRAY which does not match the target cpp_type INT32`), or
+`safe_cast`ing a still-typed column (`Invalid cast from INT64 to DATE`). Keeping both paths
+all-STRING removes the divergence — so `bigquery-conventions.md` no longer pins a *typed*
+`pa.Schema` for onboarding; it pins an all-STRING one with stable column order.
+→ `project_au_ato_abr`, `project_dump_header_parquet_bug`
 
 ### One raw data source per table (current limitation)
 


### PR DESCRIPTION
## What

Two onboarding-process fixes learned the hard way from the `au_ato_abr` pipeline, encoded into the agent rules so every future dataset gets them right.

### 1. Run every table, then test every table (never interleave `run`/`test` per table)

The canonical recipe in `prefect-pipeline-conventions.md` looped `run_dbt(..., "run/test")` per table. Cross-table tests — `relationships`, `dbt_utils` referential checks, `custom_dictionary_coverage` with `ref('..._dicionario')` — read **sibling** models. Interleaved, the first table's test runs before its referenced sibling is built:

```
Not found: Table basedosdados.au_ato_abr.dicionario
```

This stays **silent** in a re-run where a stale sibling survives (dev), and only bites in a **clean** environment (a freshly-emptied prod) — so it must be structural. `us_fed_fred` hit the same class on its `observation`↔`series` FK test. Recipe now splits into a **run loop** then a **test loop**, per environment.

### 2. Write all-STRING staging for the one-shot onboarding upload too, not only the pipeline

The rules said staging is all-STRING for pipelines but *"the one-shot onboarding upload keeps typed parquet."* That divergence is the bug: onboard + pipeline share one staging dataset, so a **typed** onboarding external table collides with the pipeline's later **all-STRING** overwrite —

```
Parquet column ... has type BYTE_ARRAY which does not match the target cpp_type INT32   # read
Invalid cast from INT64 to DATE                                                          # safe_cast
```

Both had to be hand-fixed table-by-table during the au_ato_abr refresh. Keeping **both** paths all-STRING removes the divergence. `bigquery-conventions.md` no longer pins a *typed* `pa.Schema` for onboarding — it pins an all-STRING one with stable column order; the dbt model `safe_cast`s types.

## Scope

Docs/rules only — `.claude/rules/{prefect-pipeline-conventions,bigquery-conventions}.md`. No code changes. These guide the onboarding agents; the shared-code fixes (e.g. the `tb.delete(mode=all)` prod-delete / stacking behaviour) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)