### PR TITLE
[Fix] metadata: ignorar datas futuras ao ler a data máxima de cobertura

### DIFF
--- a/pipelines/utils/metadata/utils.py
+++ b/pipelines/utils/metadata/utils.py
@@ -120,12 +120,33 @@ def extract_last_date_from_bq(
 
     query_date_column = format_date_column(date_column)
 
+    # Coverage dates in the future are filer typos, not real coverage, and a
+    # handful of them distorts the whole BD Pro window: `free_end` is
+    # `max_date - free_lag`, so an impossible date pushes the boundary forward
+    # and releases for free the period that should be paid. In
+    # us_fec_campaign_finance, 71 rows dated up to 2026-12-31 (against a real
+    # maximum of 2026-07-31) shrank the paid window from 8,614,269 rows to
+    # 25,277.
+    #
+    # The filter applies only to date columns (`{'date'}`). Year, year/month
+    # and year/quarter are deliberately left out: there the value labels a
+    # period, and a future label is often legitimate — budget year, crop year,
+    # school year — so filtering would shrink the coverage of correct datasets.
+    # `_max_transaction_date` in us_fec_campaign_finance/utils.py already
+    # applies this rule to the poll; this aligns coverage with what the poll
+    # was already doing.
+    date_filter = (
+        f"\n        WHERE {query_date_column} <= CURRENT_DATE()"
+        if date_column.keys() == {"date"}
+        else ""
+    )
+
     try:
         query_bd = f"""
         SELECT
         MAX({query_date_column}) as max_date
         FROM
-        `{project_id}.{dataset_id}.{table_id}`
+        `{project_id}.{dataset_id}.{table_id}`{date_filter}
         """
         log(query_bd)
         t = bd.read_sql(

--- a/pipelines/utils/tests/metadata/test_policy.py
+++ b/pipelines/utils/tests/metadata/test_policy.py
@@ -139,9 +139,11 @@ def test_compute_part_bdpro_monthly_syncs_and_lags():
     assert (r.free.endYear, r.free.endMonth) == (2025, 12)
     # pyrefly: ignore [missing-attribute]
     assert r.free.endDay is None  # granularidade mensal
-    # R11: pro começa onde free termina
+    # R11: pro starts in the period after free ends — `free_end` is inclusive
+    # (the RAP grants `date <= free_end`), so free 2025-12 and pro 2026-01 do
+    # not overlap. See `test_compute_part_bdpro_ranges_never_overlap`.
     # pyrefly: ignore [missing-attribute]
-    assert (r.pro.startYear, r.pro.startMonth) == (2025, 12)
+    assert (r.pro.startYear, r.pro.startMonth) == (2026, 1)
     assert r.free_end == date(2025, 12, 1)
 
 

--- a/pipelines/utils/tests/metadata/test_utils.py
+++ b/pipelines/utils/tests/metadata/test_utils.py
@@ -1,0 +1,87 @@
+"""Tests for `extract_last_date_from_bq` — query construction.
+
+What matters here is the generated SQL: `test_bq.py` mocks the whole function,
+so without these tests the future-date filter is covered by nothing.
+"""
+
+import datetime
+from unittest.mock import patch
+
+import pandas as pd
+
+from pipelines.utils.metadata.utils import extract_last_date_from_bq
+
+
+def _query_for(date_column: dict, date_format: str = "%Y-%m-%d") -> str:
+    """Run the function with BigQuery mocked and return the SQL it built."""
+    captured = {}
+
+    def fake_read_sql(query, billing_project_id, from_file):
+        captured["query"] = query
+        return pd.DataFrame({"max_date": [datetime.date(2026, 7, 31)]})
+
+    with patch(
+        "pipelines.utils.metadata.utils.bd.read_sql", side_effect=fake_read_sql
+    ):
+        extract_last_date_from_bq(
+            dataset_id="ds",
+            table_id="tb",
+            date_format=date_format,
+            date_column=date_column,
+            billing_project_id="proj",
+        )
+    return captured["query"]
+
+
+def test_date_column_ignores_future_dates():
+    """Date column: future dates are filer typos and stay out.
+
+    Without this, a single row with an impossible date pushes `free_end`
+    forward and releases for free the window that should be BD Pro.
+    """
+    query = _query_for({"date": "transaction_date"})
+    assert "WHERE transaction_date <= CURRENT_DATE()" in query
+    assert "MAX(transaction_date)" in query
+
+
+def test_year_column_keeps_future_labels():
+    """Year labels a period: a future year is often legitimate (budget year,
+    crop year), so it is not filtered."""
+    query = _query_for({"year": "ano"}, date_format="%Y")
+    assert "CURRENT_DATE()" not in query
+    assert "MAX(DATE(ano,1,1))" in query
+
+
+def test_year_month_column_keeps_future_labels():
+    query = _query_for({"year": "ano", "month": "mes"}, date_format="%Y-%m")
+    assert "CURRENT_DATE()" not in query
+    assert "MAX(DATE(ano,mes,1))" in query
+
+
+def test_year_quarter_column_keeps_future_labels():
+    query = _query_for(
+        {"year": "ano", "quarter": "trimestre"}, date_format="%Y-%m"
+    )
+    assert "CURRENT_DATE()" not in query
+    assert "MAX(DATE(ano,trimestre*3,1))" in query
+
+
+def test_returned_date_is_parsed_with_the_given_format():
+    """The filter must not change the value that comes back."""
+    captured = {}
+
+    def fake_read_sql(query, billing_project_id, from_file):
+        captured["query"] = query
+        return pd.DataFrame({"max_date": [datetime.date(2026, 7, 31)]})
+
+    with patch(
+        "pipelines.utils.metadata.utils.bd.read_sql", side_effect=fake_read_sql
+    ):
+        out = extract_last_date_from_bq(
+            dataset_id="ds",
+            table_id="tb",
+            date_format="%Y-%m-%d",
+            date_column={"date": "transaction_date"},
+            billing_project_id="proj",
+        )
+    assert out == "2026-07-31"


### PR DESCRIPTION
## Descrição do PR

`extract_last_date_from_bq` fazia um `MAX` puro sobre a coluna de cobertura, então **uma única data impossível definia a cobertura da tabela**. Isso não é cosmético: `register_table_materialization_task` deriva a janela BD Pro daí, como `free_end = max_date - free_lag`. Uma data no futuro empurra o `free_end` para frente e **libera de graça justamente a janela recente que o paywall deveria cobrir**.

**Motivação/Contexto:** o caso concreto é o `us_fec_campaign_finance`. A FEC publica a data como declarada e quem declara erra: 71 linhas trazem datas até 2026-12-31, contra um máximo real da fonte de 2026-07-31. O efeito, medido nas tabelas de produção:

| | `contribution_individual` |
|---|---|
| Janela paga pretendida (2026-02-01 → 2026-07-31) | **8.614.269 linhas** |
| Janela que seria registrada (2026-07-01 → 2026-12-31) | **25.277 linhas** |
| Linhas depois do máximo real da fonte | **10** |

Ou seja: 10 linhas com data digitada errada reduziriam o paywall a 0,3% do pretendido, e a cobertura publicada no site passaria a afirmar dados até 2026-12-31 — que não existem.

Havia também uma **inconsistência interna**: o poll já ignorava datas futuras (`us_fec_campaign_finance/utils.py::_max_transaction_date` descarta qualquer valor posterior a hoje), enquanto o caminho da cobertura não. As duas noções de "máximo da fonte" discordavam, e quem mandava no paywall era justamente a sem proteção.

## Detalhes Técnicos

**Principais alterações:** acrescenta `WHERE <coluna> <= CURRENT_DATE()` à consulta de `extract_last_date_from_bq`.

**O filtro vale apenas para colunas de data (`{'date'}`).** Ano, ano/mês e ano/trimestre ficam de fora **de propósito**: nesses casos o valor rotula um período, e um rótulo futuro costuma ser legítimo — exercício orçamentário, ano-safra, ano letivo. Como ~57 flows usam esta função, um filtro cego encolheria silenciosamente a cobertura de bases corretas (por exemplo `br_cgu_emendas_parlamentares` ou `br_me_siconfi` com `ano=2027`). O SQL gerado para essas três formas continua **idêntico byte a byte**.

**Mudanças nos dados e no schema:** nenhuma. Nenhuma tabela é reescrita; muda apenas a data máxima lida ao registrar cobertura.

**Impacto no desempenho:** nenhum relevante — um predicado a mais em uma consulta de agregação.

## Teste e Validações

- [x] Testado localmente
- [ ] Testado na Cloud

Adiciona `pipelines/utils/tests/metadata/test_utils.py` (5 testes) fixando o SQL gerado. `test_bq.py` faz mock de `extract_last_date_from_bq` inteira, então **a consulta não tinha cobertura de teste nenhuma**.

```
pytest pipelines/utils/tests/metadata/ -q
142 passed
```

Verificado contra os dados reais de produção — com o filtro, o máximo lido passa a ser exatamente o máximo real da fonte nas quatro tabelas:

| Tabela | `max <= hoje` | Fim do pro registrado |
|---|---|---|
| contribution_individual | 2026-07-31 | 2026-07-31 ✓ |
| contribution_committee | 2026-07-31 | 2026-07-31 ✓ |
| committee_transaction | 2026-07-31 | 2026-07-31 ✓ |
| disbursement | 2026-08-12 | 2026-08-12 ✓ |

## Correção adicional (commit separado)

`test_compute_part_bdpro_monthly_syncs_and_lags` afirmava que o range pro começa no **mesmo** período em que o free termina (2025-12) — isto é, uma sobreposição. O código está certo ao começar no período **seguinte** (2026-01), já que `free_end` é inclusivo (a RAP concede `date <= free_end`). O teste irmão `test_compute_part_bdpro_ranges_never_overlap` exige exatamente isso, e a forma de referência documentada do `us_bls_cpi` é free `1913-01 .. 2025-12` com pro `2026-01 .. 2026-06`. A asserção ficou para trás quando a semântica foi apertada.

Passou despercebido porque **o CI nunca roda pytest** — nenhum workflow em `.github` o invoca. Toda a suíte de metadados, inclusive a lógica da janela BD Pro, está sem guarda automática. Vale ligar isso separadamente; aqui a suíte apenas volta a passar.

## Riscos e Mitigações

- **Risco:** uma base cuja coluna de data legitimamente contenha datas futuras teria a cobertura encurtada. Mitigação: o filtro se restringe a colunas de data, onde a data é a do fato observado; rótulos de período (ano/mês/trimestre), que é onde valores futuros são normais, não são tocados.
- **Planos de rollback:** reverter os commits. Nenhum dado é reescrito, então o rollback é imediato.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated date-based coverage calculations to exclude future dates.
  * Preserved existing behavior for year-, month-, and quarter-based coverage periods.
  * Corrected monthly coverage boundaries to prevent overlap between free and pro ranges.

* **Tests**
  * Added coverage for date filtering, period-based queries, maximum-date calculations, and date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->