### PR TITLE
feat(au_rba_statistical_tables): onboard RBA statistical tables

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -55,6 +55,9 @@ models:
     au_geoscape_gnaf:
       +materialized: table
       +schema: au_geoscape_gnaf
+    au_rba_statistical_tables:
+      +materialized: table
+      +schema: au_rba_statistical_tables
     br_anatel_banda_larga_fixa:
       +materialized: table
       +schema: br_anatel_banda_larga_fixa

--- a/models/au_rba_statistical_tables/LICENCE.md
+++ b/models/au_rba_statistical_tables/LICENCE.md
@@ -1,0 +1,63 @@
+# RBA licence finding (verified 2026-08-18)
+
+Source: https://www.rba.gov.au/copyright/ — "Copyright and Disclaimer Notice"
+
+## Default: CC BY 4.0
+
+> "With exception of the Excluded Material, all RBA Material is provided under a Creative
+> Commons Attribution 4.0 International License (CC BY 4.0 Licence) and may be used in
+> accordance with the terms of that licence. The materials covered by this licence may be
+> reproduced, published, communicated to the public and adapted provided that the RBA is
+> properly attributed."
+
+Required attribution (Section 3): `Source: Reserve Bank of Australia [year]`, or `Source: RBA [year]`.
+
+## Excluded Material — the gate that matters
+
+"Third Party Material" is Excluded Material and is **not** under CC BY:
+
+> "Material containing, or derived from or prepared using, content obtained from a third
+> party, whether it has been: reproduced in whole or in part in the form supplied by the
+> third party and published as having a third party source; **or** used by the RBA to derive
+> or prepare other material published as having **both a RBA and a third party source**, may
+> not be reproduced, published, communicated to the public, adapted or otherwise used in
+> whole or part without obtaining the consent of the third party."
+
+The second limb is the sharp one: a series labelled `Source = "ABS / RBA"` is still Third
+Party Material, despite naming the RBA.
+
+The RBA labels this for us:
+
+> "The RBA has made all reasonable efforts clearly to label material as having a third party
+> source when that material contains, has been derived from or prepared using content
+> obtained from a third party."
+
+Each statistical-table CSV carries a per-series `Source` row, and that row *is* the label.
+The redistribution filter is therefore mechanical and auditable: **keep only series whose
+`Source` names the RBA alone; drop every series naming a third party** (ABS, ASX, FENICS,
+Markit, Bloomberg, APRA, ...).
+
+This mirrors the `us_fed_fred` precedent, where copyright-restricted series were excluded at
+download time rather than filtered later.
+
+## Sections 4 and 5 (Cash Rate; Financial Data) — permissive, not blocking
+
+Both sections explicitly permit use, reproduction, publication and communication to the
+public "for personal or commercial use", conditional on:
+
+1. no statement or implication that the RBA endorses the use, beyond plain attribution;
+2. no unlawful use;
+3. no "improper commercial exploitation" — which for a paid service expressly includes
+   "charging a fee to customers for access to the Cash Rate and/or Cash Rate Materials
+   without informing customers that [they] are published on this website without a fee being
+   charged by the RBA".
+
+Redistribution is permitted. Condition (3) is why every table in this dataset is registered
+**AllFree** rather than `PartBdpro` — an all-free dataset cannot engage the paid-access
+condition at all.
+
+## Verdict
+
+Onboard as **CC BY 4.0**, restricted to RBA-sourced series, all tables AllFree.
+The exclusion list is generated from the data and recorded in
+`code/excluded_series.csv`, so the filter is reproducible and reviewable.

--- a/models/au_rba_statistical_tables/au_rba_statistical_tables__data.sql
+++ b/models/au_rba_statistical_tables/au_rba_statistical_tables__data.sql
@@ -1,14 +1,14 @@
 {{
     config(
         schema="au_rba_statistical_tables",
-        alias="observation",
+        alias="data",
         materialized="table",
         partition_by={
             "field": "year",
             "data_type": "int64",
             "range": {"start": 1922, "end": 2031, "interval": 1},
         },
-        cluster_by=["table_code", "series_id"],
+        cluster_by=["table_id", "series_id"],
     )
 }}
 
@@ -16,7 +16,7 @@
 select
     safe_cast(year as int64) year,
     safe_cast(date as date) date,
-    safe_cast(table_code as string) table_code,
+    safe_cast(table_id as string) table_id,
     safe_cast(series_id as string) series_id,
     safe_cast(value as float64) value
-from {{ set_datalake_project("au_rba_statistical_tables_staging.observation") }} as t
+from {{ set_datalake_project("au_rba_statistical_tables_staging.data") }} as t

--- a/models/au_rba_statistical_tables/au_rba_statistical_tables__dicionario.sql
+++ b/models/au_rba_statistical_tables/au_rba_statistical_tables__dicionario.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        schema="au_rba_statistical_tables",
+        alias="dicionario",
+        materialized="table",
+    )
+}}
+
+
+select
+    safe_cast(id_tabela as string) id_tabela,
+    safe_cast(nome_coluna as string) nome_coluna,
+    safe_cast(chave as string) chave,
+    safe_cast(cobertura_temporal as string) cobertura_temporal,
+    safe_cast(valor as string) valor
+from {{ set_datalake_project("au_rba_statistical_tables_staging.dicionario") }} as t

--- a/models/au_rba_statistical_tables/au_rba_statistical_tables__observation.sql
+++ b/models/au_rba_statistical_tables/au_rba_statistical_tables__observation.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        schema="au_rba_statistical_tables",
+        alias="observation",
+        materialized="table",
+        partition_by={
+            "field": "year",
+            "data_type": "int64",
+            "range": {"start": 1922, "end": 2031, "interval": 1},
+        },
+        cluster_by=["table_code", "series_id"],
+    )
+}}
+
+
+select
+    safe_cast(year as int64) year,
+    safe_cast(date as date) date,
+    safe_cast(table_code as string) table_code,
+    safe_cast(series_id as string) series_id,
+    safe_cast(value as float64) value
+from {{ set_datalake_project("au_rba_statistical_tables_staging.observation") }} as t

--- a/models/au_rba_statistical_tables/au_rba_statistical_tables__series.sql
+++ b/models/au_rba_statistical_tables/au_rba_statistical_tables__series.sql
@@ -1,0 +1,23 @@
+{{
+    config(
+        schema="au_rba_statistical_tables",
+        alias="series",
+        materialized="table",
+    )
+}}
+
+
+select
+    safe_cast(table_code as string) table_code,
+    safe_cast(series_id as string) series_id,
+    safe_cast(table_name as string) table_name,
+    safe_cast(title as string) title,
+    safe_cast(description as string) description,
+    safe_cast(frequency as string) frequency,
+    safe_cast(series_type as string) series_type,
+    safe_cast(units as string) units,
+    safe_cast(source as string) source,
+    safe_cast(publication_date as date) publication_date,
+    safe_cast(observation_start as date) observation_start,
+    safe_cast(observation_end as date) observation_end
+from {{ set_datalake_project("au_rba_statistical_tables_staging.series") }} as t

--- a/models/au_rba_statistical_tables/au_rba_statistical_tables__series.sql
+++ b/models/au_rba_statistical_tables/au_rba_statistical_tables__series.sql
@@ -8,7 +8,7 @@
 
 
 select
-    safe_cast(table_code as string) table_code,
+    safe_cast(table_id as string) table_id,
     safe_cast(series_id as string) series_id,
     safe_cast(table_name as string) table_name,
     safe_cast(title as string) title,

--- a/models/au_rba_statistical_tables/au_rba_statistical_tables__series_break.sql
+++ b/models/au_rba_statistical_tables/au_rba_statistical_tables__series_break.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        schema="au_rba_statistical_tables",
+        alias="series_break",
+        materialized="table",
+    )
+}}
+
+
+select
+    safe_cast(table_code as string) table_code,
+    safe_cast(table_name as string) table_name,
+    safe_cast(date as date) date,
+    safe_cast(break_type as string) break_type,
+    safe_cast(series_title as string) series_title,
+    safe_cast(details as string) details
+from {{ set_datalake_project("au_rba_statistical_tables_staging.series_break") }} as t

--- a/models/au_rba_statistical_tables/au_rba_statistical_tables__series_break.sql
+++ b/models/au_rba_statistical_tables/au_rba_statistical_tables__series_break.sql
@@ -8,7 +8,7 @@
 
 
 select
-    safe_cast(table_code as string) table_code,
+    safe_cast(table_id as string) table_id,
     safe_cast(table_name as string) table_name,
     safe_cast(date as date) date,
     safe_cast(break_type as string) break_type,

--- a/models/au_rba_statistical_tables/code/architecture/data.csv
+++ b/models/au_rba_statistical_tables/code/architecture/data.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Ano de referência da observação,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Coluna de particionamento; derivada de date,
+date,DATE,Data da observação,,no,,,no,"Convenção de datação do próprio RBA: fim do período para séries mensais, trimestrais e semestrais; data exata para séries diárias",Data
+table_id,STRING,"Código da tabela estatística do RBA à qual a série pertence (ex.: F1, D3, B13.1)",,no,,,no,Parte da chave: o mnemônico series_id não é único entre tabelas — 228 mnemônicos aparecem em B13.1.2 e B13.2.1 com valores distintos,Derivada do cabeçalho do arquivo CSV
+series_id,STRING,Mnemônico da série atribuído pelo RBA,,no,,,no,Referencia a tabela series (catálogo de metadados) via teste de relacionamento no dbt; único apenas em conjunto com table_id,Series ID
+value,FLOAT64,Valor observado da série,,no,,,no,A unidade depende da série; ver a coluna units na tabela series,

--- a/models/au_rba_statistical_tables/code/architecture/dicionario.csv
+++ b/models/au_rba_statistical_tables/code/architecture/dicionario.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+id_tabela,STRING,Slug da tabela de au_rba_statistical_tables descrita pela entrada do dicionário,,no,,,no,,
+nome_coluna,STRING,Nome da coluna descrita pela entrada do dicionário,,no,,,no,,
+chave,STRING,Valor codificado exatamente como armazenado nos dados,,no,,,no,,
+cobertura_temporal,STRING,Cobertura temporal da chave,,no,,,no,,
+valor,STRING,Rótulo legível correspondente ao valor codificado,,no,,,no,,

--- a/models/au_rba_statistical_tables/code/architecture/observation.csv
+++ b/models/au_rba_statistical_tables/code/architecture/observation.csv
@@ -1,0 +1,6 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+year,INT64,Ano de referência da observação,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Coluna de particionamento; derivada de date,
+date,DATE,Data da observação,,no,,,no,"Convenção de datação do próprio RBA: fim do período para séries mensais, trimestrais e semestrais; data exata para séries diárias",
+table_code,STRING,Código da tabela estatística do RBA à qual a série pertence (ex.: F1, D3, B13.1),,no,,,no,"Parte da chave: o mnemônico series_id não é único entre tabelas — 233 mnemônicos aparecem em b13.1.2 e b13.2.1 com valores distintos",table_code
+series_id,STRING,Mnemônico da série atribuído pelo RBA,,no,,,no,Referencia a tabela series via teste de relacionamento no dbt; único apenas em conjunto com table_code,Series ID
+value,FLOAT64,Valor observado da série,,no,,,no,A unidade depende da série; ver a coluna units na tabela series,

--- a/models/au_rba_statistical_tables/code/architecture/observation.csv
+++ b/models/au_rba_statistical_tables/code/architecture/observation.csv
@@ -1,6 +1,0 @@
-name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
-year,INT64,Ano de referência da observação,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,Coluna de particionamento; derivada de date,
-date,DATE,Data da observação,,no,,,no,"Convenção de datação do próprio RBA: fim do período para séries mensais, trimestrais e semestrais; data exata para séries diárias",
-table_code,STRING,Código da tabela estatística do RBA à qual a série pertence (ex.: F1, D3, B13.1),,no,,,no,"Parte da chave: o mnemônico series_id não é único entre tabelas — 233 mnemônicos aparecem em b13.1.2 e b13.2.1 com valores distintos",table_code
-series_id,STRING,Mnemônico da série atribuído pelo RBA,,no,,,no,Referencia a tabela series via teste de relacionamento no dbt; único apenas em conjunto com table_code,Series ID
-value,FLOAT64,Valor observado da série,,no,,,no,A unidade depende da série; ver a coluna units na tabela series,

--- a/models/au_rba_statistical_tables/code/architecture/series.csv
+++ b/models/au_rba_statistical_tables/code/architecture/series.csv
@@ -1,0 +1,13 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+table_code,STRING,"Código da tabela estatística do RBA (ex.: F1, D3, B13.1)",,no,,,no,Parte da chave lógica do catálogo junto com series_id,table_code
+series_id,STRING,Mnemônico da série atribuído pelo RBA,,no,,,no,Único apenas em conjunto com table_code; 233 mnemônicos se repetem entre as tabelas B13.1.2 e B13.2.1 com valores distintos,Series ID
+table_name,STRING,Nome da tabela estatística do RBA à qual a série pertence,,no,,,no,,
+title,STRING,Título descritivo da série,,no,,,no,,Title
+description,STRING,Descrição detalhada da série fornecida pelo RBA,,no,,,no,,Description
+frequency,STRING,Frequência de observação da série,,no,,,no,"Normalizado para um vocabulário controlado (Daily, Weekly, Monthly, Quarterly, Semiannual, Yearly, As announced, See notes); corrige a grafia Semiannnual usada na fonte",Frequency
+series_type,STRING,Tipo de tratamento estatístico aplicado à série,,no,,,no,"Valores como Original, Seasonally adjusted e Trend, conforme publicado pelo RBA",Type
+units,STRING,Unidade de medida dos valores da série,,no,,,no,"Define a unidade da coluna value na tabela observation (ex.: Per cent, $ million, Index)",Units
+source,STRING,Órgão responsável pela compilação original da série,,no,,,no,"Preserva a atribuição exigida pela licença CC BY 4.0; apenas séries do RBA, APRA e ABS são redistribuídas",Source
+publication_date,DATE,Data de publicação da tabela estatística que contém a série,,no,,,no,,Publication date
+observation_start,DATE,Data da primeira observação disponível da série,,no,,,no,Derivada dos dados efetivamente carregados na tabela observation,
+observation_end,DATE,Data da última observação disponível da série,,no,,,no,Derivada dos dados efetivamente carregados na tabela observation; nula para séries sem observações,

--- a/models/au_rba_statistical_tables/code/architecture/series.csv
+++ b/models/au_rba_statistical_tables/code/architecture/series.csv
@@ -1,13 +1,13 @@
 name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
-table_code,STRING,"Código da tabela estatística do RBA (ex.: F1, D3, B13.1)",,no,,,no,Parte da chave lógica do catálogo junto com series_id,table_code
-series_id,STRING,Mnemônico da série atribuído pelo RBA,,no,,,no,Único apenas em conjunto com table_code; 233 mnemônicos se repetem entre as tabelas B13.1.2 e B13.2.1 com valores distintos,Series ID
+table_id,STRING,"Código da tabela estatística do RBA (ex.: F1, D3, B13.1)",,no,,,no,Parte da chave lógica do catálogo junto com series_id,Derivada do cabeçalho do arquivo CSV
+series_id,STRING,Mnemônico da série atribuído pelo RBA,,no,,,no,Único apenas em conjunto com table_id; 228 mnemônicos se repetem entre as tabelas B13.1.2 e B13.2.1 com valores distintos,Series ID
 table_name,STRING,Nome da tabela estatística do RBA à qual a série pertence,,no,,,no,,
 title,STRING,Título descritivo da série,,no,,,no,,Title
 description,STRING,Descrição detalhada da série fornecida pelo RBA,,no,,,no,,Description
 frequency,STRING,Frequência de observação da série,,no,,,no,"Normalizado para um vocabulário controlado (Daily, Weekly, Monthly, Quarterly, Semiannual, Yearly, As announced, See notes); corrige a grafia Semiannnual usada na fonte",Frequency
 series_type,STRING,Tipo de tratamento estatístico aplicado à série,,no,,,no,"Valores como Original, Seasonally adjusted e Trend, conforme publicado pelo RBA",Type
-units,STRING,Unidade de medida dos valores da série,,no,,,no,"Define a unidade da coluna value na tabela observation (ex.: Per cent, $ million, Index)",Units
+units,STRING,Unidade de medida dos valores da série,,no,,,no,"Define a unidade da coluna value na tabela data (ex.: Per cent, $ million, Index)",Units
 source,STRING,Órgão responsável pela compilação original da série,,no,,,no,"Preserva a atribuição exigida pela licença CC BY 4.0; apenas séries do RBA, APRA e ABS são redistribuídas",Source
 publication_date,DATE,Data de publicação da tabela estatística que contém a série,,no,,,no,,Publication date
-observation_start,DATE,Data da primeira observação disponível da série,,no,,,no,Derivada dos dados efetivamente carregados na tabela observation,
-observation_end,DATE,Data da última observação disponível da série,,no,,,no,Derivada dos dados efetivamente carregados na tabela observation; nula para séries sem observações,
+observation_start,DATE,Data da primeira observação disponível da série,,no,,,no,Derivada dos dados efetivamente carregados na tabela data,
+observation_end,DATE,Data da última observação disponível da série,,no,,,no,Derivada dos dados efetivamente carregados na tabela data; nula para séries sem observações,

--- a/models/au_rba_statistical_tables/code/architecture/series_break.csv
+++ b/models/au_rba_statistical_tables/code/architecture/series_break.csv
@@ -1,5 +1,5 @@
 name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
-table_code,STRING,Código da tabela estatística do RBA à qual a quebra se refere,,no,,,no,,
+table_id,STRING,Código da tabela estatística do RBA à qual a quebra se refere,,no,,,no,,Derivada do cabeçalho do arquivo CSV
 table_name,STRING,Nome da tabela estatística do RBA à qual a quebra se refere,,no,,,no,,
 date,DATE,Data em que a quebra na série ocorreu,,no,,,no,,
 break_type,STRING,Código do tipo de quebra na série,,yes,,,no,"Rótulos legíveis na tabela dicionario; o RBA repete as mesmas definições de A, B e C no preâmbulo dos 32 arquivos de quebras",Break type

--- a/models/au_rba_statistical_tables/code/architecture/series_break.csv
+++ b/models/au_rba_statistical_tables/code/architecture/series_break.csv
@@ -1,0 +1,7 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name
+table_code,STRING,Código da tabela estatística do RBA à qual a quebra se refere,,no,,,no,,
+table_name,STRING,Nome da tabela estatística do RBA à qual a quebra se refere,,no,,,no,,
+date,DATE,Data em que a quebra na série ocorreu,,no,,,no,,
+break_type,STRING,Código do tipo de quebra na série,,yes,,,no,"Rótulos legíveis na tabela dicionario; o RBA repete as mesmas definições de A, B e C no preâmbulo dos 32 arquivos de quebras",Break type
+series_title,STRING,"Título da série afetada pela quebra, conforme grafado pelo RBA",,no,,,no,Texto livre; não corresponde necessariamente ao title da tabela series,Series title
+details,STRING,Descrição da instituição ou mudança de reporte que originou a quebra,,no,,,no,,Details

--- a/models/au_rba_statistical_tables/code/clean.py
+++ b/models/au_rba_statistical_tables/code/clean.py
@@ -1,0 +1,146 @@
+"""One-shot onboarding bootstrap for au_rba_statistical_tables.
+
+Imports the shared transform from the pipeline package — the cleaning logic
+lives in exactly one place (see .claude/rules/prefect-pipeline-conventions.md).
+
+Usage:
+    uv run python models/au_rba_statistical_tables/code/clean.py [--download]
+
+Scratch data lives under ~/Downloads/au_rba_statistical_tables_data/ (override
+with RBA_DATA); nothing is written into the repo or Dropbox.
+"""
+
+import argparse
+import csv
+import os
+from collections import Counter
+from pathlib import Path
+
+from pipelines.datasets.au_rba_statistical_tables.utils import (
+    clean_all,
+    download_all,
+    write_partitioned,
+)
+
+DATA = Path(
+    os.environ.get(
+        "RBA_DATA",
+        Path.home() / "Downloads" / "au_rba_statistical_tables_data",
+    )
+)
+
+
+def validate(cleaned, counts):
+    """Assert the invariants the dbt tests will later enforce in BigQuery."""
+    obs, series = cleaned["observation"], cleaned["series"]
+    problems = []
+
+    keys = Counter((o[0], o[1], o[2]) for o in obs)
+    dups = sum(1 for v in keys.values() if v > 1)
+    if dups:
+        problems.append(f"{dups:,} duplicate (table_code, series_id, date)")
+
+    skeys = Counter((s["table_code"], s["series_id"]) for s in series)
+    sdups = sum(1 for v in skeys.values() if v > 1)
+    if sdups:
+        problems.append(
+            f"{sdups:,} duplicate (table_code, series_id) in series"
+        )
+
+    catalogue = {(s["table_code"], s["series_id"]) for s in series}
+    orphans = {(o[0], o[1]) for o in obs} - catalogue
+    if orphans:
+        problems.append(
+            f"{len(orphans):,} observation series missing from catalogue"
+        )
+
+    if any(o[3] is None for o in obs):
+        problems.append("null values present in observation.value")
+
+    dates = [o[2] for o in obs]
+    if max(dates) > "2027-12-31":
+        problems.append(f"implausible future date {max(dates)}")
+
+    print("\n=== VALIDATION ===")
+    print(f"observation rows          : {counts['observation']:,}")
+    print(f"series rows               : {counts['series']:,}")
+    print(f"series_break rows         : {counts['series_break']:,}")
+    print(f"dicionario rows           : {counts['dicionario']:,}")
+    print(
+        f"distinct tables           : {len({s['table_code'] for s in series})}"
+    )
+    print(f"date range                : {min(dates)} -> {max(dates)}")
+    print(f"duplicate observation keys: {dups}")
+    print(f"orphan series             : {len(orphans)}")
+    print(
+        f"series with no observation: {sum(1 for s in series if s['observation_start'] is None)}"
+    )
+
+    print("\nfrequency:")
+    for f, c in Counter(s["frequency"] for s in series).most_common():
+        print(f"  {c:5,}  {f or '(blank)'}")
+    print("\nsource (attribution carried per series):")
+    for f, c in Counter(s["source"] for s in series).most_common(10):
+        print(f"  {c:5,}  {f}")
+    print(f"\nexcluded by licence gate  : {len(cleaned['excluded']):,} series")
+    for f, c in Counter(s["source"] for s in cleaned["excluded"]).most_common(
+        20
+    ):
+        print(f"  {c:5,}  {f[:80]}")
+    print(f"\nskipped files             : {len(cleaned['skipped'])}")
+
+    if problems:
+        print("\n!!! PROBLEMS:")
+        for p in problems:
+            print("   -", p)
+        raise SystemExit(1)
+    print("\nAll invariants hold.")
+
+
+def write_exclusion_list(cleaned):
+    """Record every series dropped by the licence gate, so the filter is reviewable."""
+    out = Path(__file__).parent / "excluded_series.csv"
+    with open(out, "w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh, lineterminator="\n")
+        w.writerow(
+            ["table_code", "series_id", "source", "source_file", "title"]
+        )
+        for s in sorted(
+            cleaned["excluded"],
+            key=lambda r: (r["table_code"], r["series_id"]),
+        ):
+            w.writerow(
+                [
+                    s["table_code"],
+                    s["series_id"],
+                    s["source"],
+                    s["source_file"],
+                    s["title"],
+                ]
+            )
+    print(f"exclusion list written to {out}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--download",
+        action="store_true",
+        help="re-download the source CSVs first",
+    )
+    args = ap.parse_args()
+
+    if args.download:
+        print(f"downloading into {DATA / 'input'} ...")
+        got = download_all(DATA / "input")
+        print(f"  {len(got)} files")
+
+    cleaned = clean_all(DATA / "input")
+    counts = write_partitioned(cleaned, DATA / "output")
+    validate(cleaned, counts)
+    write_exclusion_list(cleaned)
+    print(f"\nparquet written to {DATA / 'output'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_rba_statistical_tables/code/clean.py
+++ b/models/au_rba_statistical_tables/code/clean.py
@@ -32,48 +32,44 @@ DATA = Path(
 
 def validate(cleaned, counts):
     """Assert the invariants the dbt tests will later enforce in BigQuery."""
-    obs, series = cleaned["observation"], cleaned["series"]
+    obs, series = cleaned["data"], cleaned["series"]
     problems = []
 
     keys = Counter((o[0], o[1], o[2]) for o in obs)
     dups = sum(1 for v in keys.values() if v > 1)
     if dups:
-        problems.append(f"{dups:,} duplicate (table_code, series_id, date)")
+        problems.append(f"{dups:,} duplicate (table_id, series_id, date)")
 
-    skeys = Counter((s["table_code"], s["series_id"]) for s in series)
+    skeys = Counter((s["table_id"], s["series_id"]) for s in series)
     sdups = sum(1 for v in skeys.values() if v > 1)
     if sdups:
-        problems.append(
-            f"{sdups:,} duplicate (table_code, series_id) in series"
-        )
+        problems.append(f"{sdups:,} duplicate (table_id, series_id) in series")
 
-    catalogue = {(s["table_code"], s["series_id"]) for s in series}
+    catalogue = {(s["table_id"], s["series_id"]) for s in series}
     orphans = {(o[0], o[1]) for o in obs} - catalogue
     if orphans:
-        problems.append(
-            f"{len(orphans):,} observation series missing from catalogue"
-        )
+        problems.append(f"{len(orphans):,} data series missing from catalogue")
 
     if any(o[3] is None for o in obs):
-        problems.append("null values present in observation.value")
+        problems.append("null values present in data.value")
 
     dates = [o[2] for o in obs]
     if max(dates) > "2027-12-31":
         problems.append(f"implausible future date {max(dates)}")
 
     print("\n=== VALIDATION ===")
-    print(f"observation rows          : {counts['observation']:,}")
+    print(f"data rows                 : {counts['data']:,}")
     print(f"series rows               : {counts['series']:,}")
     print(f"series_break rows         : {counts['series_break']:,}")
     print(f"dicionario rows           : {counts['dicionario']:,}")
     print(
-        f"distinct tables           : {len({s['table_code'] for s in series})}"
+        f"distinct tables           : {len({s['table_id'] for s in series})}"
     )
     print(f"date range                : {min(dates)} -> {max(dates)}")
-    print(f"duplicate observation keys: {dups}")
+    print(f"duplicate data keys      : {dups}")
     print(f"orphan series             : {len(orphans)}")
     print(
-        f"series with no observation: {sum(1 for s in series if s['observation_start'] is None)}"
+        f"series with no data       : {sum(1 for s in series if s['observation_start'] is None)}"
     )
 
     print("\nfrequency:")
@@ -102,16 +98,14 @@ def write_exclusion_list(cleaned):
     out = Path(__file__).parent / "excluded_series.csv"
     with open(out, "w", newline="", encoding="utf-8") as fh:
         w = csv.writer(fh, lineterminator="\n")
-        w.writerow(
-            ["table_code", "series_id", "source", "source_file", "title"]
-        )
+        w.writerow(["table_id", "series_id", "source", "source_file", "title"])
         for s in sorted(
             cleaned["excluded"],
-            key=lambda r: (r["table_code"], r["series_id"]),
+            key=lambda r: (r["table_id"], r["series_id"]),
         ):
             w.writerow(
                 [
-                    s["table_code"],
+                    s["table_id"],
                     s["series_id"],
                     s["source"],
                     s["source_file"],

--- a/models/au_rba_statistical_tables/code/excluded_series.csv
+++ b/models/au_rba_statistical_tables/code/excluded_series.csv
@@ -1,0 +1,76 @@
+table_code,series_id,source,source_file,title
+D4,DSOGSAL,AOFM; State Borrowing Authorities,d4-data.csv,Long-term government securities issued in Australia
+D4,DSOGSAS,AOFM; Austraclear Limited,d4-data.csv,Short-term government securities issued in Australia
+D4,DSOLNAA,ABS; Bloomberg; RBA,d4-data.csv,Long-term non-government securities issued in Australia – Asset-backed
+D4,DSOLNAB,Bloomberg,d4-data.csv,Long-term non-government securities issued in Australia – Banks and other financial corporations
+D4,DSOLNANC,Bloomberg,d4-data.csv,Long-term non-government securities issued in Australia – Non-financial corporations
+D4,DSOLNANR,Bloomberg,d4-data.csv,Long-term non-government securities issued in Australia – Non-residents
+D4,DSOLNAT,ABS; Bloomberg; RBA,d4-data.csv,Long-term non-government securities issued in Australia – Total
+D4,DSOMINAE,Bloomberg,d4-data.csv,Long-term non-residents' A$ eurobonds
+D4,DSOMIRMS,ABS; Bloomberg; RBA,d4-data.csv,Residential mortgage securities
+D4,DSONSOA,ABS; Bloomberg; RBA,d4-data.csv,Long-term non-government securities issued offshore – Asset-backed
+D4,DSONSOB,Bloomberg; Private Placement Monitor,d4-data.csv,Long-term non-government securities issued offshore – Banks and other financial corporations
+D4,DSONSONC,Bloomberg; Private Placement Monitor,d4-data.csv,Long-term non-government securities issued offshore – Non-financial corporations
+D4,DSONSOT,ABS; Bloomberg; Private Placement Monitor; RBA,d4-data.csv,Long-term non-government securities issued offshore – Total
+D4,DSOSNAA,ABS; Bloomberg; RBA,d4-data.csv,Short-term non-government securities issued in Australia – Asset-backed
+D4,DSOSNAB,APRA; Austraclear Limited,d4-data.csv,Short-term non-government securities issued in Australia – Banks and other financial corporations
+D4,DSOSNANC,Austraclear Limited,d4-data.csv,Short-term non-government securities issued in Australia – Non-financial corporations
+D4,DSOSNANR,Austraclear Limited,d4-data.csv,Short-term non-government securities issued in Australia – Non-residents
+D4,DSOSNAT,ABS; APRA;  Austraclear Limited; Bloomberg; RBA,d4-data.csv,Short-term non-government securities issued in Australia – Total
+F1,FIRMMBAB180D,ASX,f1-data.csv,EOD 6-month BABs/NCDs
+F1,FIRMMBAB30D,ASX,f1-data.csv,EOD 1-month BABs/NCDs
+F1,FIRMMBAB90D,ASX,f1-data.csv,EOD 3-month BABs/NCDs
+F1,FIRMMOIS1D,FENICS,f1-data.csv,1-month OIS
+F1,FIRMMOIS3D,FENICS,f1-data.csv,3-month OIS
+F1,FIRMMOIS6D,FENICS,f1-data.csv,6-month OIS
+F1.1,FIRMMBAB180,ASX,f1.1-data.csv,6-month BABs/NCDs
+F1.1,FIRMMBAB30,ASX,f1.1-data.csv,1-month BABs/NCDs
+F1.1,FIRMMBAB90,ASX,f1.1-data.csv,3-month BABs/NCDs
+F1.1,FIRMMOIS1,FENICS,f1.1-data.csv,1-month OIS
+F1.1,FIRMMOIS3,FENICS,f1.1-data.csv,3-month OIS
+F1.1,FIRMMOIS6,FENICS,f1.1-data.csv,6-month OIS
+F11.1,FXRSDR,IMF,f11.1-data.csv,A$1=SDR
+F11.1,FXRUSD,WM/Reuters,f11.1-data.csv,A$1=USD
+F12,FUSXRCD,Refinitiv,f12-data.csv,US dollar against the Canadian dollar
+F12,FUSXRE,Refinitiv,f12-data.csv,US dollar against the euro
+F12,FUSXRJY,Refinitiv,f12-data.csv,US dollar against the Japanese yen
+F12,FUSXRSF,Refinitiv,f12-data.csv,US dollar against the Swiss franc
+F12,FUSXRTWI,Board of Governors of the Federal Reserve System,f12-data.csv,US dollar trade-weighted index
+F12,FUSXRUKPS,Refinitiv,f12-data.csv,US dollar against the UK pound sterling
+F3,FNFNA10M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Number of bonds – 8–12 years
+F3,FNFNA12M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Number of bonds – >12 years
+F3,FNFNA3M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Number of bonds – 1–4 years
+F3,FNFNA5M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Number of bonds – 4–6 years
+F3,FNFNA7M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Number of bonds – 6–8 years
+F3,FNFNBBB10M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Number of bonds – 8–12 years
+F3,FNFNBBB12M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Number of bonds – >12 years
+F3,FNFNBBB3M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Number of bonds – 1–4 years
+F3,FNFNBBB5M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Number of bonds – 4–6 years
+F3,FNFNBBB7M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Number of bonds – 6–8 years
+F3,FNFTA10M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Effective tenor – 10 year target tenor
+F3,FNFTA3M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Effective tenor – 3 year target tenor
+F3,FNFTA5M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Effective tenor – 5 year target tenor
+F3,FNFTA7M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Effective tenor – 7 year target tenor
+F3,FNFTBBB10M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Effective tenor – 10 year target tenor
+F3,FNFTBBB3M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Effective tenor – 3 year target tenor
+F3,FNFTBBB5M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Effective tenor – 5 year target tenor
+F3,FNFTBBB7M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Effective tenor – 7 year target tenor
+F3,FNFYA10M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Yield – 10 year target tenor
+F3,FNFYA3M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Yield – 3 year target tenor
+F3,FNFYA5M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Yield – 5 year target tenor
+F3,FNFYA7M,Bloomberg; RBA,f3-data.csv,Non-financial corporate A-rated bonds – Yield – 7 year target tenor
+F3,FNFYBBB10M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Yield – 10 year target tenor
+F3,FNFYBBB3M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Yield – 3 year target tenor
+F3,FNFYBBB5M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Yield – 5 year target tenor
+F3,FNFYBBB7M,Bloomberg; RBA,f3-data.csv,Non-financial corporate BBB-rated bonds – Yield – 7 year target tenor
+F5,FILRSAVIIO,RBA; Securitisation System,f5-data.csv,Lending rates; Securitised housing loans; Average outstanding variable rate; Investor; Interest Only
+F5,FILRSAVIPI,RBA; Securitisation System,f5-data.csv,Lending rates; Securitised housing loans; Average outstanding variable rate; Investor; Principal & Interest
+F5,FILRSAVOI,RBA; Securitisation System,f5-data.csv,Lending rates; Securitised housing loans; Average outstanding variable rate; Owner-occupier; Interest Only
+F5,FILRSAVOPI,RBA; Securitisation System,f5-data.csv,Lending rates; Securitised housing loans; Average outstanding variable rate; Owner-occupier; Principal & Interest
+F5,FILRSAVR,RBA; Securitisation System,f5-data.csv,Lending rates; Securitised housing loans; Average outstanding variable rate
+G3,GBUSEXP,NAB,g3-data.csv,Business inflation expectations – 3-months ahead
+G3,GCONEXP,MI,g3-data.csv,Consumer inflation expectations – 1-year ahead
+G3,GUNIEXPY,"WRC, ERA, ACTU",g3-data.csv,Union officials' inflation expectations – 1-year ahead
+G3,GUNIEXPYY,"WRC, ERA, ACTU",g3-data.csv,Union officials' inflation expectations – 2-year ahead
+H3,GICNBC,NAB,h3-data.csv,Business conditions
+H3,GICWMICS,MI,h3-data.csv,Consumer sentiment

--- a/models/au_rba_statistical_tables/code/excluded_series.csv
+++ b/models/au_rba_statistical_tables/code/excluded_series.csv
@@ -1,4 +1,4 @@
-table_code,series_id,source,source_file,title
+table_id,series_id,source,source_file,title
 D4,DSOGSAL,AOFM; State Borrowing Authorities,d4-data.csv,Long-term government securities issued in Australia
 D4,DSOGSAS,AOFM; Austraclear Limited,d4-data.csv,Short-term government securities issued in Australia
 D4,DSOLNAA,ABS; Bloomberg; RBA,d4-data.csv,Long-term non-government securities issued in Australia – Asset-backed

--- a/models/au_rba_statistical_tables/code/upload.py
+++ b/models/au_rba_statistical_tables/code/upload.py
@@ -1,0 +1,122 @@
+"""Upload cleaned au_rba_statistical_tables parquet to BigQuery staging.
+
+Usage:
+    uv run python models/au_rba_statistical_tables/code/upload.py [--env dev|prod] [table_slug ...]
+
+--env dev (default) -> basedosdados-dev. Point GOOGLE_APPLICATION_CREDENTIALS at
+the matching service account. Reads the cleaned parquet from $RBA_DATA/output
+(default ~/Downloads/au_rba_statistical_tables_data/output), which is never under
+the repo or Dropbox. Uploads smallest table first and stops on first failure.
+
+Note: prod table data is materialised by the table-approve action on merge, not
+by running this with --env prod. See .claude/rules/onboarding-workflow.md.
+"""
+
+import inspect
+import os
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+import basedosdados as bd  # noqa: E402
+import google.cloud.storage as gcs  # noqa: E402
+from google.cloud import bigquery  # noqa: E402
+
+_argv = sys.argv[1:]
+if "--env" in _argv:
+    _i = _argv.index("--env")
+    ENV = _argv[_i + 1]
+    _argv = _argv[:_i] + _argv[_i + 2 :]
+else:
+    ENV = "dev"
+
+BILLING_PROJECT = "basedosdados" if ENV == "prod" else "basedosdados-dev"
+DATASET_ID = "au_rba_statistical_tables"
+DATA_ROOT = Path(
+    os.environ.get(
+        "RBA_DATA",
+        Path.home() / "Downloads" / "au_rba_statistical_tables_data",
+    )
+)
+OUTPUT_ROOT = DATA_ROOT / "output"
+
+_orig_bucket = gcs.Client.bucket
+# `generation` was added to Client.bucket in a later google-cloud-storage; only
+# forward it when the installed version actually accepts it.
+_BUCKET_TAKES_GENERATION = (
+    "generation" in inspect.signature(_orig_bucket).parameters
+)
+
+
+def _patched_bucket(
+    self: gcs.Client,
+    bucket_name: str,
+    user_project: str | None = None,
+    generation: int | None = None,
+) -> "gcs.Bucket":
+    """Force ``user_project`` so the requester-pays bucket bills our project."""
+    kwargs: dict[str, object] = {"user_project": BILLING_PROJECT}
+    if _BUCKET_TAKES_GENERATION and generation is not None:
+        kwargs["generation"] = generation
+    return _orig_bucket(self, bucket_name, **kwargs)
+
+
+gcs.Client.bucket = _patched_bucket
+
+# (table_slug, expected_rows) — smallest first
+TABLES = [
+    ("dicionario", 5),
+    ("series_break", 2_034),
+    ("series", 3_861),
+    ("observation", 924_206),
+]
+
+
+def upload_table(slug: str, expected_rows: int) -> int:
+    """Upload one cleaned parquet table to BigQuery staging and verify the count."""
+    path = OUTPUT_ROOT / slug
+    if not path.exists():
+        raise FileNotFoundError(f"Missing output path: {path}")
+
+    tb = bd.Table(dataset_id=DATASET_ID, table_id=slug)
+
+    st = bd.Storage(dataset_id=DATASET_ID, table_id=slug)
+    try:
+        st.delete_table(mode="staging", not_found_ok=True)
+    except Exception as e:
+        print(f"  [warn] staging prefix cleanup: {e}")
+
+    tb.create(
+        path=str(path),
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="pass",
+    )
+
+    client = bigquery.Client(project=BILLING_PROJECT)
+    q = f"select count(*) as n from `{BILLING_PROJECT}.{DATASET_ID}_staging.{slug}`"
+    n = next(iter(client.query(q).result())).n
+    if n != expected_rows:
+        raise SystemExit(
+            f"  {slug}: uploaded {n:,} rows but expected {expected_rows:,} — aborting"
+        )
+    print(f"  {slug}: uploaded {n:,} rows (expected {expected_rows:,}) — OK")
+    return n
+
+
+def main() -> None:
+    """Upload each table in ``TABLES`` (smallest first), stopping on failure."""
+    targets = _argv or [t[0] for t in TABLES]
+    print(f"env={ENV} billing={BILLING_PROJECT} dataset={DATASET_ID}")
+    for slug, expected in TABLES:
+        if slug in targets:
+            print(f"[upload] {slug}")
+            upload_table(slug, expected)
+    print("done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_rba_statistical_tables/code/upload.py
+++ b/models/au_rba_statistical_tables/code/upload.py
@@ -70,7 +70,7 @@ TABLES = [
     ("dicionario", 5),
     ("series_break", 2_034),
     ("series", 3_861),
-    ("observation", 924_206),
+    ("data", 924_206),
 ]
 
 

--- a/models/au_rba_statistical_tables/schema.yml
+++ b/models/au_rba_statistical_tables/schema.yml
@@ -1,7 +1,7 @@
 ---
 version: 2
 models:
-  - name: au_rba_statistical_tables__observation
+  - name: au_rba_statistical_tables__data
     description: >-
       Long time-series table of Reserve Bank of Australia statistical-table
       observations, one row per statistical table, series and date, with the
@@ -10,7 +10,7 @@ models:
       source publishes under CC BY 4.0 (RBA, APRA, ABS).
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: [table_code, series_id, date]
+          combination_of_columns: [table_id, series_id, date]
       - not_null_proportion_multiple_columns:
           at_least: 0.05
       # Composite foreign key to the series catalogue. dbt's built-in
@@ -18,8 +18,8 @@ models:
       # unique across tables, so the key is compared as a concatenation.
       - dbt_utils.expression_is_true:
           expression: >-
-            concat(table_code, '|', series_id) in (
-              select concat(s.table_code, '|', s.series_id)
+            concat(table_id, '|', series_id) in (
+              select concat(s.table_id, '|', s.series_id)
               from {{ ref('au_rba_statistical_tables__series') }} as s
             )
     columns:
@@ -36,7 +36,7 @@ models:
           period for monthly, quarterly and semiannual series, and the exact date
           for daily series
         tests: [not_null]
-      - name: table_code
+      - name: table_id
         description: >-
           Code of the RBA statistical table the series belongs to, such as F1, D3
           or B13.1
@@ -44,7 +44,7 @@ models:
       - name: series_id
         description: >-
           Series mnemonic assigned by the RBA, unique only in combination with
-          table_code
+          table_id
         tests: [not_null]
       - name: value
         description: >-
@@ -54,17 +54,17 @@ models:
     description: >-
       Metadata catalogue with one row per series in the dataset: title,
       description, unit, frequency, statistical treatment, originating source
-      agency, publication date and coverage dates. Keyed by table_code and
-      series_id together, because the RBA reuses 233 mnemonics across the B13.1.2
+      agency, publication date and coverage dates. Keyed by table_id and
+      series_id together, because the RBA reuses 228 mnemonics across the B13.1.2
       and B13.2.1 tables for different measures.
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: [table_code, series_id]
+          combination_of_columns: [table_id, series_id]
       - not_null_proportion_multiple_columns:
           at_least: 0.05
           ignore_values: [observation_start, observation_end]
     columns:
-      - name: table_code
+      - name: table_id
         description: >-
           Code of the RBA statistical table, such as F1, D3 or B13.1
         tests: [not_null]
@@ -89,7 +89,7 @@ models:
       - name: units
         description: >-
           Unit of measure of the series values, which defines the unit of the
-          value column in the observation table
+          value column in the data table
       - name: source
         description: >-
           Agency responsible for compiling the series, preserved to carry the
@@ -115,7 +115,7 @@ models:
           columns_covered_by_dictionary: [break_type]
           dictionary_model: ref('au_rba_statistical_tables__dicionario')
     columns:
-      - name: table_code
+      - name: table_id
         description: Code of the RBA statistical table the break refers to
         tests: [not_null]
       - name: table_name

--- a/models/au_rba_statistical_tables/schema.yml
+++ b/models/au_rba_statistical_tables/schema.yml
@@ -1,0 +1,160 @@
+---
+version: 2
+models:
+  - name: au_rba_statistical_tables__observation
+    description: >-
+      Long time-series table of Reserve Bank of Australia statistical-table
+      observations, one row per statistical table, series and date, with the
+      observed value. The unit of value varies by series and is given in the
+      units column of the series catalogue. Covers only series whose every named
+      source publishes under CC BY 4.0 (RBA, APRA, ABS).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [table_code, series_id, date]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+      # Composite foreign key to the series catalogue. dbt's built-in
+      # `relationships` test takes a single field, and series_id alone is not
+      # unique across tables, so the key is compared as a concatenation.
+      - dbt_utils.expression_is_true:
+          expression: >-
+            concat(table_code, '|', series_id) in (
+              select concat(s.table_code, '|', s.series_id)
+              from {{ ref('au_rba_statistical_tables__series') }} as s
+            )
+    columns:
+      - name: year
+        description: Reference year of the observation
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
+      - name: date
+        description: >-
+          Observation date, using the RBA's own dating convention: the end of the
+          period for monthly, quarterly and semiannual series, and the exact date
+          for daily series
+        tests: [not_null]
+      - name: table_code
+        description: >-
+          Code of the RBA statistical table the series belongs to, such as F1, D3
+          or B13.1
+        tests: [not_null]
+      - name: series_id
+        description: >-
+          Series mnemonic assigned by the RBA, unique only in combination with
+          table_code
+        tests: [not_null]
+      - name: value
+        description: >-
+          Observed value of the series; the unit depends on the series and is
+          given in the units column of the series table
+  - name: au_rba_statistical_tables__series
+    description: >-
+      Metadata catalogue with one row per series in the dataset: title,
+      description, unit, frequency, statistical treatment, originating source
+      agency, publication date and coverage dates. Keyed by table_code and
+      series_id together, because the RBA reuses 233 mnemonics across the B13.1.2
+      and B13.2.1 tables for different measures.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [table_code, series_id]
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          ignore_values: [observation_start, observation_end]
+    columns:
+      - name: table_code
+        description: >-
+          Code of the RBA statistical table, such as F1, D3 or B13.1
+        tests: [not_null]
+      - name: series_id
+        description: Series mnemonic assigned by the RBA
+        tests: [not_null]
+      - name: table_name
+        description: Name of the RBA statistical table the series belongs to
+      - name: title
+        description: Descriptive title of the series
+      - name: description
+        description: Detailed description of the series provided by the RBA
+      - name: frequency
+        description: >-
+          Observation frequency of the series, normalised to a controlled
+          vocabulary (Daily, Weekly, Monthly, Quarterly, Semiannual, Yearly, As
+          announced, See notes)
+      - name: series_type
+        description: >-
+          Statistical treatment applied to the series, such as Original,
+          Seasonally adjusted or Trend
+      - name: units
+        description: >-
+          Unit of measure of the series values, which defines the unit of the
+          value column in the observation table
+      - name: source
+        description: >-
+          Agency responsible for compiling the series, preserved to carry the
+          attribution required by CC BY 4.0
+      - name: publication_date
+        description: Publication date of the statistical table containing the series
+      - name: observation_start
+        description: Date of the first available observation of the series
+      - name: observation_end
+        description: >-
+          Date of the last available observation of the series; null for series
+          that carry no numeric observations
+  - name: au_rba_statistical_tables__series_break
+    description: >-
+      Structural breaks documented by the RBA for the banking and financial
+      aggregate tables, one row per break, giving the date, break type, affected
+      series title and the institutional change that caused it. Use it to
+      distinguish genuine discontinuities in the level series from data errors.
+    tests:
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+      - custom_dictionary_coverage:
+          columns_covered_by_dictionary: [break_type]
+          dictionary_model: ref('au_rba_statistical_tables__dicionario')
+    columns:
+      - name: table_code
+        description: Code of the RBA statistical table the break refers to
+        tests: [not_null]
+      - name: table_name
+        description: Name of the RBA statistical table the break refers to
+      - name: date
+        description: Date on which the break in the series occurred
+        tests: [not_null]
+      - name: break_type
+        description: >-
+          Code for the type of break in the series, decoded in the dicionario
+          table
+      - name: series_title
+        description: >-
+          Title of the affected series as written by the RBA; free text that does
+          not necessarily match the title column of the series table
+      - name: details
+        description: >-
+          Description of the institution or reporting change that caused the
+          break
+  - name: au_rba_statistical_tables__dicionario
+    description: >-
+      Dictionary of the coded values used in the dataset, mapping each key to a
+      human-readable label.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [id_tabela, nome_coluna, chave]
+    columns:
+      - name: id_tabela
+        description: >-
+          Slug of the au_rba_statistical_tables table the dictionary entry
+          describes
+        tests: [not_null]
+      - name: nome_coluna
+        description: Name of the column the dictionary entry describes
+        tests: [not_null]
+      - name: chave
+        description: Coded value exactly as stored in the data
+        tests: [not_null]
+      - name: cobertura_temporal
+        description: Temporal coverage of the key
+      - name: valor
+        description: Human-readable label corresponding to the coded value

--- a/pipelines/datasets/au_rba_statistical_tables/utils.py
+++ b/pipelines/datasets/au_rba_statistical_tables/utils.py
@@ -1,0 +1,578 @@
+"""Pure download + cleaning functions for au_rba_statistical_tables.
+
+No Prefect imports here — this module is the single source of truth for the
+transform, shared by the recurring pipeline (``tasks.py``) and the one-shot
+onboarding bootstrap under ``models/au_rba_statistical_tables/code/``.
+
+The RBA publishes each statistical table as a CSV with a metadata block keyed by
+row label (``Title``, ``Description``, ``Frequency``, ``Type``, ``Units``,
+``Source``, ``Publication date``, ``Series ID``) above a dated data block. Each
+data column is one series; the transform pivots that wide block into long
+``(table_code, series_id, date, value)`` rows and lifts the metadata block into
+a series catalogue.
+
+Two source properties drive the design:
+
+1. ``series_id`` is NOT globally unique. 233 mnemonics appear in both the
+   ``b13.1.2-*`` and ``b13.2.1-*`` tables carrying different values (827 of 834
+   overlapping cells differ). The key is therefore ``(table_code, series_id)``.
+
+2. Four file families are not ``(series_id, date)`` time series at all and are
+   excluded — see ``NON_TIMESERIES_PREFIXES``.
+
+Licence gate: only series every one of whose named sources publishes under
+CC BY 4.0 (RBA, APRA, ABS) are kept. See ``models/au_rba_statistical_tables/LICENCE.md``.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120 Safari/537.36"
+)
+BASE = "https://www.rba.gov.au"
+TABLES_INDEX = f"{BASE}/statistics/tables/"
+
+# Metadata row labels -> canonical field name. The second group is the legacy
+# layout used by a5-data.csv.
+META_LABELS = {
+    "title": "title",
+    "description": "description",
+    "frequency": "frequency",
+    "type": "series_type",
+    "units": "units",
+    "source": "source",
+    "publication date": "publication_date",
+    "series id": "series_id",
+    "mnemonic": "series_id",
+    "last updated": "publication_date",
+}
+
+# Families whose rows are transaction-, instrument-, or forecast-vintage-level
+# detail rather than a (series_id, date) time series. Including them would
+# produce ~20,700 duplicate keys and misstate the table's grain.
+#   a3-, a3.2-  open market operations / securities lending / switches
+#   f16.1-      per-bond semi-government detail
+#   j1-         market economists' forecasts, keyed by survey date AND target quarter
+NON_TIMESERIES_PREFIXES = ("a3-", "a3.2-", "f16.1-", "j1-")
+
+# Publishers that independently release under CC BY 4.0, so their material may be
+# redistributed under the RBA notice's "published licence terms" fallback.
+CCBY_PUBLISHERS = {"rba", "reserve bank of australia", "apra", "abs"}
+
+_MONTHS = [
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "may",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec",
+]
+_NUM_RE = re.compile(r"^-?\d+(\.\d+)?([eE][-+]?\d+)?$")
+
+# series_break.break_type is a coded value. The RBA repeats the same three
+# definitions verbatim in the preamble of all 32 series-breaks files, so they are
+# stable enough to hard-code as the dictionary.
+BREAK_TYPE_LABELS = {
+    "A": (
+        "Breaks in series due to the establishment of new banks. All new banks shown. "
+        "Date refers to the first month in which the institution reported as a bank."
+    ),
+    "B": (
+        "Breaks in series due to other changes in bank reporting. "
+        "Some smaller breaks are not listed."
+    ),
+    "C": (
+        "Breaks in series due to changes in the coverage and reporting of non-banks. "
+        "Other than the counterpart breaks associated with the conversion of NBFIs to banks "
+        "and transfer of assets and liabilities from NBFIs to banks. "
+        "Some smaller breaks are not listed."
+    ),
+    "B,C": "Break attributable to both a change in bank reporting (B) and in non-bank coverage (C).",
+    "Other": "Break not classified into types A, B or C by the RBA.",
+}
+
+# The RBA's Frequency field carries case drift and one persistent typo
+# ("Semiannnual"). Normalised to a small controlled vocabulary.
+_FREQ_CANON = {
+    "daily": "Daily",
+    "weekly": "Weekly",
+    "fortnightly": "Fortnightly",
+    "monthly": "Monthly",
+    "quarterly": "Quarterly",
+    "semiannual": "Semiannual",
+    "semiannnual": "Semiannual",
+    "semi-annual": "Semiannual",
+    "yearly": "Yearly",
+    "annual": "Yearly",
+    "as announced": "As announced",
+    "per operation": "Per operation",
+    "see notes": "See notes",
+}
+
+
+# --------------------------------------------------------------------------
+# download
+# --------------------------------------------------------------------------
+def list_csv_urls(session: requests.Session | None = None) -> list[str]:
+    """Scrape the statistical-tables index for every CSV path."""
+    session = session or requests.Session()
+    resp = session.get(
+        TABLES_INDEX, headers={"User-Agent": USER_AGENT}, timeout=120
+    )
+    resp.raise_for_status()
+    paths = sorted(
+        set(
+            re.findall(
+                r'href="(/statistics/tables/csv/[^"]+\.csv)"', resp.text
+            )
+        )
+    )
+    return [BASE + p for p in paths]
+
+
+def download_all(dest: Path, throttle: float = 0.3) -> list[Path]:
+    """Download every statistical-table CSV into ``dest``. Returns saved paths."""
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    session = requests.Session()
+    out = []
+    for url in list_csv_urls(session):
+        target = dest / url.rsplit("/", 1)[-1]
+        resp = session.get(
+            url, headers={"User-Agent": USER_AGENT}, timeout=180
+        )
+        if resp.status_code != 200:
+            continue
+        target.write_bytes(resp.content)
+        out.append(target)
+        time.sleep(throttle)
+    return out
+
+
+# --------------------------------------------------------------------------
+# parsing primitives
+# --------------------------------------------------------------------------
+def parse_date(raw: str) -> str | None:
+    """RBA mixes ``dd-Mon-yyyy`` and ``dd/mm/yyyy``. Return ISO date or None."""
+    s = (raw or "").strip()
+    if not s:
+        return None
+    m = re.fullmatch(r"(\d{1,2})-([A-Za-z]{3})-(\d{2,4})", s)
+    if m:
+        try:
+            mo = _MONTHS.index(m.group(2).lower()) + 1
+        except ValueError:
+            return None
+        year = int(m.group(3))
+        if year < 100:  # legacy two-digit year, e.g. "08-Oct-25"
+            year += 2000 if year < 70 else 1900
+        return f"{year:04d}-{mo:02d}-{int(m.group(1)):02d}"
+    m = re.fullmatch(r"(\d{1,2})/(\d{1,2})/(\d{4})", s)
+    if m:
+        return f"{int(m.group(3)):04d}-{int(m.group(2)):02d}-{int(m.group(1)):02d}"
+    return None
+
+
+def parse_value(raw: str) -> float | None:
+    """Numeric value, or None when the cell carries no number.
+
+    Handles RBA formatting drift: a ``$`` prefix appears in f9 from 2020,
+    thousands separators appear sporadically, and ``N/A`` marks an explicit gap.
+    Cells that are still non-numeric — such as the ``"17.00 to 17.50"`` target
+    ranges in a2 — become None; the source carries those as prose, not data.
+    """
+    s = (raw or "").strip()
+    # The en dash is a real missing-value marker in the RBA files, not a typo.
+    if not s or s.upper() in {"N/A", "NA", "-", "–", "..", "."}:  # noqa: RUF001
+        return None
+    s = s.replace("$", "").replace(",", "").replace(" ", "")
+    if s.startswith("(") and s.endswith(")"):  # accounting negative
+        s = "-" + s[1:-1]
+    if not _NUM_RE.match(s):
+        return None
+    return float(s)
+
+
+def normalise_frequency(raw: str) -> str:
+    """Fold the Frequency field onto a controlled vocabulary."""
+    s = (raw or "").strip()
+    return _FREQ_CANON.get(s.lower(), s)
+
+
+def is_redistributable(source: str) -> bool:
+    """True when every publisher named in ``Source`` releases under CC BY 4.0.
+
+    Splitting on ``; / ,`` and newlines, every token must be in
+    ``CCBY_PUBLISHERS``. This drops the commercial-vendor series (Bloomberg,
+    Refinitiv, ASX, FENICS, Austraclear, ...) including mixed attributions such
+    as ``"Bloomberg; RBA"``, where the vendor's content is inseparable.
+    """
+    if not source or not source.strip():
+        return False
+    tokens = [
+        t.strip().lower() for t in re.split(r"[;/,\n]+", source) if t.strip()
+    ]
+    return bool(tokens) and all(t in CCBY_PUBLISHERS for t in tokens)
+
+
+def table_code_and_name(header: str) -> tuple[str, str]:
+    """Split ``"F1 INTEREST RATES AND YIELDS – MONEY MARKET"`` into code + name."""  # noqa: RUF002
+    h = (header or "").strip()
+    m = re.match(r"^([A-Z]\d+(?:\.\d+)*)\s+(.*)$", h)
+    if m:
+        return m.group(1), m.group(2).strip()
+    return "", h
+
+
+def is_timeseries_file(name: str) -> bool:
+    """False for the transaction/instrument/forecast detail families."""
+    return not name.startswith(NON_TIMESERIES_PREFIXES)
+
+
+# --------------------------------------------------------------------------
+# table parsing
+# --------------------------------------------------------------------------
+@dataclass
+class ParsedTable:
+    file: str
+    table_code: str
+    table_name: str
+    series: list[dict] = field(default_factory=list)
+    # (table_code, series_id, iso_date, value)
+    observations: list[tuple] = field(default_factory=list)
+    skipped_reason: str = ""
+
+
+def parse_table(path: Path) -> ParsedTable:
+    """Parse one RBA statistical-table CSV into series metadata + long observations."""
+    path = Path(path)
+    rows = list(
+        csv.reader(
+            io.StringIO(path.read_text(encoding="utf-8-sig", errors="replace"))
+        )
+    )
+    if not rows:
+        return ParsedTable(path.name, "", "", skipped_reason="empty file")
+
+    code, name = table_code_and_name(rows[0][0] if rows[0] else "")
+    out = ParsedTable(path.name, code, name)
+
+    meta: dict[str, list[str]] = {}
+    data_start = None
+    for i, row in enumerate(rows):
+        if not row or not row[0].strip():
+            continue
+        label = row[0].strip().lower()
+        if label in META_LABELS:
+            # First occurrence wins; trailing note blocks can repeat a label.
+            meta.setdefault(META_LABELS[label], row[1:])
+        elif parse_date(row[0]):
+            data_start = i
+            break
+
+    if not meta.get("series_id") or data_start is None:
+        out.skipped_reason = "no Series ID / Mnemonic block, or no dated rows"
+        return out
+
+    sids = [s.strip() for s in meta["series_id"]]
+
+    def col(fieldname, j):
+        vals = meta.get(fieldname) or []
+        return vals[j].strip() if j < len(vals) else ""
+
+    keep_idx: dict[int, str] = {}
+    for j, sid in enumerate(sids):
+        if not sid or sid in keep_idx.values():
+            continue  # blank, or a mnemonic repeated within one file (f16.1)
+        source = col("source", j)
+        out.series.append(
+            {
+                "table_code": code,
+                "series_id": sid,
+                "table_name": name,
+                "title": col("title", j),
+                "description": col("description", j),
+                "frequency": normalise_frequency(col("frequency", j)),
+                "series_type": col("series_type", j),
+                "units": col("units", j),
+                "source": source.replace("\n", " ").strip(),
+                "publication_date": parse_date(col("publication_date", j)),
+                "source_file": path.name,
+                "redistributable": is_redistributable(source),
+            }
+        )
+        keep_idx[j] = sid
+
+    for row in rows[data_start:]:
+        if not row:
+            continue
+        iso = parse_date(row[0])
+        if not iso:
+            continue
+        for j, sid in keep_idx.items():
+            val = parse_value(row[j + 1] if j + 1 < len(row) else "")
+            if val is None:
+                continue  # drops empty future padding rows and N/A gaps
+            out.observations.append((code, sid, iso, val))
+
+    return out
+
+
+def parse_series_breaks(path: Path) -> list[dict]:
+    """Parse a ``*-series-breaks.csv`` into rows.
+
+    Layout: prose preamble, a ``Date,Break type,Series title,Details`` header,
+    then the break rows.
+    """
+    path = Path(path)
+    rows = list(
+        csv.reader(
+            io.StringIO(path.read_text(encoding="utf-8-sig", errors="replace"))
+        )
+    )
+    if not rows:
+        return []
+    code, name = table_code_and_name(rows[0][0] if rows[0] else "")
+    header_i = next(
+        (
+            i
+            for i, r in enumerate(rows)
+            if r and r[0].strip().lower() == "date" and len(r) >= 3
+        ),
+        None,
+    )
+    if header_i is None:
+        return []
+
+    out = []
+    for row in rows[header_i + 1 :]:
+        if not row or not row[0].strip():
+            continue
+        iso = parse_date(row[0])
+        if not iso:
+            continue
+
+        def cell(k, _row=row):
+            return _row[k].strip() if k < len(_row) else ""
+
+        out.append(
+            {
+                "table_code": code,
+                "table_name": name,
+                "date": iso,
+                "break_type": cell(1),
+                "series_title": cell(2),
+                "details": cell(3),
+            }
+        )
+    return out
+
+
+# --------------------------------------------------------------------------
+# orchestration
+# --------------------------------------------------------------------------
+def clean_all(input_dir: Path) -> dict:
+    """Parse every CSV in ``input_dir`` into the three output tables.
+
+    Returns ``{"observation", "series", "series_break", "excluded", "skipped"}``.
+    Licence gate and the non-time-series family filter are both applied here.
+    """
+    files = sorted(Path(input_dir).glob("*.csv"))
+    series_all, obs_all, breaks, skipped = [], [], [], []
+
+    for path in files:
+        if path.name.endswith("-series-breaks.csv"):
+            breaks.extend(parse_series_breaks(path))
+            continue
+        if not is_timeseries_file(path.name):
+            skipped.append(
+                {"file": path.name, "reason": "non-time-series family"}
+            )
+            continue
+        parsed = parse_table(path)
+        if parsed.skipped_reason:
+            skipped.append(
+                {"file": path.name, "reason": parsed.skipped_reason}
+            )
+            continue
+        series_all.extend(parsed.series)
+        obs_all.extend(parsed.observations)
+
+    keep = {
+        (s["table_code"], s["series_id"])
+        for s in series_all
+        if s["redistributable"]
+    }
+    excluded = [s for s in series_all if not s["redistributable"]]
+    observations = [o for o in obs_all if (o[0], o[1]) in keep]
+
+    # Derive per-series coverage from the observations actually kept.
+    span: dict[tuple, list] = defaultdict(lambda: [None, None])
+    for tc, sid, iso, _ in observations:
+        cur = span[(tc, sid)]
+        if cur[0] is None or iso < cur[0]:
+            cur[0] = iso
+        if cur[1] is None or iso > cur[1]:
+            cur[1] = iso
+
+    series = []
+    for s in series_all:
+        if not s["redistributable"]:
+            continue
+        start, end = span.get((s["table_code"], s["series_id"]), (None, None))
+        rec = {
+            k: v
+            for k, v in s.items()
+            if k not in {"redistributable", "source_file"}
+        }
+        rec["observation_start"] = start
+        rec["observation_end"] = end
+        series.append(rec)
+
+    # Dictionary for the one coded column in the dataset.
+    used_types = sorted({b["break_type"] for b in breaks if b["break_type"]})
+    dicionario = [
+        {
+            "id_tabela": "series_break",
+            "nome_coluna": "break_type",
+            "chave": code,
+            "cobertura_temporal": "",
+            "valor": BREAK_TYPE_LABELS.get(code, ""),
+        }
+        for code in used_types
+    ]
+
+    return {
+        "observation": observations,
+        "series": series,
+        "series_break": breaks,
+        "dicionario": dicionario,
+        "excluded": excluded,
+        "skipped": skipped,
+        "n_files": len(files),
+    }
+
+
+# --------------------------------------------------------------------------
+# parquet output — all-STRING staging (see .claude/rules/bigquery-conventions.md)
+# --------------------------------------------------------------------------
+def _string_table(rows: list[dict], columns: list[str]) -> pa.Table:
+    """Build an all-STRING arrow table with a stable column order.
+
+    Cast through arrow rather than ``astype(str)``: the latter renders NULL as
+    the literal ``"nan"``, which ``safe_cast`` will not turn back into NULL.
+    """
+    arrays = []
+    for c in columns:
+        vals = [r.get(c) for r in rows]
+        if vals and any(
+            isinstance(v, (int, float)) and not isinstance(v, bool)
+            for v in vals
+        ):
+            arr = pa.array(vals)  # let arrow infer the real type first
+            arr = arr.cast(pa.string())
+        else:
+            arr = pa.array(
+                [None if v is None else str(v) for v in vals], type=pa.string()
+            )
+        arrays.append(arr)
+    return pa.Table.from_arrays(arrays, names=columns)
+
+
+OBSERVATION_COLUMNS = ["year", "date", "table_code", "series_id", "value"]
+SERIES_COLUMNS = [
+    "table_code",
+    "series_id",
+    "table_name",
+    "title",
+    "description",
+    "frequency",
+    "series_type",
+    "units",
+    "source",
+    "publication_date",
+    "observation_start",
+    "observation_end",
+]
+SERIES_BREAK_COLUMNS = [
+    "table_code",
+    "table_name",
+    "date",
+    "break_type",
+    "series_title",
+    "details",
+]
+DICIONARIO_COLUMNS = [
+    "id_tabela",
+    "nome_coluna",
+    "chave",
+    "cobertura_temporal",
+    "valor",
+]
+
+
+def write_partitioned(cleaned: dict, output_dir: Path) -> dict:
+    """Write the three tables as all-STRING parquet. Returns row counts.
+
+    ``observation`` is hive-partitioned by ``year``; the two small catalogue
+    tables are single files.
+    """
+    output_dir = Path(output_dir)
+    counts = {}
+
+    by_year: dict[str, list[dict]] = defaultdict(list)
+    for tc, sid, iso, value in cleaned["observation"]:
+        by_year[iso[:4]].append(
+            {
+                "year": iso[:4],
+                "date": iso,
+                "table_code": tc,
+                "series_id": sid,
+                "value": value,
+            }
+        )
+    total = 0
+    for year, rows in sorted(by_year.items()):
+        d = output_dir / "observation" / f"year={year}"
+        d.mkdir(parents=True, exist_ok=True)
+        # `year` is the partition key: hive-encoded in the path, dropped from the file.
+        cols = [c for c in OBSERVATION_COLUMNS if c != "year"]
+        pq.write_table(
+            _string_table(rows, cols), d / "data.parquet", compression="snappy"
+        )
+        total += len(rows)
+    counts["observation"] = total
+
+    for name, cols in (
+        ("series", SERIES_COLUMNS),
+        ("series_break", SERIES_BREAK_COLUMNS),
+        ("dicionario", DICIONARIO_COLUMNS),
+    ):
+        rows = cleaned[name]
+        d = output_dir / name
+        d.mkdir(parents=True, exist_ok=True)
+        pq.write_table(
+            _string_table(rows, cols), d / "data.parquet", compression="snappy"
+        )
+        counts[name] = len(rows)
+
+    return counts

--- a/pipelines/datasets/au_rba_statistical_tables/utils.py
+++ b/pipelines/datasets/au_rba_statistical_tables/utils.py
@@ -8,14 +8,14 @@ The RBA publishes each statistical table as a CSV with a metadata block keyed by
 row label (``Title``, ``Description``, ``Frequency``, ``Type``, ``Units``,
 ``Source``, ``Publication date``, ``Series ID``) above a dated data block. Each
 data column is one series; the transform pivots that wide block into long
-``(table_code, series_id, date, value)`` rows and lifts the metadata block into
+``(table_id, series_id, date, value)`` rows and lifts the metadata block into
 a series catalogue.
 
 Two source properties drive the design:
 
-1. ``series_id`` is NOT globally unique. 233 mnemonics appear in both the
+1. ``series_id`` is NOT globally unique. 228 mnemonics appear in both the
    ``b13.1.2-*`` and ``b13.2.1-*`` tables carrying different values (827 of 834
-   overlapping cells differ). The key is therefore ``(table_code, series_id)``.
+   overlapping cells differ). The key is therefore ``(table_id, series_id)``.
 
 2. Four file families are not ``(series_id, date)`` time series at all and are
    excluded — see ``NON_TIMESERIES_PREFIXES``.
@@ -234,7 +234,7 @@ def is_redistributable(source: str) -> bool:
     return bool(tokens) and all(t in CCBY_PUBLISHERS for t in tokens)
 
 
-def table_code_and_name(header: str) -> tuple[str, str]:
+def table_id_and_name(header: str) -> tuple[str, str]:
     """Split ``"F1 INTEREST RATES AND YIELDS – MONEY MARKET"`` into code + name."""  # noqa: RUF002
     h = (header or "").strip()
     m = re.match(r"^([A-Z]\d+(?:\.\d+)*)\s+(.*)$", h)
@@ -254,10 +254,10 @@ def is_timeseries_file(name: str) -> bool:
 @dataclass
 class ParsedTable:
     file: str
-    table_code: str
+    table_id: str
     table_name: str
     series: list[dict] = field(default_factory=list)
-    # (table_code, series_id, iso_date, value)
+    # (table_id, series_id, iso_date, value)
     observations: list[tuple] = field(default_factory=list)
     skipped_reason: str = ""
 
@@ -273,7 +273,7 @@ def parse_table(path: Path) -> ParsedTable:
     if not rows:
         return ParsedTable(path.name, "", "", skipped_reason="empty file")
 
-    code, name = table_code_and_name(rows[0][0] if rows[0] else "")
+    code, name = table_id_and_name(rows[0][0] if rows[0] else "")
     out = ParsedTable(path.name, code, name)
 
     meta: dict[str, list[str]] = {}
@@ -306,7 +306,7 @@ def parse_table(path: Path) -> ParsedTable:
         source = col("source", j)
         out.series.append(
             {
-                "table_code": code,
+                "table_id": code,
                 "series_id": sid,
                 "table_name": name,
                 "title": col("title", j),
@@ -351,7 +351,7 @@ def parse_series_breaks(path: Path) -> list[dict]:
     )
     if not rows:
         return []
-    code, name = table_code_and_name(rows[0][0] if rows[0] else "")
+    code, name = table_id_and_name(rows[0][0] if rows[0] else "")
     header_i = next(
         (
             i
@@ -376,7 +376,7 @@ def parse_series_breaks(path: Path) -> list[dict]:
 
         out.append(
             {
-                "table_code": code,
+                "table_id": code,
                 "table_name": name,
                 "date": iso,
                 "break_type": cell(1),
@@ -393,7 +393,7 @@ def parse_series_breaks(path: Path) -> list[dict]:
 def clean_all(input_dir: Path) -> dict:
     """Parse every CSV in ``input_dir`` into the three output tables.
 
-    Returns ``{"observation", "series", "series_break", "excluded", "skipped"}``.
+    Returns ``{"data", "series", "series_break", "excluded", "skipped"}``.
     Licence gate and the non-time-series family filter are both applied here.
     """
     files = sorted(Path(input_dir).glob("*.csv"))
@@ -418,7 +418,7 @@ def clean_all(input_dir: Path) -> dict:
         obs_all.extend(parsed.observations)
 
     keep = {
-        (s["table_code"], s["series_id"])
+        (s["table_id"], s["series_id"])
         for s in series_all
         if s["redistributable"]
     }
@@ -438,7 +438,7 @@ def clean_all(input_dir: Path) -> dict:
     for s in series_all:
         if not s["redistributable"]:
             continue
-        start, end = span.get((s["table_code"], s["series_id"]), (None, None))
+        start, end = span.get((s["table_id"], s["series_id"]), (None, None))
         rec = {
             k: v
             for k, v in s.items()
@@ -462,7 +462,7 @@ def clean_all(input_dir: Path) -> dict:
     ]
 
     return {
-        "observation": observations,
+        "data": observations,
         "series": series,
         "series_break": breaks,
         "dicionario": dicionario,
@@ -498,9 +498,9 @@ def _string_table(rows: list[dict], columns: list[str]) -> pa.Table:
     return pa.Table.from_arrays(arrays, names=columns)
 
 
-OBSERVATION_COLUMNS = ["year", "date", "table_code", "series_id", "value"]
+DATA_COLUMNS = ["year", "date", "table_id", "series_id", "value"]
 SERIES_COLUMNS = [
-    "table_code",
+    "table_id",
     "series_id",
     "table_name",
     "title",
@@ -514,7 +514,7 @@ SERIES_COLUMNS = [
     "observation_end",
 ]
 SERIES_BREAK_COLUMNS = [
-    "table_code",
+    "table_id",
     "table_name",
     "date",
     "break_type",
@@ -533,34 +533,34 @@ DICIONARIO_COLUMNS = [
 def write_partitioned(cleaned: dict, output_dir: Path) -> dict:
     """Write the three tables as all-STRING parquet. Returns row counts.
 
-    ``observation`` is hive-partitioned by ``year``; the two small catalogue
+    ``data`` is hive-partitioned by ``year``; the two small catalogue
     tables are single files.
     """
     output_dir = Path(output_dir)
     counts = {}
 
     by_year: dict[str, list[dict]] = defaultdict(list)
-    for tc, sid, iso, value in cleaned["observation"]:
+    for tc, sid, iso, value in cleaned["data"]:
         by_year[iso[:4]].append(
             {
                 "year": iso[:4],
                 "date": iso,
-                "table_code": tc,
+                "table_id": tc,
                 "series_id": sid,
                 "value": value,
             }
         )
     total = 0
     for year, rows in sorted(by_year.items()):
-        d = output_dir / "observation" / f"year={year}"
+        d = output_dir / "data" / f"year={year}"
         d.mkdir(parents=True, exist_ok=True)
         # `year` is the partition key: hive-encoded in the path, dropped from the file.
-        cols = [c for c in OBSERVATION_COLUMNS if c != "year"]
+        cols = [c for c in DATA_COLUMNS if c != "year"]
         pq.write_table(
             _string_table(rows, cols), d / "data.parquet", compression="snappy"
         )
         total += len(rows)
-    counts["observation"] = total
+    counts["data"] = total
 
     for name, cols in (
         ("series", SERIES_COLUMNS),


### PR DESCRIPTION
## What

Onboards the **Reserve Bank of Australia statistical tables** (`au_rba_statistical_tables`) — the Australian analogue of the already-onboarded `us_fed_fred`.

**924,206 observations · 3,861 series · 81 RBA statistical tables · 1922-06-30 → 2026-09-30**

| Table | Rows | Grain |
|---|---:|---|
| `data` | 924,206 | one row per (table_id, series_id, date) |
| `series` | 3,861 | series catalogue, keyed (table_id, series_id) |
| `series_break` | 2,034 | structural breaks documented by the RBA |
| `dicionario` | 5 | decodes `series_break.break_type` |

Covers the cash rate, market and lending rates, monetary and credit aggregates, exchange rates and banking statistics. Daily, weekly, monthly, quarterly, semiannual and yearly frequencies.

## Three source properties that shaped the design

**1. `series_id` is not globally unique.** 228 mnemonics appear in both `b13.1.2-*` and `b13.2.1-*` carrying genuinely different values — the BIS immediate-risk-basis vs ultimate-risk-basis pair:

```
BFC5R  [B13.1.2] Foreign claims: By country: Immediate risk basis: Developed countries
       [B13.2.1] Foreign claims by country: Ultimate risk basis: Developed countries

BFC1C  2026-03-31   B13.1.2 = 27,090.0   vs   B13.2.1 = 24,760.4
BFC1N  2026-03-31   B13.1.2 = 141,490.2  vs   B13.2.1 = 106,693.6
```

So the key is `(table_id, series_id, date)`. Keying on `series_id` alone would silently collapse 228 series into 114, mixing the two bases in one line. dbt enforces the composite key, and the FK to the catalogue is compared as a concatenation because dbt's built-in `relationships` test takes a single field.

**2. Four file families are not time series and are excluded** — including them produced ~20,700 duplicate keys:

| Family | What it actually is |
|---|---|
| `a3-`, `a3.2-` | open market operation / securities lending transaction detail (many rows per day) |
| `f16.1-` | per-bond semi-government detail |
| `j1-` | market economists' forecasts, keyed by survey date **and** target quarter |

These need a different grain and would be a separate dataset.

**3. Licence — the gate is per series, and the RBA labels it for us.** RBA material is CC BY 4.0 *except* Third Party Material, which is Excluded Material. The notice's second limb catches `Source = "ABS / RBA"` too — naming the RBA alongside a third party does not make it CC BY.

Each CSV carries a per-series `Source` row, which *is* that label, so the filter is mechanical and auditable: **keep only series whose every named publisher releases under CC BY 4.0**. APRA and ABS qualify on their own copyright pages, which is exactly the "published licence terms" fallback the RBA notice names. **75 series** sourced from commercial vendors (Bloomberg, Refinitiv, ASX, FENICS, Austraclear, NAB, WM/Reuters, IMF, Melbourne Institute) are dropped and listed in `code/excluded_series.csv`.

Full reasoning: `models/au_rba_statistical_tables/LICENCE.md`.

All tables are registered **AllFree** — no BD Pro window. RBA Section 4 lists, as prohibited "improper commercial exploitation", charging for the Cash Rate without disclosing it is free at source; an all-free dataset cannot engage that condition.

## Verified in dev

- 4 models built with exact expected row counts
- **20/20 dbt tests pass**, including the composite-key uniqueness and the composite FK (checked non-vacuous: swapping in a bogus catalogue fails all 924,206 rows)
- Values cross-checked against the source CSVs — F1 cash rate `4.35` at 2026-08-17, D3 currency `105.3` at 2026-06-30
- Staging metadata registered and published; prod metadata registered `under_review`

## Notes for review

- The cleaning transform lives in `pipelines/datasets/au_rba_statistical_tables/utils.py`, not under `models/`, so the forthcoming daily pipeline shares it rather than duplicating it. `models/.../code/clean.py` imports it.
- Only 2 rows are dated after today: G3 *inflation expectations* for the September quarter — a forward-looking survey series, legitimately dated at the target quarter end.
- 31 catalogue series carry no numeric observations (all-empty in the source); `observation_start`/`observation_end` are null for those and excluded from the not-null-proportion test.
- A recurring daily pipeline is deliberately **not** in this PR — it follows as a separate one, per the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Australian Reserve Bank statistical tables covering historical observations from 1922 onward.
  - Added searchable metadata for series, table definitions, coded values, and documented series breaks.
  - Added standardized dates, identifiers, frequencies, units, sources, and observed values.
  - Added partitioned data delivery to support efficient access to long-term time series.

- **Data Quality**
  - Added validation for duplicate records, missing values, orphaned series, dates, and row counts.
  - Applied licensing and redistribution rules, including attribution requirements and excluded sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->