### PR TITLE
fix(us_cfpb_hmda): scope not-null-proportion tests to newest year

### DIFF
--- a/macros/custom_get_where_subquery.sql
+++ b/macros/custom_get_where_subquery.sql
@@ -51,6 +51,26 @@
             {% endif %}
         {% endif %}
 
+        {# This block looks for __most_recent_year_en__ placeholder #}
+        {# English-language datasets partition on `year` (INT64), not `ano`. #}
+        {% if "__most_recent_year_en__" in where %}
+            {% set max_year_query = (
+                "select max(cast(year as int64)) as max_year from " ~ relation
+            ) %}
+            {% set max_year_result = run_query(max_year_query) %}
+            {% if execute and max_year_result.rows[0][0] %}
+                {% set max_year = max_year_result.rows[0][0] %}
+                {% set where = where | replace(
+                    "__most_recent_year_en__", "year = " ~ max_year
+                ) %}
+                {% do log(
+                    "The test will filter by the most recent year: "
+                    ~ max_year,
+                    info=True,
+                ) %}
+            {% endif %}
+        {% endif %}
+
         {# This block looks for __most_recent_date__  placeholder #}
         {% if "__most_recent_date__" in where %}
             {% set max_date_query = "select max(data) as max_date from " ~ relation %}

--- a/models/us_cfpb_hmda/code/gen_dbt.py
+++ b/models/us_cfpb_hmda/code/gen_dbt.py
@@ -135,6 +135,12 @@ def gen_schema() -> None:
         parts.append("    tests:")
         parts.append("      - not_null_proportion_multiple_columns:")
         parts.append("          at_least: 0.05")
+        # Scope the full-table scan to the newest year (partition-pruned) so the
+        # annual pipeline's dbt test stays well under the BigQuery daily query
+        # quota; `year` is the English-dataset partition column (see the
+        # __most_recent_year_en__ branch in macros/custom_get_where_subquery.sql).
+        parts.append("          config:")
+        parts.append("            where: __most_recent_year_en__")
         if ignore:
             parts.append("          ignore_values:")
             parts += [f"            - {c}" for c in ignore]

--- a/models/us_cfpb_hmda/schema.yml
+++ b/models/us_cfpb_hmda/schema.yml
@@ -9,6 +9,8 @@ models:
     tests:
       - not_null_proportion_multiple_columns:
           at_least: 0.05
+          config:
+            where: __most_recent_year_en__
           ignore_values:
             - total_points_and_fees
             - prepayment_penalty_term
@@ -361,6 +363,8 @@ models:
     tests:
       - not_null_proportion_multiple_columns:
           at_least: 0.05
+          config:
+            where: __most_recent_year_en__
           ignore_values:
             - rate_spread
             - applicant_race_2


### PR DESCRIPTION
## Problem

The `us_cfpb_hmda` annual pipeline's first prod run failed at **dev `dbt test`** — not a data-quality failure, a BigQuery quota:

> `Custom quota exceeded: QueryUsagePerUserPerDay` (set by your administrator)

`not_null_proportion_multiple_columns` scans **every column across the full table** each run — `loan_application_register` is ~124M rows, `loan_application_register_legacy` ~187M. Combined with a full 8-year rebuild and every other pipeline sharing the worker SA's daily query budget, the test is heavy enough to trip the daily cap. The build, dev upload, and `dbt run` all succeeded; only the test step failed, so prod was never reached.

## Fix

Scope the heavy test to the **newest year only**, following the repo's existing precedent for non-`ano` partition columns (`__most_recent_year_month_sicor__` for `ano_emissao`, `__most_recent_date_cno__` for `data_extracao`):

- **`macros/custom_get_where_subquery.sql`** — add a `__most_recent_year_en__` placeholder that mirrors `__most_recent_year__` but targets the English-dataset partition column `year` (INT64, unquoted comparison).
- **`models/us_cfpb_hmda/schema.yml`** — apply `config: where: __most_recent_year_en__` to the `not_null_proportion_multiple_columns` test on both LAR tables.
- **`models/us_cfpb_hmda/code/gen_dbt.py`** — emit the same config so a schema regeneration doesn't drift.

Filtering on the partition column **prunes to a single partition**, so the test scans the latest year (~16M rows) instead of all 124M/187M. The custom test `tests-dbt/generic/not_null_proportion_multiple_columns.sql` is already built to accept a `where`-scoped subquery (its docstring references `__most_recent_year__`), so no test-macro change is needed.

## Verification

- `dbt parse` passes (no errors on the macro or `us_cfpb_hmda` schema).
- `ruff`, `sqlfmt`, `yamlfix` clean.
- New placeholder is additive — no effect on any dataset that doesn't reference it.

## After merge

The deployed worker runs `main`, so the scoped tests take effect on the next run. Re-trigger the `us_cfpb_hmda` prod deployment (ideally after the daily quota resets at midnight Pacific) to promote 2025 to prod and roll coverage forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
