### PR TITLE
fix(br_bcb_estban): add cnpj_basico to agencia unique key

### DIFF
--- a/models/br_bcb_estban/schema.yml
+++ b/models/br_bcb_estban/schema.yml
@@ -79,6 +79,7 @@ models:
             - ano
             - mes
             - id_municipio
+            - cnpj_basico
             - cnpj_agencia
             - id_verbete
           config:


### PR DESCRIPTION
## Problema

O flow `br_bcb_estban__agencia` falha no passo `dbt test`, no teste
`dbt_utils.unique_combination_of_columns`:

```
Got 45 results, configured to fail if != 0
```

Última ocorrência: run `ivory-seahorse` (`acf10912-9a0b-449d-ac22-1b1b5205a5f1`),
2026-08-18. O poll, o download, a limpeza, o upload e o `dbt run` funcionaram —
a correção do PR #1783 está OK. A falha é só no teste.

## Causa

Não é duplicação de ingestão. Todos os 45 grupos duplicados (585 linhas) estão em
Brasília (`id_municipio = 5300108`), onde **treze instituições distintas
compartilham o mesmo `cnpj_agencia`**: `00000000000191`, o CNPJ do Banco do
Brasil. O valor vem direto da coluna `AGENCIA` da fonte — a limpeza em
`pipelines/crawler/bcb_estban/utils.py` só remove apóstrofos.

Ou seja, a chave do teste está incompleta: `cnpj_agencia` sozinho não identifica
a linha.

Como o teste é escopado em `__most_recent_year_month__`, ele falha sempre que a
competência mais recente carrega a colisão — 3 dos últimos 5 meses:

| competência | grupos duplicados (chave atual) |
|---|---|
| 2025-11 | 45 (também em prod) |
| 2025-12 | 0 |
| 2026-01 | 45 |
| 2026-02 | 45 |
| 2026-03 | 45 |

## Correção

Incluir `cnpj_basico` na chave — a mesma coluna que a tabela `municipio` já usa.

Verificado no BigQuery: **0 grupos duplicados** com a chave nova, tanto em
`basedosdados-dev` 2026-03 quanto em `basedosdados` 2025-11.

## Notas

- Só mexe em teste; nenhum modelo `.sql` muda, então **não precisa de
  `table-approve`** nem de `deploy-flow`. O worker clona `main` em tempo de
  execução, então basta o merge.
- Sem isso, armar o schedule do `agencia` significa falha em toda run.
- **Fora do escopo, mas registrado:** a tabela `municipio` tem um carve-out
  pré-existente (`id_municipio not in ('5300108')`) que mascara 270 grupos
  duplicados em 2026-03 — mesma causa raiz, em Brasília.
