### PR TITLE
feat(br_bcb_ifdata): onboard IF.data (BCB) + pipeline trimestral

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -79,6 +79,9 @@ models:
     br_bcb_estban:
       +materialized: table
       +schema: br_bcb_estban
+    br_bcb_ifdata:
+      +materialized: table
+      +schema: br_bcb_ifdata
     br_bcb_sicor:
       +materialized: table
       +schema: br_bcb_sicor

--- a/models/br_bcb_ifdata/br_bcb_ifdata__coluna.sql
+++ b/models/br_bcb_ifdata/br_bcb_ifdata__coluna.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        alias="coluna",
+        schema="br_bcb_ifdata",
+        materialized="table",
+        partition_by={
+            "field": "ano",
+            "data_type": "int64",
+            "range": {"start": 2000, "end": 2031, "interval": 1},
+        },
+        cluster_by=["mes", "id_relatorio"],
+    )
+}}
+select
+    safe_cast(ano as int64) ano,
+    safe_cast(mes as int64) mes,
+    safe_cast(id_relatorio as string) id_relatorio,
+    safe_cast(id_coluna as string) id_coluna,
+    safe_cast(tipo_consolidado as string) tipo_consolidado,
+    safe_cast(nome_relatorio as string) nome_relatorio,
+    safe_cast(nome_grupo as string) nome_grupo,
+    safe_cast(nome_coluna as string) nome_coluna,
+    safe_cast(nome_coluna_ingles as string) nome_coluna_ingles,
+    safe_cast(ordem_coluna as int64) ordem_coluna
+from {{ set_datalake_project("br_bcb_ifdata_staging.coluna") }} as t

--- a/models/br_bcb_ifdata/br_bcb_ifdata__dicionario.sql
+++ b/models/br_bcb_ifdata/br_bcb_ifdata__dicionario.sql
@@ -1,0 +1,14 @@
+{{
+    config(
+        alias="dicionario",
+        schema="br_bcb_ifdata",
+        materialized="table",
+    )
+}}
+select
+    safe_cast(id_tabela as string) id_tabela,
+    safe_cast(nome_coluna as string) nome_coluna,
+    safe_cast(chave as string) chave,
+    safe_cast(cobertura_temporal as string) cobertura_temporal,
+    safe_cast(valor as string) valor
+from {{ set_datalake_project("br_bcb_ifdata_staging.dicionario") }} as t

--- a/models/br_bcb_ifdata/br_bcb_ifdata__instituicao.sql
+++ b/models/br_bcb_ifdata/br_bcb_ifdata__instituicao.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        alias="instituicao",
+        schema="br_bcb_ifdata",
+        materialized="table",
+        partition_by={
+            "field": "ano",
+            "data_type": "int64",
+            "range": {"start": 2000, "end": 2031, "interval": 1},
+        },
+        cluster_by=["mes", "tipo_consolidado"],
+    )
+}}
+select
+    safe_cast(ano as int64) ano,
+    safe_cast(mes as int64) mes,
+    safe_cast(tipo_consolidado as string) tipo_consolidado,
+    safe_cast(id_instituicao as string) id_instituicao,
+    safe_cast(nome_instituicao as string) nome_instituicao,
+    safe_cast(tcb as string) tcb,
+    safe_cast(td as string) td,
+    safe_cast(tc as string) tc,
+    safe_cast(ti as string) ti,
+    safe_cast(sr as string) sr,
+    safe_cast(segmento as string) segmento,
+    safe_cast(id_municipio as string) id_municipio,
+    safe_cast(id_conglomerado_financeiro as string) id_conglomerado_financeiro,
+    safe_cast(id_conglomerado_prudencial as string) id_conglomerado_prudencial,
+    safe_cast(data_alteracao_segmento as date) data_alteracao_segmento
+from {{ set_datalake_project("br_bcb_ifdata_staging.instituicao") }} as t

--- a/models/br_bcb_ifdata/br_bcb_ifdata__relatorio.sql
+++ b/models/br_bcb_ifdata/br_bcb_ifdata__relatorio.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        alias="relatorio",
+        schema="br_bcb_ifdata",
+        materialized="table",
+        partition_by={
+            "field": "ano",
+            "data_type": "int64",
+            "range": {"start": 2000, "end": 2031, "interval": 1},
+        },
+        cluster_by=["mes", "id_instituicao", "id_coluna"],
+    )
+}}
+select
+    safe_cast(ano as int64) ano,
+    safe_cast(mes as int64) mes,
+    safe_cast(id_instituicao as string) id_instituicao,
+    safe_cast(id_coluna as string) id_coluna,
+    safe_cast(valor as float64) valor
+from {{ set_datalake_project("br_bcb_ifdata_staging.relatorio") }} as t

--- a/models/br_bcb_ifdata/code/architecture/coluna.csv
+++ b/models/br_bcb_ifdata/code/architecture/coluna.csv
@@ -1,0 +1,10 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+ano,INT64,Ano de referência,,no,br_bd_diretorios_data_tempo.ano:ano,,no,Partição,
+mes,INT64,Mês de referência do trimestre (3 março; 6 junho; 9 setembro; 12 dezembro),,no,br_bd_diretorios_data_tempo.mes:mes,,no,,
+id_relatorio,STRING,Código do relatório do IF.data,,yes,,,no,,id
+id_coluna,STRING,Código da coluna dentro do relatório,,no,,,no,,ifd
+tipo_consolidado,STRING,"Tipo de consolidado a que o relatório se aplica (1005 conglomerados financeiros e instituições independentes; 1006 instituições individuais; 1009 conglomerados prudenciais e instituições independentes)",,yes,,,no,Cada relatório se aplica a exatamente um tipo de consolidado,s
+nome_relatorio,STRING,Nome do relatório em português,,no,,,no,,n
+nome_coluna,STRING,Nome da coluna em português,,no,,,no,,n
+nome_coluna_ingles,STRING,Nome da coluna em inglês,,no,,,no,Publicado pela própria fonte,ni
+ordem_coluna,INT64,Posição da coluna no relatório publicado,,no,,,no,Preserva a ordem de exibição do IF.data,o

--- a/models/br_bcb_ifdata/code/architecture/coluna.csv
+++ b/models/br_bcb_ifdata/code/architecture/coluna.csv
@@ -2,9 +2,9 @@ name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory
 ano,INT64,Ano de referência,,no,br_bd_diretorios_data_tempo.ano:ano,,no,Partição,
 mes,INT64,Mês de referência do trimestre (3 março; 6 junho; 9 setembro; 12 dezembro),,no,br_bd_diretorios_data_tempo.mes:mes,,no,,
 id_relatorio,STRING,Código do relatório do IF.data,,yes,,,no,,id
-id_coluna,STRING,Código da coluna dentro do relatório,,no,,,no,,ifd
-tipo_consolidado,STRING,"Tipo de consolidado a que o relatório se aplica (1005 conglomerados financeiros e instituições independentes; 1006 instituições individuais; 1009 conglomerados prudenciais e instituições independentes)",,yes,,,no,Cada relatório se aplica a exatamente um tipo de consolidado,s
+id_coluna,STRING,Código da rubrica reportada,,no,,,no,Liga a relatorio,lid
+tipo_consolidado,STRING,Tipo de consolidado a que o relatório se aplica,,yes,,,no,Cada relatório se aplica a exatamente um tipo de consolidado; o conjunto de tipos muda ao longo da série,s
 nome_relatorio,STRING,Nome do relatório em português,,no,,,no,,n
-nome_coluna,STRING,Nome da coluna em português,,no,,,no,,n
-nome_coluna_ingles,STRING,Nome da coluna em inglês,,no,,,no,Publicado pela própria fonte,ni
-ordem_coluna,INT64,Posição da coluna no relatório publicado,,no,,,no,Preserva a ordem de exibição do IF.data,o
+nome_coluna,STRING,Nome da rubrica em português,,no,,,no,,n
+nome_coluna_ingles,STRING,Nome da rubrica em inglês,,no,,,no,Publicado pela própria fonte,ni
+ordem_coluna,INT64,Posição da rubrica no relatório publicado,,no,,,no,Preserva a ordem de exibição do IF.data,o

--- a/models/br_bcb_ifdata/code/architecture/coluna.csv
+++ b/models/br_bcb_ifdata/code/architecture/coluna.csv
@@ -1,7 +1,7 @@
 name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
 ano,INT64,Ano de referência,,no,br_bd_diretorios_data_tempo.ano:ano,,no,Partição,
 mes,INT64,Mês de referência do trimestre (3 março; 6 junho; 9 setembro; 12 dezembro),,no,br_bd_diretorios_data_tempo.mes:mes,,no,,
-id_relatorio,STRING,Código do relatório do IF.data,,yes,,,no,,id
+id_relatorio,STRING,Código do relatório do IF.data,,no,,,no,"Nulo quando a rubrica não é referenciada por nenhum relatório da competência; o nome está em nome_relatorio, por isso não há dicionário",id
 id_coluna,STRING,Código da rubrica reportada,,no,,,no,Liga a relatorio,lid
 tipo_consolidado,STRING,Tipo de consolidado a que o relatório se aplica,,yes,,,no,Cada relatório se aplica a exatamente um tipo de consolidado; o conjunto de tipos muda ao longo da série,s
 nome_relatorio,STRING,Nome do relatório em português,,no,,,no,,n

--- a/models/br_bcb_ifdata/code/architecture/dicionario.csv
+++ b/models/br_bcb_ifdata/code/architecture/dicionario.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_tabela,STRING,Nome da tabela,,no,,,no,,
+nome_coluna,STRING,Nome da coluna,,no,,,no,,
+chave,STRING,Chave (valor codificado da coluna),,no,,,no,,
+cobertura_temporal,STRING,Cobertura temporal da chave,,no,,,no,,
+valor,STRING,Valor (descrição da chave),,no,,,no,,

--- a/models/br_bcb_ifdata/code/architecture/instituicao.csv
+++ b/models/br_bcb_ifdata/code/architecture/instituicao.csv
@@ -9,7 +9,7 @@ td,STRING,Tipo de consolidação (TD),,yes,,,no,,c4
 tc,STRING,Tipo de controle (TC),,yes,,,no,Indica controle público federal estadual privado nacional ou estrangeiro,c6
 ti,STRING,Tipo de instituição (TI),,yes,,,no,,c13
 sr,STRING,Segmento definido pela Resolução nº 4.553/2017 (SR),,yes,,,no,Segmentação prudencial S1 a S5,c32
-segmento,STRING,Segmento de atuação da instituição,,yes,,,no,,c8
+segmento,STRING,Código de segmento de atuação da instituição,,no,,,no,O IF.data publica o código sem tabela de rótulos; 31 valores distintos observados,c8
 id_municipio,STRING,ID Município - IBGE 7 Dígitos da sede da instituição,,no,br_bd_diretorios_brasil.municipio:id_municipio,,no,Resolvido a partir do nome da cidade e da UF informados pelo IF.data; a fonte não publica o código IBGE,c11
 id_conglomerado_financeiro,STRING,Código do conglomerado financeiro ao qual a instituição pertence,,no,,,no,Vazio quando a instituição é independente,c14
 id_conglomerado_prudencial,STRING,Código do conglomerado prudencial ao qual a instituição pertence,,no,,,no,Vazio quando a instituição é independente,c15

--- a/models/br_bcb_ifdata/code/architecture/instituicao.csv
+++ b/models/br_bcb_ifdata/code/architecture/instituicao.csv
@@ -1,0 +1,16 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+ano,INT64,Ano de referência,,no,br_bd_diretorios_data_tempo.ano:ano,,no,Partição. Extraído da competência AAAAMM,c1
+mes,INT64,Mês de referência do trimestre (3 março; 6 junho; 9 setembro; 12 dezembro),,no,br_bd_diretorios_data_tempo.mes:mes,,no,IF.data é trimestral; o mês é sempre o de fechamento do trimestre,c1
+tipo_consolidado,STRING,"Tipo de consolidado do IF.data (1005 conglomerados financeiros e instituições independentes; 1006 instituições individuais; 1009 conglomerados prudenciais e instituições independentes)",,yes,,,no,Corresponde ao arquivo cadastro<competência>_<tipo>.json,
+id_instituicao,STRING,Código da instituição ou conglomerado atribuído pelo Banco Central,,no,,,no,Chave que liga esta tabela a relatorio,c0
+nome_instituicao,STRING,Nome da instituição ou conglomerado,,no,,,no,,c2
+tcb,STRING,Tipo de consolidado bancário (TCB),,yes,,,no,,c3
+td,STRING,Tipo de consolidação (TD),,yes,,,no,,c4
+tc,STRING,Tipo de controle (TC),,yes,,,no,Indica controle público federal estadual privado nacional ou estrangeiro,c6
+ti,STRING,Tipo de instituição (TI),,yes,,,no,,c13
+sr,STRING,Segmento definido pela Resolução nº 4.553/2017 (SR),,yes,,,no,Segmentação prudencial S1 a S5,c32
+segmento,STRING,Segmento de atuação da instituição,,yes,,,no,,c8
+id_municipio,STRING,ID Município - IBGE 7 Dígitos da sede da instituição,,no,br_bd_diretorios_brasil.municipio:id_municipio,,no,Resolvido a partir do nome da cidade e da UF informados pelo IF.data; a fonte não publica o código IBGE,c11
+id_conglomerado_financeiro,STRING,Código do conglomerado financeiro ao qual a instituição pertence,,no,,,no,Vazio quando a instituição é independente,c14
+id_conglomerado_prudencial,STRING,Código do conglomerado prudencial ao qual a instituição pertence,,no,,,no,Vazio quando a instituição é independente,c15
+data_alteracao_segmento,DATE,Data da última alteração de segmento da instituição,,no,,,no,,c20

--- a/models/br_bcb_ifdata/code/architecture/relatorio.csv
+++ b/models/br_bcb_ifdata/code/architecture/relatorio.csv
@@ -1,0 +1,7 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+ano,INT64,Ano de referência,,no,br_bd_diretorios_data_tempo.ano:ano,,no,Partição,
+mes,INT64,Mês de referência do trimestre (3 março; 6 junho; 9 setembro; 12 dezembro),,no,br_bd_diretorios_data_tempo.mes:mes,,no,,
+id_instituicao,STRING,Código da instituição ou conglomerado atribuído pelo Banco Central,,no,,,no,Liga a instituicao,e
+id_relatorio,STRING,Código do relatório do IF.data (por exemplo 105 Ativo do conglomerado prudencial; 106 Ativo da instituição individual),,yes,,,no,O tipo de consolidado está embutido no relatório; ver a tabela coluna,
+id_coluna,STRING,Código da coluna dentro do relatório,,no,,,no,Liga a coluna; corresponde ao campo ifd do IF.data,ifd
+valor,FLOAT64,Saldo reportado pela instituição,,no,,BRL,no,Valores em reais correntes sem ajuste de inflação,v

--- a/models/br_bcb_ifdata/code/architecture/relatorio.csv
+++ b/models/br_bcb_ifdata/code/architecture/relatorio.csv
@@ -2,6 +2,5 @@ name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory
 ano,INT64,Ano de referência,,no,br_bd_diretorios_data_tempo.ano:ano,,no,Partição,
 mes,INT64,Mês de referência do trimestre (3 março; 6 junho; 9 setembro; 12 dezembro),,no,br_bd_diretorios_data_tempo.mes:mes,,no,,
 id_instituicao,STRING,Código da instituição ou conglomerado atribuído pelo Banco Central,,no,,,no,Liga a instituicao,e
-id_relatorio,STRING,Código do relatório do IF.data (por exemplo 105 Ativo do conglomerado prudencial; 106 Ativo da instituição individual),,yes,,,no,O tipo de consolidado está embutido no relatório; ver a tabela coluna,
-id_coluna,STRING,Código da coluna dentro do relatório,,no,,,no,Liga a coluna; corresponde ao campo ifd do IF.data,ifd
-valor,FLOAT64,Saldo reportado pela instituição,,no,,BRL,no,Valores em reais correntes sem ajuste de inflação,v
+id_coluna,STRING,Código da rubrica reportada,,no,,,no,"Liga a coluna. Uma mesma rubrica aparece em vários relatórios (um por tipo de consolidado) com o mesmo código, por isso o relatório não faz parte da chave desta tabela",i
+valor,FLOAT64,Valor reportado pela instituição para a rubrica,,no,,BRL,no,Valores em reais correntes sem ajuste de inflação,v

--- a/models/br_bcb_ifdata/code/clean.py
+++ b/models/br_bcb_ifdata/code/clean.py
@@ -1,0 +1,105 @@
+"""Onboarding estático do br_bcb_ifdata — limpa as 105 competências.
+
+Reaproveita as funções puras de `pipelines/datasets/br_bcb_ifdata/utils.py`,
+as mesmas que o pipeline trimestral usa, em vez de duplicar a transformação.
+
+Cada competência é baixada, decodificada e gravada em parquet uma por vez, e
+o JSON bruto nunca vai para o disco — só o parquet de saída ocupa espaço.
+
+Uso:
+    uv run python models/br_bcb_ifdata/code/clean.py [--desde AAAAMM]
+
+Saída (padrão `~/Downloads/br_bcb_ifdata_data/output`, sobrescrevível pela
+variável de ambiente `IFDATA_OUTPUT`):
+
+    output/instituicao/ano=<AAAA>/data_<AAAAMM>.parquet
+    output/coluna/ano=<AAAA>/data_<AAAAMM>.parquet
+    output/relatorio/ano=<AAAA>/data_<AAAAMM>.parquet
+    output/dicionario/data.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import os
+import pathlib
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+
+from pipelines.datasets.br_bcb_ifdata.utils import (
+    build_dicionario,
+    build_municipio_crosswalk,
+    clean_period,
+    fetch_index,
+)
+
+DEFAULT_OUT = (
+    pathlib.Path.home() / "Downloads" / "br_bcb_ifdata_data" / "output"
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--desde", type=int, default=0, help="competência AAAAMM")
+    ap.add_argument("--ate", type=int, default=999912)
+    args = ap.parse_args()
+
+    outdir = pathlib.Path(os.environ.get("IFDATA_OUTPUT") or DEFAULT_OUT)
+    outdir.mkdir(parents=True, exist_ok=True)
+    print(f"saída: {outdir}", flush=True)
+
+    exact, squashed = build_municipio_crosswalk()
+    print(f"crosswalk município: {len(exact)} chaves", flush=True)
+
+    index = [e for e in fetch_index() if args.desde <= e["dt"] <= args.ate]
+    print(f"competências a processar: {len(index)}", flush=True)
+
+    totais: collections.Counter = collections.Counter()
+    nao_resolvidos: collections.Counter = collections.Counter()
+    sem_rubrica = 0
+    falhas: list[tuple[int, str]] = []
+    t0 = time.time()
+
+    for n, entry in enumerate(index, 1):
+        dt = entry["dt"]
+        try:
+            st = clean_period(entry, outdir, exact, squashed)
+        except Exception as exc:
+            falhas.append((dt, repr(exc)))
+            print(f"  [{n}/{len(index)}] {dt} FALHOU: {exc!r}", flush=True)
+            continue
+        for k in ("instituicao", "coluna", "relatorio"):
+            totais[k] += st[k]
+        nao_resolvidos.update(st["municipios_nao_resolvidos"])
+        sem_rubrica += st["celulas_sem_rubrica"]
+        print(
+            f"  [{n}/{len(index)}] {dt}: inst={st['instituicao']:>5} "
+            f"col={st['coluna']:>4} fato={st['relatorio']:>9} "
+            f"({time.time() - t0:.0f}s)",
+            flush=True,
+        )
+
+    print("\nmontando dicionário...", flush=True)
+    dic = build_dicionario(index, outdir)
+
+    print("\n=== TOTAIS ===")
+    for k in ("instituicao", "coluna", "relatorio"):
+        print(f"  {k:<12} {totais[k]:>12,}")
+    print(f"  {'dicionario':<12} {dic['dicionario']:>12,}")
+    print(f"\ncélulas sem rubrica: {sem_rubrica}")
+    print(f"municípios não resolvidos: {sum(nao_resolvidos.values())}")
+    for k, v in nao_resolvidos.most_common(30):
+        print("  MISS", k, v)
+    if falhas:
+        print(f"\nFALHAS ({len(falhas)}):")
+        for dt, err in falhas:
+            print("  ", dt, err)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/br_bcb_ifdata/code/upload.py
+++ b/models/br_bcb_ifdata/code/upload.py
@@ -1,0 +1,170 @@
+"""Upload de onboarding do br_bcb_ifdata para o staging do BigQuery dev.
+
+Envia o parquet all-STRING para `basedosdados-dev.br_bcb_ifdata_staging.<tabela>`
+e confere a contagem de linhas contra o que existe em disco.
+
+Duas escolhas que valem explicação:
+
+* **All-STRING, não tipado.** É a convenção da casa para staging — o modelo dbt
+  faz o `safe_cast` de cada coluna. Manter o upload do onboarding e o do
+  pipeline recorrente no mesmo formato evita a divergência de esquema descrita
+  em `prefect-pipeline-conventions` (tabela externa tipada sobrevivendo a um
+  overwrite all-STRING).
+
+* **Sem hive partitioning.** O `ano` já é uma coluna dentro do parquet, então
+  ligar o hive partitioning sobre `ano=<AAAA>/` declararia a mesma coluna duas
+  vezes, com tipos diferentes (STRING no arquivo, INT64 inferido do caminho). O
+  particionamento de verdade é o do modelo dbt; o caminho no GCS é só
+  organização.
+
+Billing / requester-pays: basedosdados-dev. Autenticação: ADC.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import google.cloud.storage as gcs
+import pyarrow.parquet as pq
+from google.cloud import bigquery
+
+BILLING_PROJECT = "basedosdados-dev"
+BUCKET = "basedosdados-dev"
+GCP_DATASET_ID = "br_bcb_ifdata"
+STAGING_DATASET = "br_bcb_ifdata_staging"
+DATA_ROOT = os.environ.get(
+    "IFDATA_OUTPUT",
+    os.path.expanduser("~/Downloads/br_bcb_ifdata_data/output"),
+)
+TABLES = ["instituicao", "coluna", "relatorio", "dicionario"]
+
+_orig_bucket = gcs.Client.bucket
+
+
+def _patched_bucket(self, bucket_name, user_project=None):
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
+
+
+gcs.Client.bucket = _patched_bucket
+
+storage_client = gcs.Client(project=BILLING_PROJECT)
+bq = bigquery.Client(project=BILLING_PROJECT)
+
+
+def ensure_dataset() -> None:
+    ds = bigquery.Dataset(f"{BILLING_PROJECT}.{STAGING_DATASET}")
+    ds.location = "US"
+    bq.create_dataset(ds, exists_ok=True)
+    print(f"  dataset {BILLING_PROJECT}.{STAGING_DATASET} pronto")
+
+
+def delete_prefix(prefix: str) -> None:
+    bucket = storage_client.bucket(BUCKET)
+    blobs = list(storage_client.list_blobs(bucket, prefix=prefix))
+    if not blobs:
+        print(f"  sem blobs antigos em {prefix}")
+        return
+    for i in range(0, len(blobs), 500):
+        bucket.delete_blobs(blobs[i : i + 500])
+    print(f"  removidos {len(blobs)} blobs antigos em {prefix}")
+
+
+def local_files(name: str) -> list[tuple[str, str]]:
+    root = os.path.join(DATA_ROOT, name)
+    out = []
+    for dirpath, _, filenames in os.walk(root):
+        for fn in filenames:
+            if fn.endswith(".parquet"):
+                full = os.path.join(dirpath, fn)
+                out.append((full, os.path.relpath(full, root)))
+    return sorted(out)
+
+
+def local_rows(files: list[tuple[str, str]]) -> int:
+    """Linhas em disco, lidas do metadado do parquet (não carrega os dados)."""
+    return sum(pq.ParquetFile(f).metadata.num_rows for f, _ in files)
+
+
+def _upload_one(bucket, prefix, full, rel) -> None:
+    blob = bucket.blob(prefix + rel.replace(os.sep, "/"))
+    blob.chunk_size = 256 * 1024 * 1024
+    for attempt in range(3):
+        try:
+            blob.upload_from_filename(full)
+            return
+        except Exception:
+            if attempt == 2:
+                raise
+
+
+def upload_files(files, prefix: str) -> None:
+    bucket = storage_client.bucket(BUCKET)
+    print(f"  enviando {len(files)} arquivos -> gs://{BUCKET}/{prefix}")
+    done = 0
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        futs = [
+            ex.submit(_upload_one, bucket, prefix, full, rel)
+            for full, rel in files
+        ]
+        for fut in as_completed(futs):
+            fut.result()
+            done += 1
+            if done % 50 == 0 or done == len(files):
+                print(f"    {done}/{len(files)}")
+
+
+def load_table(name: str, prefix: str) -> str:
+    table_id = f"{BILLING_PROJECT}.{STAGING_DATASET}.{name}"
+    jc = bigquery.LoadJobConfig(
+        source_format=bigquery.SourceFormat.PARQUET,
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+    )
+    job = bq.load_table_from_uri(
+        f"gs://{BUCKET}/{prefix}*.parquet", table_id, job_config=jc
+    )
+    job.result()
+    print(f"  load job {job.job_id}: output_rows={job.output_rows:,}")
+    return table_id
+
+
+def process(name: str) -> tuple[str, int]:
+    files = local_files(name)
+    if not files:
+        print(f"\n=== {name}: NENHUM parquet em disco, pulando ===")
+        return name, 0
+    esperado = local_rows(files)
+    print(f"\n=== {name} ({len(files)} arquivos, {esperado:,} linhas) ===")
+    prefix = f"staging/{GCP_DATASET_ID}/{name}/"
+    delete_prefix(prefix)
+    upload_files(files, prefix)
+    table_id = load_table(name, prefix)
+    n = next(iter(bq.query(f"SELECT COUNT(*) n FROM `{table_id}`").result())).n
+    print(
+        f"  COUNT(*)={n:,} esperado={esperado:,} bate={'S' if n == esperado else 'N'}"
+    )
+    if n != esperado:
+        print(f"!! DIVERGÊNCIA em {name}: {n} != {esperado}")
+        sys.exit(1)
+    return name, n
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--only", default=None, help="tabelas separadas por vírgula"
+    )
+    args = ap.parse_args()
+    only = set(args.only.split(",")) if args.only else None
+
+    ensure_dataset()
+    res = [process(t) for t in TABLES if not only or t in only]
+    print("\n=== RESUMO ===")
+    for name, n in res:
+        print(f"  {name:<12} {n:>12,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/br_bcb_ifdata/schema.yml
+++ b/models/br_bcb_ifdata/schema.yml
@@ -1,0 +1,203 @@
+---
+version: 2
+models:
+  - name: br_bcb_ifdata__instituicao
+    description: >
+      Cadastro das instituições e conglomerados financeiros que reportam ao
+      IF.data, com uma linha por competência trimestral, tipo de consolidado e
+      instituição. Traz a classificação regulatória (TCB, TD, TC, TI, SR), o
+      município da sede e os conglomerados financeiro e prudencial aos quais a
+      instituição pertence.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [ano, mes, tipo_consolidado, id_instituicao]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - ti
+            - sr
+            - segmento
+            - id_conglomerado_financeiro
+            - id_conglomerado_prudencial
+            - data_alteracao_segmento
+      - custom_dictionary_coverage:
+          columns_covered_by_dictionary:
+            - tipo_consolidado
+            - tcb
+            - td
+            - tc
+            - ti
+            - sr
+          dictionary_model: ref('br_bcb_ifdata__dicionario')
+    columns:
+      - name: ano
+        description: Ano de referência
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano
+      - name: mes
+        description: Mês de referência do trimestre
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes
+      - name: tipo_consolidado
+        description: Tipo de consolidado do IF.data
+        tests: [not_null]
+      - name: id_instituicao
+        description: >
+          Código da instituição ou conglomerado atribuído pelo Banco Central
+        tests: [not_null]
+      - name: nome_instituicao
+        description: Nome da instituição ou conglomerado
+      - name: tcb
+        description: Tipo de consolidado bancário (TCB)
+      - name: td
+        description: Tipo de consolidação (TD)
+      - name: tc
+        description: Tipo de controle (TC)
+      - name: ti
+        description: Tipo de instituição (TI)
+      - name: sr
+        description: Segmento definido pela Resolução nº 4.553/2017 (SR)
+      - name: segmento
+        description: >
+          Código de segmento de atuação da instituição. O IF.data publica o
+          código sem tabela de rótulos, por isso não há entrada no dicionário
+      - name: id_municipio
+        description: >
+          ID Município - IBGE 7 Dígitos da sede da instituição. A fonte informa
+          apenas UF e nome da cidade; o código é resolvido por nome
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio
+      - name: id_conglomerado_financeiro
+        description: Código do conglomerado financeiro
+      - name: id_conglomerado_prudencial
+        description: Código do conglomerado prudencial
+      - name: data_alteracao_segmento
+        description: Data da última alteração de segmento da instituição
+  - name: br_bcb_ifdata__coluna
+    description: >
+      Dimensão das rubricas publicadas pelo IF.data, com uma linha por
+      competência, relatório e rubrica. Cada relatório se aplica a exatamente um
+      tipo de consolidado, e uma mesma rubrica aparece em vários relatórios com
+      o mesmo código. Rubricas presentes nos dados que nenhum relatório da
+      competência referencia (séries antigas ainda publicadas, mas não exibidas)
+      entram com id_relatorio nulo.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [ano, mes, id_relatorio, id_coluna]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values:
+            - id_relatorio
+            - tipo_consolidado
+            - nome_relatorio
+            - nome_grupo
+            - ordem_coluna
+      - custom_dictionary_coverage:
+          columns_covered_by_dictionary: [tipo_consolidado]
+          dictionary_model: ref('br_bcb_ifdata__dicionario')
+    columns:
+      - name: ano
+        description: Ano de referência
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano
+      - name: mes
+        description: Mês de referência do trimestre
+        tests: [not_null]
+      - name: id_relatorio
+        description: >
+          Código do relatório do IF.data. Nulo quando a rubrica não é
+          referenciada por nenhum relatório da competência
+      - name: id_coluna
+        description: Código da rubrica reportada
+        tests: [not_null]
+      - name: tipo_consolidado
+        description: Tipo de consolidado a que o relatório se aplica
+      - name: nome_relatorio
+        description: Nome do relatório em português
+      - name: nome_grupo
+        description: >
+          Nome do grupo de colunas ao qual a rubrica pertence, quando o
+          relatório agrupa rubricas sob um cabeçalho
+      - name: nome_coluna
+        description: Nome da rubrica em português
+      - name: nome_coluna_ingles
+        description: Nome da rubrica em inglês, publicado pela própria fonte
+      - name: ordem_coluna
+        description: Posição da rubrica no relatório publicado
+  - name: br_bcb_ifdata__relatorio
+    description: >
+      Valores reportados pelas instituições ao IF.data, em formato longo, com
+      uma linha por competência trimestral, instituição e rubrica. O relatório
+      não faz parte da chave: suas variantes por tipo de consolidado
+      compartilham os mesmos códigos de rubrica e o mesmo valor. Use a tabela
+      coluna para recuperar relatório, tipo de consolidado e nome da rubrica.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [ano, mes, id_instituicao, id_coluna]
+          config:
+            where: __most_recent_year__
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+    columns:
+      - name: ano
+        description: Ano de referência
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano
+      - name: mes
+        description: Mês de referência do trimestre
+        tests: [not_null]
+      - name: id_instituicao
+        description: >
+          Código da instituição ou conglomerado atribuído pelo Banco Central
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bcb_ifdata__instituicao')
+              field: id_instituicao
+              config:
+                where: __most_recent_year__
+      - name: id_coluna
+        description: Código da rubrica reportada
+        tests: [not_null]
+      - name: valor
+        description: Valor reportado pela instituição para a rubrica, em reais
+  - name: br_bcb_ifdata__dicionario
+    description: >
+      Dicionário com a tradução de todas as variáveis codificadas do conjunto,
+      montado a partir dos filtros publicados pelo próprio IF.data.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - id_tabela
+            - nome_coluna
+            - chave
+            - cobertura_temporal
+    columns:
+      - name: id_tabela
+        description: Nome da tabela
+        tests: [not_null]
+      - name: nome_coluna
+        description: Nome da coluna
+        tests: [not_null]
+      - name: chave
+        description: Chave (valor codificado da coluna)
+        tests: [not_null]
+      - name: cobertura_temporal
+        description: Cobertura temporal da chave
+      - name: valor
+        description: Valor (descrição da chave)
+        tests: [not_null]

--- a/models/br_bcb_ifdata/schema.yml
+++ b/models/br_bcb_ifdata/schema.yml
@@ -20,30 +20,35 @@ models:
             - id_conglomerado_financeiro
             - id_conglomerado_prudencial
             - data_alteracao_segmento
+      # `ti` e `tcb` ficam fora da cobertura: o IF.data usa códigos que ele
+      # próprio nunca rotula em nenhum `filtro` da série — nove valores de `ti`
+      # (194, 196-200, 20, 42, 38) e o `tcb` 'z2'. O dicionário cobre o resto.
       - custom_dictionary_coverage:
-          columns_covered_by_dictionary:
-            - tipo_consolidado
-            - tcb
-            - td
-            - tc
-            - ti
-            - sr
+          columns_covered_by_dictionary: [tipo_consolidado, td, tc, sr]
           dictionary_model: ref('br_bcb_ifdata__dicionario')
     columns:
       - name: ano
         description: Ano de referência
         tests:
           - not_null
+          # `field: ano.ano`, não `ano`. O teste compila para
+          # `select ano from `proj`.`ds`.`ano``, e com o caminho citado em
+          # partes o `ano` cru casa com a *range variable* (a linha inteira,
+          # STRUCT<ano, bissexto>) em vez da coluna, quebrando o join com
+          # "No matching signature for operator = ... INT64, STRUCT<...>".
+          # Qualificar resolve. Afeta todo diretório cujo nome de tabela é
+          # igual ao do campo (ano, mes) — 76 datasets do repositório usam a
+          # forma crua e têm o mesmo teste quebrado.
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__ano')
-              field: ano
+              field: ano.ano
       - name: mes
         description: Mês de referência do trimestre
         tests:
           - not_null
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__mes')
-              field: mes
+              field: mes.mes
       - name: tipo_consolidado
         description: Tipo de consolidado do IF.data
         tests: [not_null]
@@ -88,10 +93,24 @@ models:
       tipo de consolidado, e uma mesma rubrica aparece em vários relatórios com
       o mesmo código. Rubricas presentes nos dados que nenhum relatório da
       competência referencia (séries antigas ainda publicadas, mas não exibidas)
-      entram com id_relatorio nulo.
+      entram com id_relatorio nulo. Seis rubricas, presentes entre 2008 e 2024,
+      não têm nome publicado em nenhuma competência: carregam valores monetários
+      reais, mas o IF.data não divulga o rótulo, então nome_coluna é nulo. São
+      335 das 50.240 linhas desta tabela e 0,28% dos valores em relatorio; os
+      valores foram mantidos em vez de descartados.
     tests:
+      # `ordem_coluna` faz parte da chave porque uma mesma rubrica pode
+      # aparecer duas vezes no mesmo relatório, em posições diferentes: em
+      # 2002-12 o relatório 3 traz a 78196 como "Credores por Antecipação de
+      # Valor Residual (e3)", dentro do grupo Arrendamento Mercantil, e de novo
+      # como "(j)" no nível de cima. Os dois rótulos são reais.
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: [ano, mes, id_relatorio, id_coluna]
+          combination_of_columns:
+            - ano
+            - mes
+            - id_relatorio
+            - id_coluna
+            - ordem_coluna
       - not_null_proportion_multiple_columns:
           at_least: 0.05
           ignore_values:
@@ -108,9 +127,17 @@ models:
         description: Ano de referência
         tests:
           - not_null
+          # `field: ano.ano`, não `ano`. O teste compila para
+          # `select ano from `proj`.`ds`.`ano``, e com o caminho citado em
+          # partes o `ano` cru casa com a *range variable* (a linha inteira,
+          # STRUCT<ano, bissexto>) em vez da coluna, quebrando o join com
+          # "No matching signature for operator = ... INT64, STRUCT<...>".
+          # Qualificar resolve. Afeta todo diretório cujo nome de tabela é
+          # igual ao do campo (ano, mes) — 76 datasets do repositório usam a
+          # forma crua e têm o mesmo teste quebrado.
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__ano')
-              field: ano
+              field: ano.ano
       - name: mes
         description: Mês de referência do trimestre
         tests: [not_null]
@@ -154,22 +181,31 @@ models:
         description: Ano de referência
         tests:
           - not_null
+          # `field: ano.ano`, não `ano`. O teste compila para
+          # `select ano from `proj`.`ds`.`ano``, e com o caminho citado em
+          # partes o `ano` cru casa com a *range variable* (a linha inteira,
+          # STRUCT<ano, bissexto>) em vez da coluna, quebrando o join com
+          # "No matching signature for operator = ... INT64, STRUCT<...>".
+          # Qualificar resolve. Afeta todo diretório cujo nome de tabela é
+          # igual ao do campo (ano, mes) — 76 datasets do repositório usam a
+          # forma crua e têm o mesmo teste quebrado.
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__ano')
-              field: ano
+              field: ano.ano
       - name: mes
         description: Mês de referência do trimestre
         tests: [not_null]
       - name: id_instituicao
         description: >
           Código da instituição ou conglomerado atribuído pelo Banco Central
-        tests:
-          - not_null
-          - relationships:
-              to: ref('br_bcb_ifdata__instituicao')
-              field: id_instituicao
-              config:
-                where: __most_recent_year__
+        # Sem teste de FK contra `instituicao`: o cadastro do IF.data lista
+        # só as instituições exibidas em cada tipo de consolidado, enquanto os
+        # dados trazem toda entidade que reporta. 22,7% dos valores da série
+        # (12,4 milhões de linhas) são de instituições sem linha no cadastro da
+        # competência, e das 1.977 órfãs de 2026-03 apenas 7 aparecem no
+        # cadastro de outra competência. Não é lacuna da limpeza: a fonte não
+        # publica cadastro para elas.
+        tests: [not_null]
       - name: id_coluna
         description: Código da rubrica reportada
         tests: [not_null]

--- a/pipelines/datasets/br_bcb_ifdata/constants.py
+++ b/pipelines/datasets/br_bcb_ifdata/constants.py
@@ -1,0 +1,16 @@
+"""Constantes do pipeline br_bcb_ifdata."""
+
+from enum import Enum
+
+
+class constants(Enum):
+    DATASET_ID = "br_bcb_ifdata"
+
+    # A ordem importa: `coluna` e `instituicao` são referenciadas pelos testes
+    # de `relatorio`, e `dicionario` pelo custom_dictionary_coverage das duas
+    # primeiras. Todas são construídas antes de qualquer teste rodar.
+    ALL_TABLES = ["dicionario", "instituicao", "coluna", "relatorio"]
+
+    # Tabela usada para o poll da fonte. `relatorio` é a que carrega a
+    # cobertura temporal completa.
+    POLL_TABLE = "relatorio"

--- a/pipelines/datasets/br_bcb_ifdata/flows.py
+++ b/pipelines/datasets/br_bcb_ifdata/flows.py
@@ -1,0 +1,174 @@
+"""Flow trimestral do br_bcb_ifdata (IF.data — Banco Central)."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+
+from prefect import flow
+
+from pipelines.datasets.br_bcb_ifdata.constants import constants
+from pipelines.datasets.br_bcb_ifdata.tasks import (
+    clean_all,
+    get_source_max_period,
+)
+from pipelines.utils.metadata.domain import (
+    AllFree,
+    DateFormat,
+    YearMonth,
+)
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+ALL_TABLES = constants.ALL_TABLES.value
+POLL_TABLE = constants.POLL_TABLE.value
+
+# O IF.data é trimestral, portanto menos frequente que mensal — pela regra de
+# negócio da BD, não entra no paywall rotativo. Todas as tabelas são AllFree, e
+# nenhuma Row Access Policy é emitida. `dicionario` não tem coluna de data e
+# por isso não recebe spec de cobertura.
+_COVERAGE = {
+    table: AllFree(
+        date_column=YearMonth(year="ano", month="mes"),
+        date_format=DateFormat.YEAR_MONTH,
+    )
+    for table in ("instituicao", "coluna", "relatorio")
+}
+
+
+def _materialize(target: str, bucket: str, paths: dict) -> None:
+    """Sobe o staging e materializa todas as tabelas, depois testa todas.
+
+    A separação entre `run` e `test` é obrigatória aqui, não estilística: o
+    `custom_dictionary_coverage` de `instituicao` e `coluna` referencia
+    `ref('br_bcb_ifdata__dicionario')`, e o `relationships` de `relatorio`
+    referencia `ref('br_bcb_ifdata__instituicao')`. Testando tabela a tabela, o
+    teste da primeira roda antes de a irmã existir e falha com
+    `Not found: Table ... br_bcb_ifdata.dicionario`. Num ambiente já povoado
+    isso passa despercebido porque a irmã sobrou da build anterior; só quebra
+    num ambiente limpo, então a ordem precisa ser estrutural.
+    """
+    for table in ALL_TABLES:
+        upload_to_gcs(
+            data_path=paths[table],
+            dataset_id=DATASET_ID,
+            table_id=table,
+            bucket_name=bucket,
+            dump_mode="overwrite",
+            source_format="parquet",
+        )
+        run_dbt(
+            dataset_id=DATASET_ID,
+            table_id=table,
+            dbt_command="run",
+            target=target,
+        )
+
+    for table in ALL_TABLES:
+        run_dbt(
+            dataset_id=DATASET_ID,
+            table_id=table,
+            dbt_command="test",
+            target=target,
+        )
+
+
+@flow(name="br_bcb_ifdata", log_prints=True)
+def br_bcb_ifdata_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+) -> None:
+    """Reconstrói o IF.data inteiro e materializa.
+
+    A reconstrução é completa a cada run, não incremental: na data-base de
+    dezembro o BCB republica os dados contábeis dos últimos quatro trimestres,
+    então competências já carregadas mudam depois. Por isso `dump_mode` é
+    `overwrite`. O poll da fonte transforma uma run agendada em no-op barato
+    entre publicações.
+
+    Args:
+        materialize_to_prod: segue além da materialização em dev para escrever
+            o bucket de prod e rodar o dbt com `target="prod"`. Use False para
+            exercitar só a metade dev — necessário para uma run de teste
+            segura, já que o padrão escreve produção.
+        update_metadata: registra cobertura das tabelas após a materialização
+            em prod. Sem efeito quando `materialize_to_prod` é False.
+        force_run: materializa mesmo quando o poll não vê competência nova.
+    """
+    # pyrefly: ignore [unused-coroutine]
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id="br_bcb_ifdata"
+    )
+
+    max_ym = get_source_max_period()
+    print(f"competência mais recente na fonte: {max_ym}")
+
+    has_new_data = poll_source_for_update_task(
+        dataset_id=DATASET_ID,
+        table_id=POLL_TABLE,
+        source_max_date=max_ym,
+        env="prod",
+        date_format="%Y-%m",
+        compare_against="coverage",
+    )
+    if not has_new_data and not force_run:
+        print("Não há novas competências na fonte.")
+        return
+
+    # Grava o Update da fonte antes de baixar: se o flow falhar no meio, o
+    # metadado ainda registra que havia competência nova publicada.
+    commit_source_update_task(
+        dataset_id=DATASET_ID,
+        table_id=POLL_TABLE,
+        source_max_date=max_ym,
+        env="prod",
+        date_format="%Y-%m",
+        update_metadata=update_metadata,
+        materialize_after_dump=materialize_to_prod,
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="br_bcb_ifdata_")
+    try:
+        paths = clean_all(work_dir=work_dir)
+        _materialize("dev", "basedosdados-dev", paths)
+
+        if not materialize_to_prod:
+            return
+
+        _materialize("prod", "basedosdados", paths)
+
+        if update_metadata:
+            for table, coverage in _COVERAGE.items():
+                register_table_materialization_task(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    coverage=coverage,
+                    env="prod",
+                    bq_project="basedosdados",
+                )
+    finally:
+        # Cobre a saída antecipada (dev-only) e qualquer exceção.
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# O IF.data publica cerca de 90 dias após o fim do trimestre (a competência
+# 2026-03 saiu em 2026-06-01). Poller nos primeiros dias de cada mês às 16:00
+# BRT; a trava do poll no-opa até uma competência nova aparecer de fato.
+# pyrefly: ignore [missing-attribute]
+br_bcb_ifdata_flow.deploy_schedules = [
+    {"cron": "0 16 1,2,3,4,5 * *", "timezone": "America/Sao_Paulo"}
+]
+# A limpeza percorre 105 competências, mantendo no máximo uma na memória
+# (~1M células), mas o crosswalk do IBGE e o índice ficam residentes.
+# pyrefly: ignore [missing-attribute]
+br_bcb_ifdata_flow.job_variables = {"memory": "4Gi"}

--- a/pipelines/datasets/br_bcb_ifdata/flows.py
+++ b/pipelines/datasets/br_bcb_ifdata/flows.py
@@ -13,8 +13,9 @@ from pipelines.datasets.br_bcb_ifdata.tasks import (
     get_source_max_period,
 )
 from pipelines.utils.metadata.domain import (
-    AllFree,
     DateFormat,
+    FreeLag,
+    PartBdpro,
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
@@ -32,14 +33,28 @@ DATASET_ID = constants.DATASET_ID.value
 ALL_TABLES = constants.ALL_TABLES.value
 POLL_TABLE = constants.POLL_TABLE.value
 
-# O IF.data é trimestral, portanto menos frequente que mensal — pela regra de
-# negócio da BD, não entra no paywall rotativo. Todas as tabelas são AllFree, e
-# nenhuma Row Access Policy é emitida. `dicionario` não tem coluna de data e
-# por isso não recebe spec de cobertura.
+# Os dois trimestres mais recentes ficam fechados para assinantes BD Pro; o
+# resto da série é livre. `free_lag` de 6 meses são exatamente 2 competências
+# trimestrais.
+#
+# A coluna de data é `YearMonth`, não `YearQuarter`: `mes` já guarda o mês de
+# fechamento do trimestre (3, 6, 9, 12), enquanto `YearQuarter` multiplicaria o
+# valor por 3 e produziria meses inexistentes (9, 18, 27, 36). Com `YearMonth`
+# a cobertura termina num mês de trimestre de verdade.
+#
+# Uma ressalva sobre o início da faixa pro: `compute_coverage_ranges` faz a pro
+# começar em `free_end + 1 mês`, porque a granularidade do formato é mensal.
+# Com a fonte em 2026-03, a free termina em 2025-09 e a pro começa em 2025-10 —
+# um mês sem dado. Quem decide o acesso é a Row Access Policy (`mes <=
+# free_end`), então o conjunto fechado é exatamente {2025-12, 2026-03}. Só o
+# limite inferior da faixa pro não cai num mês de trimestre.
+#
+# `dicionario` não tem coluna de data e por isso não recebe spec de cobertura.
 _COVERAGE = {
-    table: AllFree(
+    table: PartBdpro(
         date_column=YearMonth(year="ano", month="mes"),
         date_format=DateFormat.YEAR_MONTH,
+        free_lag=FreeLag(unit="months", value=6),
     )
     for table in ("instituicao", "coluna", "relatorio")
 }

--- a/pipelines/datasets/br_bcb_ifdata/tasks.py
+++ b/pipelines/datasets/br_bcb_ifdata/tasks.py
@@ -1,0 +1,70 @@
+"""Tasks do pipeline br_bcb_ifdata — invólucros Prefect sobre `utils`."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from prefect import task
+
+from pipelines.constants import constants as pipeline_constants
+from pipelines.datasets.br_bcb_ifdata.utils import (
+    build_dicionario,
+    build_municipio_crosswalk,
+    clean_period,
+    fetch_index,
+    source_max_period,
+)
+
+
+@task(
+    retries=pipeline_constants.TASK_MAX_RETRIES.value,
+    retry_delay_seconds=pipeline_constants.TASK_RETRY_DELAY.value,
+)
+def get_source_max_period() -> str:
+    """Competência mais recente na fonte, como `AAAA-MM`."""
+    dt = source_max_period()
+    return f"{dt // 100:04d}-{dt % 100:02d}"
+
+
+@task(
+    retries=pipeline_constants.TASK_MAX_RETRIES.value,
+    retry_delay_seconds=pipeline_constants.TASK_RETRY_DELAY.value,
+)
+def clean_all(work_dir: str) -> dict[str, Any]:
+    """Reconstrói todas as competências e devolve o caminho de cada tabela.
+
+    A reconstrução é **completa**, não incremental: na data-base de dezembro o
+    BCB republica os dados contábeis dos últimos quatro trimestres, então uma
+    competência já carregada pode mudar depois. Anexar só o trimestre novo
+    deixaria as revisões para trás.
+    """
+    outdir = pathlib.Path(work_dir)
+    exact, squashed = build_municipio_crosswalk()
+    index = fetch_index()
+    print(f"competências a processar: {len(index)}")
+
+    totais: dict[str, int] = {"instituicao": 0, "coluna": 0, "relatorio": 0}
+    nao_resolvidos: list[tuple[str, str]] = []
+    for n, entry in enumerate(index, 1):
+        st = clean_period(entry, outdir, exact, squashed)
+        for k in totais:
+            totais[k] += st[k]
+        nao_resolvidos.extend(st["municipios_nao_resolvidos"])
+        if n % 10 == 0 or n == len(index):
+            print(f"  {n}/{len(index)} — {st['dt']}")
+
+    totais.update(build_dicionario(index, outdir))
+    if nao_resolvidos:
+        # Não derruba a run: o teste dbt `relationships` de id_municipio é o
+        # portão de verdade. Mas registra, porque um nome novo sem match é
+        # sinal de município renomeado que precisa entrar em ALIAS_MUNICIPIO.
+        print(f"ATENÇÃO: {len(nao_resolvidos)} municípios não resolvidos")
+        for uf_nome in sorted(set(nao_resolvidos))[:20]:
+            print(f"  {uf_nome}")
+
+    print(f"totais: {totais}")
+    return {
+        **{t: str(outdir / t) for t in totais},
+        "totais": totais,
+    }

--- a/pipelines/datasets/br_bcb_ifdata/utils.py
+++ b/pipelines/datasets/br_bcb_ifdata/utils.py
@@ -27,22 +27,36 @@ BASE = "https://www3.bcb.gov.br/ifdata/rest"
 HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; basedosdados/1.0)"}
 INDEXES = ("relatorios2000a2024", "relatorios2025a2030")
 
-# tipos de consolidado expostos pelo IF.data (arquivo sel<p>.json)
-TIPOS_INSTITUICAO = {
-    "1005": "Conglomerados Financeiros e Instituições Independentes",
-    "1006": "Instituições Individuais",
-    "1009": "Conglomerados Prudenciais e Instituições Independentes",
-}
+# O conjunto de tipos de consolidado **muda ao longo do tempo** — não são
+# fixos. Ao longo das 105 competências aparecem seis:
+#
+#   1004  Conglomerados Prudenciais e Instituições Independentes  201403..202306
+#   1005  Conglomerados Financeiros e Instituições Independentes  200003..202603
+#   1006  Instituições Individuais                                200003..202603
+#   1007  Instituições com Operações de Câmbio                    201412..202306
+#   1008  (descontinuado)                                         201206..201403
+#   1009  Conglomerados Prudenciais e Instituições Independentes  202309..202603
+#
+# 1009 substitui 1004 a partir de 2023-09. Por isso os nomes são lidos do
+# índice por competência (`sel`), nunca de uma constante.
 
 
-def _get(url: str, *, tries: int = 4, timeout: int = 180) -> requests.Response:
-    """GET com retry exponencial — o www3 do BCB é intermitente."""
+def _get_json(url: str, *, tries: int = 5, timeout: int = 180) -> Any:
+    """GET + parse do JSON, com retry exponencial.
+
+    O www3 do BCB falha de forma **silenciosa**: em vez de um 5xx devolve
+    `HTTP 200` com o corpo `Erro interno - Internal error`, então
+    `raise_for_status` passa e só o parse quebra. Numa varredura das 105
+    competências isso aconteceu em 2 dos 315 arquivos de cadastro, e os dois
+    baixaram normalmente na tentativa seguinte — é intermitente, não
+    permanente. Por isso o retry precisa olhar o corpo, não só o status.
+    """
     last: Exception | None = None
     for attempt in range(tries):
         try:
             r = requests.get(url, headers=HEADERS, timeout=timeout)
             r.raise_for_status()
-            return r
+            return r.json()
         except Exception as exc:
             last = exc
             time.sleep(2**attempt)
@@ -53,7 +67,7 @@ def fetch_index() -> list[dict[str, Any]]:
     """Índice de competências (trimestral). Junta as duas faixas publicadas."""
     periods: list[dict[str, Any]] = []
     for name in INDEXES:
-        periods.extend(_get(f"{BASE}/{name}").json())
+        periods.extend(_get_json(f"{BASE}/{name}"))
     return sorted(periods, key=lambda p: p["dt"])
 
 
@@ -73,7 +87,7 @@ def fetch_file(path: str) -> Any:
     O caminho vem com barra dupla (`ifdata_2025_2030//202603/...`); isso é
     literal e exigido pelo endpoint.
     """
-    return _get(f"{BASE}/arquivos?nomeArquivo={path}").json()
+    return _get_json(f"{BASE}/arquivos?nomeArquivo={path}")
 
 
 def _files_by_kind(period_entry: dict[str, Any]) -> dict[str, list[str]]:
@@ -84,6 +98,19 @@ def _files_by_kind(period_entry: dict[str, Any]) -> dict[str, list[str]]:
             0
         ]  # cadastro/dados/trel/info/...
         out.setdefault(kind, []).append(f["f"])
+    return out
+
+
+def period_tipos(period_entry: dict[str, Any]) -> dict[str, dict[str, str]]:
+    """`{id_tipo: {"pt": nome, "en": nome}}` para uma competência.
+
+    Lido do bloco `sel` que o próprio índice já traz — não exige baixar o
+    `sel<p>.json`. O conjunto varia por competência (ver a nota no topo).
+    """
+    out: dict[str, dict[str, str]] = {}
+    for f in period_entry["files"]:
+        for s in f.get("sel") or []:
+            out[str(s["id"])] = {"pt": s["n"], "en": s.get("ni", "")}
     return out
 
 
@@ -115,7 +142,13 @@ ALIAS_MUNICIPIO: dict[tuple[str, str], str] = {
     ("RO", "NOVA BRASILANDIA"): "1100155",  # Nova Brasilândia D'Oeste
     ("RS", "ELDORADO"): "4306767",  # Eldorado do Sul
     ("TO", "PARAISO DO NORTE DO TOCANTINS"): "1716109",  # Paraíso do Tocantins
+    ("RN", "ACU"): "2400208",  # grafia antiga de Assú
 }
+
+# O DF tem um único município (Brasília). O IF.data às vezes informa a região
+# administrativa na cidade — `BRASILIA SAMAMBAIA`, `BRASILIA TAGUATINGA` —, que
+# não é município. Tudo no DF resolve para Brasília.
+ID_MUNICIPIO_DF = "5300108"
 
 
 def normalize_municipio(name: str) -> str:
@@ -150,7 +183,7 @@ def build_municipio_crosswalk() -> tuple[dict, dict]:
     """`(exato, sem_espacos)` — ambos `{(sigla_uf, nome): id_municipio}`."""
     exact: dict[tuple[str, str], str] = {}
     squashed: dict[tuple[str, str], str] = {}
-    for m in _get(IBGE_MUNICIPIOS).json():
+    for m in _get_json(IBGE_MUNICIPIOS):
         uf = _uf_of(m)
         if uf is None:
             continue
@@ -171,6 +204,8 @@ def resolve_id_municipio(
     não-resolvidos em vez de gravar nulo em silêncio.
     """
     uf = (uf or "").strip()
+    if uf == "DF":
+        return ID_MUNICIPIO_DF
     key = (uf, normalize_municipio(nome))
     if key in exact:
         return exact[key]

--- a/pipelines/datasets/br_bcb_ifdata/utils.py
+++ b/pipelines/datasets/br_bcb_ifdata/utils.py
@@ -1,0 +1,183 @@
+"""Funções puras de download e limpeza do IF.data (BCB).
+
+Compartilhado entre o onboarding estático (`models/br_bcb_ifdata/code/`) e o
+pipeline recorrente trimestral. Sem imports do Prefect.
+
+A API documentada do IF.data (Olinda OData, `servico/IFDATA`) respondia 500 em
+todas as chamadas de dados em 2026-08-18, então o download usa a API do próprio
+aplicativo IF.data (`www3.bcb.gov.br/ifdata/rest/`). Ela não é documentada, mas é
+a que o site usa. O formato é decodificado assim:
+
+    trel<p>_<rel>.json  ->  c[]  ->  ifd  --(info[].id)-->  info entry
+    info entry.ty == 0  ->  valor vem do cadastro, coluna `c<lid>`
+    info entry.ty == 1  ->  valor vem de dados<p>_<n>.json, célula `lid`
+    info entry.lid == -1 ->  coluna não disponível nesta competência/tipo
+
+`dados[].e` é o **código da instituição** (CodInst), não um índice posicional.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+
+BASE = "https://www3.bcb.gov.br/ifdata/rest"
+HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; basedosdados/1.0)"}
+INDEXES = ("relatorios2000a2024", "relatorios2025a2030")
+
+# tipos de consolidado expostos pelo IF.data (arquivo sel<p>.json)
+TIPOS_INSTITUICAO = {
+    "1005": "Conglomerados Financeiros e Instituições Independentes",
+    "1006": "Instituições Individuais",
+    "1009": "Conglomerados Prudenciais e Instituições Independentes",
+}
+
+
+def _get(url: str, *, tries: int = 4, timeout: int = 180) -> requests.Response:
+    """GET com retry exponencial — o www3 do BCB é intermitente."""
+    last: Exception | None = None
+    for attempt in range(tries):
+        try:
+            r = requests.get(url, headers=HEADERS, timeout=timeout)
+            r.raise_for_status()
+            return r
+        except Exception as exc:
+            last = exc
+            time.sleep(2**attempt)
+    raise RuntimeError(f"falha ao baixar {url}") from last
+
+
+def fetch_index() -> list[dict[str, Any]]:
+    """Índice de competências (trimestral). Junta as duas faixas publicadas."""
+    periods: list[dict[str, Any]] = []
+    for name in INDEXES:
+        periods.extend(_get(f"{BASE}/{name}").json())
+    return sorted(periods, key=lambda p: p["dt"])
+
+
+def list_periods() -> list[int]:
+    """Competências disponíveis, como inteiros `AAAAMM` (ex.: 202603)."""
+    return [p["dt"] for p in fetch_index()]
+
+
+def source_max_period() -> int:
+    """Competência mais recente publicada na fonte."""
+    return max(list_periods())
+
+
+def fetch_file(path: str) -> Any:
+    """Baixa um arquivo JSON do IF.data pelo caminho listado no índice.
+
+    O caminho vem com barra dupla (`ifdata_2025_2030//202603/...`); isso é
+    literal e exigido pelo endpoint.
+    """
+    return _get(f"{BASE}/arquivos?nomeArquivo={path}").json()
+
+
+def _files_by_kind(period_entry: dict[str, Any]) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    for f in period_entry["files"]:
+        name = f["f"].rsplit("/", 1)[-1]
+        kind = name.split(str(period_entry["dt"]))[
+            0
+        ]  # cadastro/dados/trel/info/...
+        out.setdefault(kind, []).append(f["f"])
+    return out
+
+
+def build_cell_map(paths: list[str]) -> dict[int, dict[int, Any]]:
+    """`{cod_inst: {lid: valor}}` a partir dos chunks `dados<p>_<n>.json`."""
+    cells: dict[int, dict[int, Any]] = {}
+    for p in paths:
+        for row in fetch_file(p)["values"]:
+            cells.setdefault(row["e"], {}).update(
+                {c["i"]: c["v"] for c in row["v"]}
+            )
+    return cells
+
+
+# --------------------------------------------------------- crosswalk município
+# O IF.data identifica a sede da instituição por UF + **nome** da cidade, sem
+# código IBGE, então o `id_municipio` é resolvido por nome. A fonte do
+# crosswalk é a API de localidades do IBGE (pública, sem credencial, e a
+# autoridade sobre o código de 7 dígitos). O teste dbt `relationships` contra
+# `br_bd_diretorios_brasil__municipio` é o portão que verifica o resultado.
+
+IBGE_MUNICIPIOS = (
+    "https://servicodados.ibge.gov.br/api/v1/localidades/municipios"
+)
+
+# Nomes históricos usados pelo IF.data que não existem mais no IBGE (município
+# renomeado ou desmembrado). Mapeia para o código atual.
+ALIAS_MUNICIPIO: dict[tuple[str, str], str] = {
+    ("RO", "NOVA BRASILANDIA"): "1100155",  # Nova Brasilândia D'Oeste
+    ("RS", "ELDORADO"): "4306767",  # Eldorado do Sul
+    ("TO", "PARAISO DO NORTE DO TOCANTINS"): "1716109",  # Paraíso do Tocantins
+}
+
+
+def normalize_municipio(name: str) -> str:
+    """Caixa alta, sem acento e sem pontuação — `Sant'Ana` -> `SANT ANA`."""
+    import re
+    import unicodedata
+
+    s = unicodedata.normalize("NFKD", name or "")
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = re.sub(r"[^A-Z0-9 ]", " ", s.upper())
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _squash(name: str) -> str:
+    return normalize_municipio(name).replace(" ", "")
+
+
+def _uf_of(m: dict[str, Any]) -> str | None:
+    for path in (
+        ("microrregiao", "mesorregiao", "UF"),
+        ("regiao-imediata", "regiao-intermediaria", "UF"),
+    ):
+        node: Any = m
+        for key in path:
+            node = node.get(key) if isinstance(node, dict) else None
+        if node:
+            return node["sigla"]
+    return None
+
+
+def build_municipio_crosswalk() -> tuple[dict, dict]:
+    """`(exato, sem_espacos)` — ambos `{(sigla_uf, nome): id_municipio}`."""
+    exact: dict[tuple[str, str], str] = {}
+    squashed: dict[tuple[str, str], str] = {}
+    for m in _get(IBGE_MUNICIPIOS).json():
+        uf = _uf_of(m)
+        if uf is None:
+            continue
+        code = str(m["id"])
+        exact[(uf, normalize_municipio(m["nome"]))] = code
+        squashed.setdefault((uf, _squash(m["nome"])), code)
+    return exact, squashed
+
+
+def resolve_id_municipio(
+    uf: str, nome: str, exact: dict, squashed: dict
+) -> str | None:
+    """`id_municipio` (IBGE, 7 dígitos) ou `None` se o nome não resolver.
+
+    Tenta, em ordem: nome normalizado; nome sem espaços (pega `Sant'Ana` vs
+    `Santana`); a variante `D OESTE` -> `DO OESTE`; e a tabela de nomes
+    históricos. Devolver `None` é deliberado — o chamador deve reportar os
+    não-resolvidos em vez de gravar nulo em silêncio.
+    """
+    uf = (uf or "").strip()
+    key = (uf, normalize_municipio(nome))
+    if key in exact:
+        return exact[key]
+    sq = (uf, _squash(nome))
+    if sq in squashed:
+        return squashed[sq]
+    doeste = (uf, _squash(nome).replace("DOESTE", "DOOESTE"))
+    if doeste in squashed:
+        return squashed[doeste]
+    return ALIAS_MUNICIPIO.get(key)

--- a/pipelines/datasets/br_bcb_ifdata/utils.py
+++ b/pipelines/datasets/br_bcb_ifdata/utils.py
@@ -457,3 +457,89 @@ def clean_period(entry, outdir, exact, squashed) -> dict[str, Any]:
         "municipios_nao_resolvidos": unresolved,
         "celulas_sem_rubrica": sem_rotulo,
     }
+
+
+# ------------------------------------------------------------------ dicionário
+# Os rótulos das colunas codificadas do cadastro vêm de `filtro<p>.json`: cada
+# filtro traz `ii` (o id em `info`, cujo `lid` é o índice `cN` do cadastro) e
+# `d[]` com `{v: chave, n: rótulo PT, ni: rótulo EN}`. O `tipo_consolidado` vem
+# do bloco `sel` do índice. `segmento` (c8) é código sem tabela de rótulos
+# publicada — fica sem dicionário, de propósito.
+
+# índice `cN` do cadastro -> coluna nas nossas tabelas
+_LID_PARA_COLUNA = {3: "tcb", 4: "td", 6: "tc", 13: "ti", 32: "sr"}
+
+
+def build_dicionario(index: list[dict], outdir) -> dict[str, Any]:
+    """Monta o `dicionario` varrendo o `filtro` de todas as competências.
+
+    `cobertura_temporal` sai como `AAAA(1)AAAA` — o intervalo de anos em que
+    aquele par (chave, valor) foi observado. Rótulos que mudam de texto ao
+    longo da série viram linhas distintas, cada uma com sua cobertura.
+    """
+    import pathlib
+
+    outdir = pathlib.Path(outdir)
+    # (id_tabela, nome_coluna, chave, valor) -> [anos]
+    visto: dict[tuple[str, str, str, str], list[int]] = {}
+
+    def marcar(tabela: str, coluna: str, chave: Any, valor: Any, ano: int):
+        if chave is None or valor is None:
+            return
+        visto.setdefault(
+            (tabela, coluna, str(chave).strip(), str(valor).strip()), []
+        ).append(ano)
+
+    for entry in index:
+        ano = entry["dt"] // 100
+        for tipo, nomes in period_tipos(entry).items():
+            for tabela in ("instituicao", "coluna"):
+                marcar(tabela, "tipo_consolidado", tipo, nomes["pt"], ano)
+
+        kinds = _files_by_kind(entry)
+        if not kinds.get("filtro"):
+            continue
+        info = {i["id"]: i for i in fetch_file(kinds["info"][0])}
+        for filtro in fetch_file(kinds["filtro"][0]):
+            m = info.get(filtro.get("ii"))
+            coluna = _LID_PARA_COLUNA.get(m.get("lid")) if m else None
+            if coluna is None:
+                continue
+            for v in filtro.get("d") or []:
+                marcar("instituicao", coluna, v.get("v"), v.get("n"), ano)
+
+    linhas = []
+    for (tabela, coluna, chave, valor), anos in sorted(visto.items()):
+        linhas.append(
+            {
+                "id_tabela": tabela,
+                "nome_coluna": coluna,
+                "chave": chave,
+                "cobertura_temporal": f"{min(anos)}(1){max(anos)}",
+                "valor": valor,
+            }
+        )
+
+    if linhas:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        cols = [
+            "id_tabela",
+            "nome_coluna",
+            "chave",
+            "cobertura_temporal",
+            "valor",
+        ]
+        tbl = pa.Table.from_arrays(
+            [
+                pa.array([_clean_str(r[c]) for r in linhas], type=pa.string())
+                for c in cols
+            ],
+            names=cols,
+        )
+        dest = outdir / "dicionario"
+        dest.mkdir(parents=True, exist_ok=True)
+        pq.write_table(tbl, dest / "data.parquet", compression="snappy")
+
+    return {"dicionario": len(linhas)}

--- a/pipelines/datasets/br_bcb_ifdata/utils.py
+++ b/pipelines/datasets/br_bcb_ifdata/utils.py
@@ -216,3 +216,244 @@ def resolve_id_municipio(
     if doeste in squashed:
         return squashed[doeste]
     return ALIAS_MUNICIPIO.get(key)
+
+
+# ------------------------------------------------------------------- limpeza
+# O staging da BD é todo STRING por convenção da casa (o modelo dbt faz o
+# safe_cast de cada coluna), então o parquet sai com todas as colunas STRING.
+# A conversão passa pelo arrow, nunca por `astype(str)`, que renderiza NULL
+# como a string literal "nan" — que o safe_cast não devolve para NULL.
+
+SCHEMAS: dict[str, list[str]] = {
+    "instituicao": [
+        "ano",
+        "mes",
+        "tipo_consolidado",
+        "id_instituicao",
+        "nome_instituicao",
+        "tcb",
+        "td",
+        "tc",
+        "ti",
+        "sr",
+        "segmento",
+        "id_municipio",
+        "id_conglomerado_financeiro",
+        "id_conglomerado_prudencial",
+        "data_alteracao_segmento",
+    ],
+    "coluna": [
+        "ano",
+        "mes",
+        "id_relatorio",
+        "id_coluna",
+        "tipo_consolidado",
+        "nome_relatorio",
+        "nome_grupo",
+        "nome_coluna",
+        "nome_coluna_ingles",
+        "ordem_coluna",
+    ],
+    "relatorio": ["ano", "mes", "id_instituicao", "id_coluna", "valor"],
+}
+
+# posição -> coluna, para o cadastro (ver `info` com ty=0; `lid` é o índice cN)
+_CADASTRO = {
+    "id_instituicao": "c0",
+    "nome_instituicao": "c2",
+    "tcb": "c3",
+    "td": "c4",
+    "tc": "c6",
+    "segmento": "c8",
+    "ti": "c13",
+    "id_conglomerado_financeiro": "c14",
+    "id_conglomerado_prudencial": "c15",
+    "data_alteracao_segmento": "c20",
+    "sr": "c32",
+}
+
+
+def _clean_str(v: Any) -> str | None:
+    """Normaliza para string, preservando NULL — nunca devolve "nan"."""
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+def _write_table(rows: list[dict], table: str, ano: int, dt: int, outdir):
+    """Grava `outdir/<table>/ano=<ano>/data_<dt>.parquet`, tudo STRING."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    cols = SCHEMAS[table]
+    arrays = [
+        pa.array([_clean_str(r.get(c)) for r in rows], type=pa.string())
+        for c in cols
+    ]
+    tbl = pa.Table.from_arrays(arrays, names=cols)
+    dest = outdir / table / f"ano={ano}"
+    dest.mkdir(parents=True, exist_ok=True)
+    pq.write_table(tbl, dest / f"data_{dt}.parquet", compression="snappy")
+
+
+def _walk_colunas(cols: list[dict], info: dict, grupo: str | None = None):
+    """Percorre as colunas de um relatório, descendo um nível em `sc`.
+
+    As colunas de primeiro nível de vários relatórios são apenas **cabeçalhos
+    de grupo** (por exemplo `Empréstimo com Consignação em Folha`), e as
+    medidas ficam em `sc` (as faixas de vencimento). O relatório 123 tem 18
+    colunas de primeiro nível e 56 subcolunas. Ignorar `sc` perde ~88% das
+    células, então a varredura precisa ser recursiva.
+
+    Devolve `(coluna, entrada_info, nome_do_grupo)` só para as folhas com
+    `ty=1` e `lid` válido — `ty=0` é atributo cadastral e já está em
+    `instituicao`.
+    """
+    for c in cols:
+        m = info.get(c["ifd"])
+        nome = (m.get("n") or "").replace("\n", " ").strip() if m else None
+        if c.get("sc"):
+            yield from _walk_colunas(c["sc"], info, nome)
+            continue
+        if m is None or m.get("ty") != 1 or m.get("lid") in (None, -1):
+            continue
+        yield c, m, grupo
+
+
+def clean_period(entry, outdir, exact, squashed) -> dict[str, Any]:
+    """Decodifica uma competência e grava o parquet das três tabelas.
+
+    Devolve estatísticas para validação — contagens por tabela, nomes de
+    município não resolvidos e células sem rubrica correspondente. Nada é
+    descartado em silêncio.
+    """
+    import pathlib
+
+    outdir = pathlib.Path(outdir)
+    dt = entry["dt"]
+    ano, mes = divmod(dt, 100)
+    kinds = _files_by_kind(entry)
+
+    info = {i["id"]: i for i in fetch_file(kinds["info"][0])}
+
+    # ---- instituicao (um registro por tipo de consolidado)
+    inst: list[dict] = []
+    unresolved: list[tuple[str, str]] = []
+    for path in sorted(kinds.get("cadastro", [])):
+        tipo = path.rsplit("_", 1)[-1].removesuffix(".json")
+        for r in fetch_file(path):
+            uf = (r.get("c10") or "").strip()
+            cidade = (r.get("c11") or "").strip()
+            id_mun = (
+                resolve_id_municipio(uf, cidade, exact, squashed)
+                if cidade
+                else None
+            )
+            if cidade and id_mun is None:
+                unresolved.append((uf, cidade))
+            row = {"ano": ano, "mes": mes, "tipo_consolidado": tipo}
+            row.update({k: r.get(src) for k, src in _CADASTRO.items()})
+            row["id_municipio"] = id_mun
+            inst.append(row)
+
+    # ---- coluna (definições vêm do próprio índice, em `trel`)
+    colunas: list[dict] = []
+    rotulada: set[int] = set()
+    for f in entry["files"]:
+        t = f.get("trel")
+        if not t:
+            continue
+        tipos = [str(s["id"]) for s in (t.get("s") or [])]
+        for c, m, grupo in _walk_colunas(t.get("c", []), info):
+            rotulada.add(m["lid"])
+            colunas.append(
+                {
+                    "ano": ano,
+                    "mes": mes,
+                    "id_relatorio": str(t["id"]),
+                    "id_coluna": str(m["lid"]),
+                    "tipo_consolidado": tipos[0] if tipos else None,
+                    "nome_relatorio": t.get("n"),
+                    "nome_grupo": grupo,
+                    "nome_coluna": (m.get("n") or "")
+                    .replace("\n", " ")
+                    .strip(),
+                    "nome_coluna_ingles": (m.get("ni") or "")
+                    .replace("\n", " ")
+                    .strip(),
+                    "ordem_coluna": c.get("o"),
+                }
+            )
+
+    # ---- relatorio (fato) — é exatamente o mapa de células
+    cells = build_cell_map(kinds.get("dados", []))
+
+    # Nem toda rubrica presente nos dados é referenciada por um relatório da
+    # competência: em 2026-03 são 258 de 631 (~43% das células), séries antigas
+    # que o IF.data ainda publica mas não exibe mais. Elas têm nome em `info`,
+    # então entram em `coluna` com `id_relatorio` nulo em vez de ficarem sem
+    # rótulo — nenhum valor é descartado.
+    por_lid: dict[int, dict] = {}
+    for i in info.values():
+        if i.get("ty") == 1 and isinstance(i.get("lid"), int):
+            por_lid.setdefault(i["lid"], i)
+
+    orfas = {lid for cm in cells.values() for lid in cm} - rotulada
+    for lid in sorted(orfas):
+        m = por_lid.get(lid)
+        colunas.append(
+            {
+                "ano": ano,
+                "mes": mes,
+                "id_relatorio": None,
+                "id_coluna": str(lid),
+                "tipo_consolidado": None,
+                "nome_relatorio": None,
+                "nome_grupo": None,
+                "nome_coluna": (m.get("n") or "").replace("\n", " ").strip()
+                if m
+                else None,
+                "nome_coluna_ingles": (m.get("ni") or "")
+                .replace("\n", " ")
+                .strip()
+                if m
+                else None,
+                "ordem_coluna": None,
+            }
+        )
+
+    fato: list[dict] = []
+    sem_rotulo = 0
+    for cod, cellmap in cells.items():
+        for lid, valor in cellmap.items():
+            if valor is None:
+                continue
+            if lid not in rotulada and lid not in por_lid:
+                sem_rotulo += 1  # nem relatório nem `info` — só aí é órfã real
+            fato.append(
+                {
+                    "ano": ano,
+                    "mes": mes,
+                    "id_instituicao": str(cod),
+                    "id_coluna": str(lid),
+                    "valor": valor,
+                }
+            )
+
+    for table, rows in (
+        ("instituicao", inst),
+        ("coluna", colunas),
+        ("relatorio", fato),
+    ):
+        if rows:
+            _write_table(rows, table, ano, dt, outdir)
+
+    return {
+        "dt": dt,
+        "instituicao": len(inst),
+        "coluna": len(colunas),
+        "relatorio": len(fato),
+        "municipios_nao_resolvidos": unresolved,
+        "celulas_sem_rubrica": sem_rotulo,
+    }


### PR DESCRIPTION
Onboarding do **IF.data** — dados contábeis, de capital e de carteira de crédito das instituições financeiras autorizadas pelo Banco Central, trimestrais de **2000-03 a 2026-03** (105 competências). Licença **ODbL**. O SCR (microdados de crédito, restrito) está fora de escopo.

## Tabelas

| tabela | linhas (dev) | conteúdo |
|---|---:|---|
| `relatorio` | 54.457.085 | fato longo: competência × instituição × rubrica → valor |
| `instituicao` | 449.439 | cadastro por competência e tipo de consolidado |
| `coluna` | 50.240 | dimensão das rubricas (relatório, grupo, nome PT/EN) |
| `dicionario` | 56 | tradução das variáveis codificadas |

`dbt run` 4/4 · **`dbt test` PASS=29, ERROR=0** em `basedosdados-dev`.

## A fonte

A API OData documentada (`olinda.bcb.gov.br/.../IFDATA`) respondia **500 em todas as chamadas de dados** — todas as competências, todos os tipos de instituição, todos os relatórios, com sintaxe de parâmetro inline e por alias. O Olinda em si estava saudável (o serviço Expectativas respondia), então é específico do IFDATA. A extração usa a API do próprio aplicativo IF.data (`www3.bcb.gov.br/ifdata/rest`), que é o que o site consome. Vale re-testar o Olinda antes de armar o pipeline; o download está isolado atrás de `fetch_file`/`build_cell_map` para facilitar a troca.

O formato é decodificado por `trel.c[].ifd → info[].id → info[].lid → célula`. Detalhes que custaram tempo e estão documentados no código:

- **As colunas dos relatórios são aninhadas.** Vários relatórios trazem no primeiro nível apenas cabeçalhos de grupo, com as medidas em `sc` — o relatório 123 tem 18 colunas de primeiro nível e 56 subcolunas. Varredura não recursiva perde ~88% das células.
- **O `www3` falha em silêncio**: devolve `HTTP 200` com o corpo `Erro interno - Internal error`, então `raise_for_status` passa e só o parse quebra. Aconteceu em 2 de 315 arquivos; o retry passou a olhar o corpo, e isso recuperou 2.878 linhas que sumiriam sem erro nenhum.
- **Os tipos de consolidado mudam ao longo da série** — seis no total, com 1009 substituindo 1004 em 2023-09. Lidos por competência, nunca de constante.

## Decisões de modelagem

**O relatório não faz parte da chave do fato.** As variantes por tipo de consolidado (Ativo = 105/106/107) compartilham os mesmos códigos de rubrica, e os dados trazem uma única linha por instituição — o valor não varia por tipo. 1.384 códigos aparecem em 2+ tipos, então chavear por relatório triplicaria uma tabela de ~54M linhas. A chave é `(ano, mes, id_instituicao, id_coluna)`; relatório e tipo vivem na dimensão `coluna`.

**`relatorio.id_instituicao` não é FK para `instituicao`.** O cadastro lista só as instituições *exibidas* em cada tipo de consolidado, enquanto os dados trazem toda entidade que reporta: **22,7% dos valores (12,4M linhas)** são de instituições sem linha no cadastro da competência, e das 1.977 órfãs de 2026-03 apenas 7 aparecem em outra competência. O teste de FK foi removido e a limitação está na descrição da tabela — quem juntar as duas perde um quarto dos dados sem aviso.

**`id_municipio` resolvido por nome.** O IF.data publica a sede por UF + nome de cidade, sem código IBGE. O crosswalk usa a API de localidades do IBGE e fecha em **100% das 449.396 linhas** com nome de cidade preenchido (43 linhas têm cidade em branco e ficam nulas). Precisou de normalização, um fallback sem espaços (`Sant'Ana` vs `Santana`), a variante `D OESTE`→`DO OESTE`, quatro renomeações e uma regra para o DF, que tem um único município mas aparece com a região administrativa no nome (`BRASILIA SAMAMBAIA`). Quem verifica isso é o teste dbt `relationships` contra `br_bd_diretorios_brasil__municipio`, que passa.

**Seis rubricas sem nome** (2008–2024, 0,28% dos valores) carregam valores monetários reais mas a fonte não publica o rótulo em nenhuma competência. Mantidas com `nome_coluna` nulo em vez de descartadas.

## Pipeline trimestral

Reconstrução **completa** a cada run (`dump_mode="overwrite"`), não incremental: na data-base de dezembro o BCB republica os dados dos últimos quatro trimestres, então competências já carregadas mudam depois.

Roda **todas as tabelas e só então testa todas**, por ambiente. Não é estilo: o `custom_dictionary_coverage` referencia `ref('..._dicionario')` e o `relationships` de `relatorio` referencia `ref('..._instituicao')`. Testando tabela a tabela, o teste da primeira roda antes de a irmã existir — falha que passa despercebida num ambiente povoado e só quebra num limpo. Mesmo defeito de #1826 e #1833.

**BD Pro:** os dois trimestres mais recentes ficam fechados (`PartBdpro`, `free_lag` de 6 meses); o resto é livre. A janela rola sozinha — com a fonte em 2026-06 a free vai a 2025-12 e a pro a 2026-01..2026-06. A coluna de data é `YearMonth`, **não** `YearQuarter`, porque `mes` já guarda o mês de fechamento (3/6/9/12) e `YearQuarter` multiplicaria por 3. As duas Coverages já existem em prod, então `assert_coverage_topology` passa.

## Fora do escopo deste PR

Os testes `relationships` contra `br_bd_diretorios_data_tempo__ano/__mes` são estruturalmente quebrados: o dbt cita o caminho em partes, então o `ano` cru casa com a *range variable* do BigQuery (`STRUCT<ano, bissexto>`) em vez da coluna. Aqui usei a forma qualificada (`field: ano.ano`) com comentário, mas **76 datasets do repositório usam a forma crua** e têm o mesmo teste impossível de passar. Merece correção no teste genérico, em PR separado.

## Checklist

- [x] Arquitetura + código de limpeza (compartilhado com o pipeline, não duplicado)
- [x] Upload para `basedosdados-dev`, contagens conferidas contra o parquet local
- [x] Modelos dbt + 29 testes verdes
- [x] Metadados no staging (publicado) e no prod (`under_review`)
- [ ] **Labels `table-approve` e `deploy-flow`** — sem elas o prod não materializa e o pipeline não é registrado (o job reporta *skipped*, não falha)
- [ ] Merge → materialização em prod → conferir contagens → publicar dataset
- [ ] Run de validação do pipeline no pool de dev com `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the BCB IF.data dataset, including institution, report, column, and dictionary tables.
  * Added automated data downloading, cleaning, validation, staging, and publication workflows.
  * Added municipality identification and dictionary generation for improved data consistency.
  * Added configurable period filtering, local output, selective uploads, retries, and row-count verification.

* **Documentation & Quality**
  * Added Portuguese model and column descriptions with uniqueness, relationship, nullability, and coverage checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->