### PR TITLE
fix(us_bea): quarter-level coverage for gdp_by_industry and regional_state

### DIFF
--- a/pipelines/datasets/us_bea/flows.py
+++ b/pipelines/datasets/us_bea/flows.py
@@ -29,6 +29,7 @@ from pipelines.utils.metadata.domain import (
     DateFormat,
     YearMonth,
     YearOnly,
+    YearQuarter,
 )
 from pipelines.utils.metadata.tasks import (
     commit_source_update_task,
@@ -57,11 +58,17 @@ _COVERAGE = {
         date_column=YearMonth(year="year", month="month"),
         date_format=DateFormat.YEAR_MONTH,
     ),
+    # gdp_by_industry and regional_state mix annual + quarterly rows (no monthly);
+    # the finest grain present is quarterly, so their coverage is quarter-level
+    # (YearQuarter → YEAR_MONTH, quarter mapped to month = quarter*3). County and
+    # metro are genuinely annual and stay year-level.
     "gdp_by_industry": AllFree(
-        date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
+        date_column=YearQuarter(year="year", quarter="quarter"),
+        date_format=DateFormat.YEAR_MONTH,
     ),
     "regional_state": AllFree(
-        date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
+        date_column=YearQuarter(year="year", quarter="quarter"),
+        date_format=DateFormat.YEAR_MONTH,
     ),
     "regional_county": AllFree(
         date_column=YearOnly(col="year"), date_format=DateFormat.YEAR


### PR DESCRIPTION
## Fix: quarter-level coverage for `us_bea` `gdp_by_industry` and `regional_state`

Follow-up to the `us_bea` recurring pipeline (#1825). Corrects the temporal coverage granularity on two tables.

### Problem
Prod coverage showed only `nipa` at month level; every other table at year level. But `gdp_by_industry` and `regional_state` both carry **quarterly** rows (no monthly), so year-only understated them — per the house rule "year-only is correct only for genuinely annual tables."

| Table | Finest grain in data | Was | Now |
|---|---|---|---|
| nipa | monthly (247,343 rows) | month | month ✅ |
| gdp_by_industry | **quarterly** (176,178 rows) | year | **quarter** |
| regional_state | **quarterly** (3,113,570 rows) | year | **quarter** |
| regional_county | annual (no quarter/month col) | year | year ✅ |
| regional_metro | annual (no quarter/month col) | year | year ✅ |

### Change
`_COVERAGE` for `gdp_by_industry` and `regional_state`: `YearOnly`/`YEAR` → `YearQuarter(year="year", quarter="quarter")`/`YEAR_MONTH`. `register_table_materialization` maps quarter → month via `DATE(year, quarter*3, 1)` (Q1→3 … Q4→12), so it writes a quarter-level `endMonth`. All six tables remain `AllFree`.

### Prod metadata already corrected
The live prod `DateTimeRange`s were updated directly to match (no drift with the next run):
- `gdp_by_industry`: 1997 → 2026-03 (Q1)
- `regional_state`: 1929 → 2026-03 (Q1)

Verified via prod GraphQL (`endMonth=3`; `nipa` `endMonth=6`). This code change keeps future `register_table_materialization` runs from reverting them to annual.

### Verification
- ruff check/format clean.
- Import + config check: both entries now `YearQuarter`/`%Y-%m`.
- No data-transform changes; no `deploy-flow` label needed. On merge the prod deploy re-registers the flow with the corrected coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added year-and-quarter metadata to relevant economic datasets.
  * Increased GDP by industry and regional state data coverage from annual to quarterly periods.
  * Quarterly dates are now displayed in year-month format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->