### PR TITLE
[Bugfix] us_sec_edgar — pyrefly no CI

### DIFF
--- a/pipelines/datasets/us_sec_edgar/utils.py
+++ b/pipelines/datasets/us_sec_edgar/utils.py
@@ -21,7 +21,7 @@ import re
 import shutil
 import time
 import zipfile
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -290,15 +290,30 @@ def _read_tsv(handle, columns: list[str]) -> pa.Table:
 
 def _to_iso_date(array: pa.Array) -> pa.Array:
     """yyyymmdd -> YYYY-MM-DD, so `safe_cast(col as date)` resolves in dbt."""
+    # pyarrow.compute generates its kernels at import time, so pyrefly cannot
+    # see any of them.
+    # pyrefly: ignore [missing-attribute]
     trimmed = pc.utf8_trim_whitespace(array)
+    # pyrefly: ignore [missing-attribute]
     iso = pc.binary_join_element_wise(
+        # pyrefly: ignore [missing-attribute]
         pc.utf8_slice_codeunits(trimmed, 0, 4),
+        # pyrefly: ignore [missing-attribute]
         pc.utf8_slice_codeunits(trimmed, 4, 6),
+        # pyrefly: ignore [missing-attribute]
         pc.utf8_slice_codeunits(trimmed, 6, 8),
         "-",
     )
+    # pyrefly: ignore [missing-attribute]
     return pc.if_else(
-        pc.equal(pc.utf8_length(trimmed), 8), iso, pa.scalar(None, pa.string())
+        # pyrefly: ignore [missing-attribute]
+        pc.equal(
+            # pyrefly: ignore [missing-attribute]
+            pc.utf8_length(trimmed),
+            8,
+        ),
+        iso,
+        pa.scalar(None, pa.string()),
     )
 
 
@@ -394,7 +409,7 @@ def _derive_label(value: str) -> str:
 
 
 def build_dicionario(
-    output_dir: str, observed: dict[tuple[str, str], Iterable[str]]
+    output_dir: str, observed: Mapping[tuple[str, str], Iterable[str]]
 ) -> int:
     """Write the `dicionario` parquet covering every observed coded value."""
     rows = []


### PR DESCRIPTION
## Descrição do PR

Corrige o CI do `main`, que ficou vermelho após o merge de #1850.

- **Motivação/Contexto:** o `pyrefly` roda no CI e apontou 9 diagnósticos em `pipelines/datasets/us_sec_edgar/utils.py`. O `main` estava verde no commit anterior (`c2beda35`) e quebrou no merge (`00a20a8a`).

## Detalhes Técnicos

- **Principais alterações na pipeline/scripts:**
  - 8 dos 9 diagnósticos são falsos positivos em `pyarrow.compute`: os kernels são gerados em tempo de import, então o checker não enxerga nenhum deles. Suprimidos com `# pyrefly: ignore [missing-attribute]`, a convenção já usada em `pipelines/utils/gcs.py` e `pipelines/utils/tasks.py`.
  - 1 é um erro real de tipo: `dict` é invariante no tipo do valor, então um `dict[..., set[str]]` não satisfaz um parâmetro `dict[..., Iterable[str]]`. O parâmetro de `build_dicionario` virou `Mapping`, que é covariante e é o que a função de fato precisa.
- **Mudanças nos dados e no schema:** nenhuma.
- **Impacto no desempenho:** nenhum.

**Por que passou despercebido:** este worktree fica sob `.claude/`, que está no `.gitignore`, então o `pyrefly` do pre-commit não casou nenhum arquivo e saiu com código 1 — indistinguível de uma falha de ambiente pré-existente, e escondendo os diagnósticos reais. `uv run pyrefly check <arquivo>` checa o arquivo independentemente disso e reproduz o CI.

## Teste e Validações

- [x] Testado localmente
- [ ] Testado na Cloud

`uv run pyrefly check` limpo nos 7 arquivos adicionados por #1850. Comportamento inalterado — `_to_iso_date` continua mapeando `20241231` para `2024-12-31` e qualquer coisa que não tenha oito caracteres para NULL, conferido com um caso de teste direto.

## Riscos e Mitigações

- **Riscos conhecidos:** nenhum; a mudança é de anotação de tipo e comentários de supressão.
- **Planos de rollback:** reverter o commit.

## Dependencias

- [x] Nenhuma dependencia adicional


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when processing observed dictionary values supplied through different mapping types.
  * Preserved date conversion behavior while improving static validation for date-processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->