### PR TITLE
[Fix] us_fec_campaign_finance: pipeline quebra ao ler a data máxima da partição

### DIFF
--- a/pipelines/datasets/us_fec_campaign_finance/utils.py
+++ b/pipelines/datasets/us_fec_campaign_finance/utils.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 import pandas as pd
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.parquet as pq
 import requests
 
@@ -682,9 +683,32 @@ def _max_transaction_date(partition: Path) -> str | None:
     today = date.today().isoformat()
     best = None
     for file in sorted(partition.glob("*.parquet")):
-        table = pq.read_table(file, columns=["transaction_date"])
-        column = table.column("transaction_date")
-        for value in column.to_pylist():
-            if value and value <= today and (best is None or value > best):
-                best = value
+        # ParquetFile, not pq.read_table: the latter defaults to
+        # partitioning="hive", reads `year` from the `year=YYYY` directory as
+        # dictionary<int32>, and tries to merge it with the STRING `year`
+        # column stored inside the file (staging is all-STRING by convention).
+        # The two do not merge: ArrowTypeError, Field year has incompatible
+        # types. This path is only reached by refresh_cycle, so the onboarding
+        # never exercised it.
+        #
+        # Read in batches because the largest partition holds 30.6M rows: the
+        # previous version called to_pylist() on the whole column, building
+        # tens of millions of Python strings inside an 8Gi worker.
+        parquet_file = pq.ParquetFile(file)
+        for batch in parquet_file.iter_batches(
+            columns=["transaction_date"], batch_size=1_000_000
+        ):
+            column = batch.column("transaction_date").drop_null()
+            if len(column) == 0:
+                continue
+            # Dates are ISO strings, so the lexicographic max is the calendar
+            # max. Future dates are filer typos and are ignored.
+            # pyarrow.compute builds less_equal/max dynamically, so static
+            # checkers cannot see them (cf. us_bea/utils.py).
+            column = column.filter(pc.less_equal(column, today))  # pyrefly: ignore
+            if len(column) == 0:
+                continue
+            candidate = pc.max(column).as_py()  # pyrefly: ignore
+            if candidate is not None and (best is None or candidate > best):
+                best = candidate
     return best


### PR DESCRIPTION
## Descrição do PR

**O pipeline recorrente do `us_fec_campaign_finance` nunca conseguiria completar uma execução.** A primeira rodada de verificação em dev falhou nas três tentativas, sempre no mesmo ponto — logo depois de limpar `contribution_individual`:

```
ArrowTypeError: Unable to merge: Field year has incompatible types:
string vs dictionary<values=int32, indices=int32, ordered=0>
```

Run: `blond-malamute` (`afaae64a-4cc3-4a52-ab24-5be471152806`), `Failed`.

**Motivação/Contexto:** `pq.read_table` usa `partitioning="hive"` por padrão. Ao ler `.../year=2026/data.parquet`, ela deduz `year` do nome do diretório como `dictionary<int32>` e tenta fundir com a coluna `year` **STRING** gravada dentro do próprio arquivo — staging é todo STRING por convenção da casa, e a coluna de partição fica também dentro do parquet. As duas não fundem. `pq.ParquetFile` não passa pela API de datasets e por isso não infere partição nenhuma.

**Por que o onboarding não pegou:** `_max_transaction_date` só é alcançada por `refresh_cycle`, ou seja, pelo pipeline recorrente. O `clean_all` do onboarding não passa por ali. O onboarding inteiro — 368 milhões de linhas, 46 testes dbt — rodou limpo enquanto o pipeline estava quebrado desde o primeiro commit. É exatamente a lacuna que a execução de verificação em dev existe para fechar.

## Detalhes Técnicos

**Principais alterações:** troca `pq.read_table(file, columns=[...])` por `pq.ParquetFile(file).iter_batches(columns=[...])`.

Aproveita para ler em lotes. A versão anterior fazia `to_pylist()` da coluna inteira: na maior partição são **30.632.248 linhas**, ou seja dezenas de milhões de strings Python (~2GB) dentro de um worker de 8Gi. Com `iter_batches` + `pyarrow.compute` o pico de RSS medido cai para **0,24GB**.

`pc.less_equal`/`pc.max` levam `# pyrefly: ignore`: `pyarrow.compute` constrói essas funções dinamicamente, então verificadores estáticos não as enxergam. Ambas foram confirmadas como `callable` em tempo de execução, e o padrão segue o que já existe em `us_bea/utils.py`.

**Mudanças nos dados e no schema:** nenhuma. A função só lê.

**Impacto no desempenho:** positivo — pico de memória ~8x menor; a maior tabela leva 1s.

## Teste e Validações

- [x] Testado localmente
- [ ] Testado na Cloud

Primeiro reproduzido isoladamente, para confirmar o diagnóstico em vez de supor:

```
pyarrow 22.0.0
  pq.read_table default:            ArrowTypeError: Unable to merge: Field year ...
  pq.read_table partitioning=None:  OK rows=2
  pq.ParquetFile.read:              OK rows=2
```

Depois verificado **contra os dados reais que derrubaram o flow**, e os máximos batem exatamente com a cobertura registrada em produção:

| Tabela | máximo lido | tempo | pico RSS |
|---|---|---|---|
| contribution_individual (30,6M linhas) | 2026-07-31 | 0,8s | 0,24GB |
| contribution_committee | 2026-07-31 | 0,0s | 0,24GB |
| committee_transaction | 2026-07-31 | 0,2s | 0,24GB |
| disbursement | 2026-08-12 | 0,0s | 0,24GB |

```
pyrefly check pipelines/datasets/us_fec_campaign_finance/
INFO 0 diagnostics (5 suppressed)
```

## Riscos e Mitigações

- Riscos conhecidos: nenhum. A função apenas lê, e o valor devolvido foi conferido contra os dados reais nas quatro tabelas.
- Planos de rollback: reverter o commit.

## Dependencias

Depende de #1848 apenas na ordem de operação, não no código: os dois precisam estar mesclados antes de uma execução em produção valer a pena. Este PR faz o pipeline **rodar**; o #1848 faz a janela BD Pro ser registrada **corretamente** quando ele rodar. Depois de mesclados, o certo é repetir a verificação em dev antes de encostar em produção.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction date processing for campaign finance data.
  * Resolved compatibility issues when reading partitioned Parquet files.
  * Reduced memory usage and improved efficiency when processing large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->