### PR TITLE
[Fix] br_denatran_frota

### DIFF
--- a/pipelines/datasets/br_denatran_frota/constants.py
+++ b/pipelines/datasets/br_denatran_frota/constants.py
@@ -3,7 +3,6 @@ Constant values for the datasets projects
 """
 
 from enum import Enum
-from pathlib import Path
 
 
 class constants(Enum):
@@ -11,8 +10,8 @@ class constants(Enum):
     Constant values for the br_denatran_frota project
     """
 
-    BASE_URL_PRE_2012 = "https://www.gov.br/infraestrutura/pt-br/assuntos/transito/arquivos-senatran/estatisticas/renavam"
-    BASE_URL_POST_2012 = "https://www.gov.br/infraestrutura/pt-br/assuntos/transito/conteudo-Senatran"
+    BASE_URL_PRE_2012 = "https://www.gov.br/transportes/pt-br/assuntos/transito/arquivos-senatran/estatisticas/renavam"
+    BASE_URL_POST_2012 = "https://www.gov.br/transportes/pt-br/assuntos/transito/conteudo-Senatran"
     MONTHS = {
         "janeiro": 1,
         "fevereiro": 2,
@@ -33,9 +32,18 @@ class constants(Enum):
 
     DATASET = "br_denatran_frota"
     HEADERS = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36"
+        "sec-ch-ua": '"Not=A?Brand";v="99", "Google Chrome";v="151", "Chromium";v="151"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"Windows"',
+        "Upgrade-Insecure-Requests": "1",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+        "Sec-Fetch-Site": "same-origin",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-User": "?1",
+        "Sec-Fetch-Dest": "document",
+        "host": "www.gov.br",
     }
-
     DICT_UFS = {
         "AC": "Acre",
         "AL": "Alagoas",
@@ -85,17 +93,6 @@ class constants(Enum):
         ("SC", "barra do sul"): "balneario barra do sul",
         ("SP", "ibitiuva"): "pitangueiras",
     }
-
-    ## Paths
-    DOWNLOAD_PATH = Path(f"tmp/input/{DATASET}")
-    OUTPUT_PATH = Path(f"tmp/output/{DATASET}")
-    DOWNLOAD_PATH.mkdir(exist_ok=True, parents=True)
-    OUTPUT_PATH.mkdir(exist_ok=True, parents=True)
-
-    DOWNLOAD_FILES_PATH = Path(DOWNLOAD_PATH / "files")
-    OUTPUT_FILES_PATH = Path(OUTPUT_PATH / "files")
-    DOWNLOAD_FILES_PATH.mkdir(exist_ok=True, parents=True)
-    DOWNLOAD_FILES_PATH.mkdir(exist_ok=True, parents=True)
 
     UF_TIPO_BASIC_FILENAME = "frota_por_uf_e_tipo_de_veiculo"
     MUNIC_TIPO_BASIC_FILENAME = "frota_por_municipio_e_tipo"

--- a/pipelines/datasets/br_denatran_frota/flows.py
+++ b/pipelines/datasets/br_denatran_frota/flows.py
@@ -4,10 +4,11 @@ Flows para br_denatran_frota — Prefect 3.
 
 from prefect import flow
 
-from pipelines.crawler.denatran_frota.constants import (
+from pipelines.datasets.br_denatran_frota.constants import (
     constants as denatran_constants,
 )
-from pipelines.crawler.denatran_frota.tasks import (
+from pipelines.datasets.br_denatran_frota.tasks import (
+    build_paths,
     crawl_task,
     get_desired_file_task,
     get_latest_date_task,
@@ -48,12 +49,16 @@ def _run_denatran(
         prefix="Dump: ", dataset_id=dataset_id, table_id=table_id
     )
 
+    input_dir, output_dir = build_paths()
+
     (
         source_available_dates,
         _source_available_dates_str,
         _source_first_available_date,
         source_first_available_date_str,
-    ) = get_latest_date_task(table_id=table_id, dataset_id=dataset_id)
+    ) = get_latest_date_task(
+        table_id=table_id, dataset_id=dataset_id, input_dir=input_dir
+    )
 
     print(f"First available date: {source_first_available_date_str}")
 
@@ -89,16 +94,18 @@ def _run_denatran(
         crawl_task(
             source_max_date=source_max_date,
             table_id=table_id,
-            temp_dir=denatran_constants.DOWNLOAD_PATH.value,
+            temp_dir=input_dir,
         )
         # pyrefly: ignore [no-matching-overload]
         desired_file = get_desired_file_task(
             source_max_date=source_max_date,
-            download_directory=denatran_constants.DOWNLOAD_PATH.value,
+            download_directory=input_dir,
             table_id=table_id,
             filetype=filetype,
         )
-        parquet_outputs.append(treat_task(file=desired_file))
+        parquet_outputs.append(
+            treat_task(file=desired_file, output_dir=output_dir)
+        )
 
     filepath = parquet_outputs[0]
 
@@ -108,6 +115,7 @@ def _run_denatran(
         table_id=table_id,
         bucket_name="basedosdados-dev",
         dump_mode="append",
+        source_format="parquet",
     )
 
     run_dbt(
@@ -127,6 +135,7 @@ def _run_denatran(
         table_id=table_id,
         bucket_name="basedosdados",
         dump_mode="append",
+        source_format="parquet",
     )
 
     run_dbt(

--- a/pipelines/datasets/br_denatran_frota/tasks.py
+++ b/pipelines/datasets/br_denatran_frota/tasks.py
@@ -11,10 +11,10 @@ from dateutil.relativedelta import relativedelta
 from prefect import task
 from string_utils import asciify
 
-from pipelines.crawler.denatran_frota.constants import (
+from pipelines.datasets.br_denatran_frota.constants import (
     constants as denatran_constants,
 )
-from pipelines.crawler.denatran_frota.utils import (
+from pipelines.datasets.br_denatran_frota.utils import (
     DenatranType,
     call_downloader,
     change_df_header,
@@ -34,11 +34,20 @@ from pipelines.utils.utils import log
 
 
 @task
+def build_paths() -> tuple[Path, Path]:
+    input_dir = Path("tmp/br_denatran_frota/input")
+    output_dir = Path("tmp/br_denatran_frota/output")
+    input_dir.mkdir(exist_ok=True, parents=True)
+    output_dir.mkdir(exist_ok=True, parents=True)
+    return input_dir, output_dir
+
+
+@task
 def crawl_task(
     # pyrefly: ignore [not-a-type]
     source_max_date: datetime,
     table_id: str,
-    temp_dir: str | Path = denatran_constants.DOWNLOAD_PATH.value,
+    temp_dir: str | Path,
 ) -> bool:
     """
     Main task to extract data from *frota por município e tipo* and *frota por UF e tipo*.
@@ -143,7 +152,7 @@ def get_desired_file_task(
 
 
 @task
-def treat_uf_tipo_task(file) -> pl.DataFrame:
+def treat_uf_tipo_task(file: str, output_dir: str | Path) -> pl.DataFrame:
     """Task to treat data from  frota por UF e tipo.
 
 
@@ -216,14 +225,18 @@ def treat_uf_tipo_task(file) -> pl.DataFrame:
     )  # Long format.
 
     log("-------- Data Wrangling finished")
-    output_path = output_file_to_parquet(clean_pl_df, table_id="uf_tipo")
+    output_path = output_file_to_parquet(
+        clean_pl_df, table_id="uf_tipo", output_dir=output_dir
+    )
     log(f"-------- Data Saved: {output_path}")
     # pyrefly: ignore [bad-return]
     return output_path
 
 
 @task
-def treat_municipio_tipo_task(file: str) -> pl.DataFrame:
+def treat_municipio_tipo_task(
+    file: str, output_dir: str | Path
+) -> pl.DataFrame:
     """Task to treat data from  frota por UF e tipo.
 
 
@@ -300,7 +313,9 @@ def treat_municipio_tipo_task(file: str) -> pl.DataFrame:
 
     log("-------- Data Wrangling finished")
 
-    output_path = output_file_to_parquet(full_pl_df, table_id="municipio_tipo")
+    output_path = output_file_to_parquet(
+        full_pl_df, table_id="municipio_tipo", output_dir=output_dir
+    )
     log(f"-------- Data Saved: {output_path}")
     # pyrefly: ignore [bad-return]
     return output_path
@@ -308,7 +323,7 @@ def treat_municipio_tipo_task(file: str) -> pl.DataFrame:
 
 @task
 def get_latest_date_task(
-    table_id: str, dataset_id: str
+    table_id: str, dataset_id: str, input_dir: str | Path
 ) -> tuple[list, list, int | None, str | None]:
     """Task to extract the latest data from available on the data source
     Args:
@@ -338,9 +353,8 @@ def get_latest_date_task(
     # pyrefly: ignore [unnecessary-type-conversion]
     while datetime.date(int(year), int(month), 1) <= today:
         if year > 2012:
-            files_dir = os.path.join(
-                str(denatran_constants.DOWNLOAD_PATH.value), "files"
-            )
+            files_dir = Path(input_dir) / "files"
+            files_dir.mkdir(exist_ok=True, parents=True)
             # pyrefly: ignore [unnecessary-type-conversion]
             year_dir_name = os.path.join(str(files_dir), f"{year}")
             try:

--- a/pipelines/datasets/br_denatran_frota/utils.py
+++ b/pipelines/datasets/br_denatran_frota/utils.py
@@ -19,7 +19,7 @@ from dateutil import relativedelta
 from rarfile import RarFile
 from string_utils import asciify
 
-from pipelines.crawler.denatran_frota.constants import (
+from pipelines.datasets.br_denatran_frota.constants import (
     constants as denatran_constants,
 )
 from pipelines.utils.utils import log, to_partitions
@@ -732,7 +732,7 @@ def treat_uf(
 def output_file_to_parquet(
     df: pl.DataFrame,
     table_id: str,
-    output_path: str | Path = denatran_constants.OUTPUT_PATH.value,
+    output_dir: str | Path,
 ) -> Path:
     """Task to save .parquet uf_tipo and municipio_tipo files
 
@@ -745,14 +745,16 @@ def output_file_to_parquet(
 
     pd_df = df.to_pandas()
     pd_df = pd_df.astype(str)
+    savepath = Path(output_dir) / table_id
+
     to_partitions(
         pd_df,
         partition_columns=["ano", "mes"],
-        savepath=os.path.join(output_path, table_id),
+        savepath=savepath.as_posix(),
         file_type="parquet",
     )
     # pyrefly: ignore [bad-return]
-    return os.path.join(output_path, table_id)
+    return savepath
 
 
 # pyrefly: ignore [bad-return]


### PR DESCRIPTION
## Descrição do PR:

Corrige a pipeline recorrente de `br_denatran_frota`, que estava com a URL base do Senatran desatualizada, o `source_format` incorreto no upload para o GCS, e migra o módulo da estrutura antiga de crawler (`pipelines/crawler/denatran_frota`) para a estrutura padrão de datasets (`pipelines/datasets/br_denatran_frota`), alinhada com o restante das pipelines Prefect 3.

- **Motivação/Contexto:** A URL base do governo (`gov.br/infraestrutura/...`) mudou para `gov.br/transportes/...`, quebrando o crawler. Além disso, o upload para o GCS estava passando `source_format` incorreto (o pipeline gera Parquet, mas o parâmetro não refletia isso), e o módulo ainda vivia em `pipelines/crawler/`, fora do padrão atual (`pipelines/datasets/<dataset_id>/`).

## Detalhes Técnicos:

- **Principais alterações na pipeline/scripts:**
  - Migração de `pipelines/crawler/denatran_frota/` para `pipelines/datasets/br_denatran_frota/`.
  - Nova task `build_paths` (em `tasks.py`) centraliza a criação dos diretórios temporários de input/output, substituindo a lógica que antes vivia em `constants.py`.
  - Correção das URLs base: `BASE_URL_PRE_2012` e `BASE_URL_POST_2012` atualizadas de `gov.br/infraestrutura/...` para `gov.br/transportes/...` (novo domínio do Senatran).
  - Ajuste do `HEADER` usado nas requests HTTP.
  - `upload_to_gcs` agora recebe `source_format="parquet"` explicitamente (dev e prod), corrigindo um mismatch em que o dado gerado é Parquet mas o parâmetro de upload não refletia isso.
  
- **Mudanças nos dados e no schema:** Nenhuma mudança de schema; apenas correção do formato de origem declarado no upload.
- **Impacto no desempenho:** Nenhum impacto relevante — mudanças são estruturais/de configuração, não afetam volume ou lógica de transformação dos dados.

Se alguma parte do código precisar de atenção extra, comentar diretamente na linha para os revisores (ex.: a task `build_paths` e o uso de `tmp/br_denatran_frota/` como diretório temporário fixo).

## Teste e Validações:

- [x] Testado localmente
- [x] Testado na Cloud

**Caso haja algo relacionado aos testes que vale a pena informar:** Recomenda-se rodar a flow no pool de dev (`materialize_to_prod=False, update_metadata=False, force_run=True`) para validar a URL corrigida e o upload em Parquet antes de promover para produção.

## Riscos e Mitigações:
- **Riscos conhecidos:** Se a URL do Senatran mudar novamente, o crawler volta a quebrar. 
- **Planos de rollback:** Reverter para o commit anterior à migração (`4b71e366`) restaura o módulo em `pipelines/crawler/denatran_frota` e o `source_format` antigo.

## Dependencias:
- [ ] Nenhuma dependência adicional

## Revisadores:
- Ao ficar pronto para revisão, remover o **Draft**, marcar os revisadores (**basedosdados/dados**) e avisar no Discord, aba **Correções de PRs, arquiteturas e afins**, marcando **@equipe_dados**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated government data source URLs to maintain reliable access to current datasets.
  * Improved compatibility with the source service through updated browser-style request headers.
  * Standardized temporary input and output directory handling for more reliable downloads and processing.
  * Ensured generated Parquet files are correctly identified during cloud uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->