### PR TITLE
[Feature] us_sec_edgar — pipeline trimestral

### DIFF
--- a/models/us_sec_edgar/ONBOARDING_PLAN.md
+++ b/models/us_sec_edgar/ONBOARDING_PLAN.md
@@ -169,3 +169,25 @@ PartBdpro(
 
 and `dicionario` takes no spec. `needs_row_access_policy` is True for this tier, so the
 first armed prod run is also the first time the paywall is applied in BigQuery — watch it.
+
+### How the run differs from us_bls_cpi
+
+- **Append, not replace.** The SEC never rewrites an earlier quarter, so each run adds one
+  partition (`dump_mode="append"`) instead of rebuilding the history. Only `dicionario`
+  overwrites.
+- **`dicionario` is rebuilt as a union**, not from the new quarter alone. It is the
+  accumulated record of every code ever seen; a `datatype` last used in 2011 still has to
+  resolve or `custom_dictionary_coverage` fails on that partition. The task reads the
+  published table, unions it with the quarter's observed values, and overwrites.
+- **Run every table, then test every table**, per environment — never `run/test` inside the
+  per-table loop. The tests are cross-table: `numeric_fact` and `presentation` have
+  `relationships` onto `submission`, and three tables check `custom_dictionary_coverage`
+  against `dicionario`. Interleaving would test a table before its sibling is built.
+- **The poll compares against coverage, not `Table.Update`.** `max_date` is the quarter's
+  last month (`2026-06` for 2026Q2), which is how `read_max_date` reads a year/quarter
+  column, so it is compared like with like. `get_api_most_recent_date` takes the max across
+  *all* the table's coverage ranges, so the pro range is what it sees — correct here.
+- **The source Update is committed right after the poll**, before materializing, following
+  `commit_source_update_task`'s own contract: the poll never reads the source Update, so an
+  early commit cannot strand a later run, and a mid-flow failure still records that the SEC
+  published.

--- a/pipelines/datasets/us_sec_edgar/flows.py
+++ b/pipelines/datasets/us_sec_edgar/flows.py
@@ -1,0 +1,211 @@
+"""
+Flows for us_sec_edgar — Prefect 3.
+
+SEC EDGAR Financial Statement Data Sets. The SEC publishes one ZIP per calendar
+quarter, roughly five weeks after quarter end, and never rewrites an earlier
+one — so each run **appends one partition** (``dump_mode="append"``) rather than
+replacing the history the way us_bls_cpi does.
+
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers `us_sec_edgar_flow`;
+the dev pool ignores the schedule, the prod pool activates it.
+"""
+
+import shutil
+import tempfile
+
+from prefect import flow
+
+from pipelines.datasets.us_sec_edgar.constants import constants
+from pipelines.datasets.us_sec_edgar.tasks import (
+    build_dicionario_task,
+    download_and_clean,
+    resolve_latest_quarter,
+)
+from pipelines.utils.metadata.domain import (
+    DateFormat,
+    FreeLag,
+    PartBdpro,
+    YearQuarter,
+)
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+
+# The four data tables refresh together and carry the BD Pro rolling window:
+# the two most recent quarters are pro-only, everything older is free. With a
+# quarter read as DATE(year, quarter * 3, 1), a six-month lag lands free_end on
+# the last month of the quarter before last, so the window is exactly two
+# quarters wide and slides forward on every release.
+#
+# part_bdpro requires BOTH a free (is_closed=False) and a pro (is_closed=True)
+# Coverage to already exist on the table, or assert_coverage_topology raises
+# before anything is written. Both were registered during onboarding.
+#
+# `dicionario` has no date column, so it takes no coverage spec at all.
+_COVERAGE = {
+    table: PartBdpro(
+        date_column=YearQuarter(year="year", quarter="quarter"),
+        date_format=DateFormat.YEAR_MONTH,
+        free_lag=FreeLag(unit="months", value=6),
+    )
+    for table in constants.SOURCE_FILES.value.values()
+}
+
+# dicionario is a full rebuild every run — it is the union of the published
+# table and the new quarter — so it overwrites while the rest append.
+_DUMP_MODE = {"dicionario": "overwrite"}
+
+
+@flow(name="us_sec_edgar", log_prints=True)
+def us_sec_edgar_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+    year: int | None = None,
+    quarter: int | None = None,
+) -> None:
+    """Append the newest quarterly Financial Statement Data Set and materialize.
+
+    The source poll short-circuits the run when the SEC has not published a new
+    quarter, which makes a scheduled run a cheap no-op between releases.
+
+    Args:
+        materialize_to_prod: Continue past the dev materialization to write the
+            prod staging bucket and run dbt against ``target="prod"``. Set False
+            to exercise only the dev half — required for a safe test run, since
+            the default writes production.
+        update_metadata: After a successful prod materialization, register table
+            coverage, which also re-issues the BD Pro Row Access Policies. Has no
+            effect when ``materialize_to_prod`` is False.
+        force_run: Materialize even when the source poll reports no new quarter.
+        year: Release year to ingest. Defaults to the newest the SEC serves.
+        quarter: Release quarter to ingest, 1-4. Use with ``year`` to backfill a
+            specific quarter; ``force_run`` is then usually wanted too, since the
+            poll only looks at the newest.
+    """
+    # pyrefly: ignore [unused-coroutine]
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id="numeric_fact"
+    )
+
+    if year is None or quarter is None:
+        latest = resolve_latest_quarter()
+        year, quarter = int(latest["year"]), int(latest["quarter"])
+    max_date = f"{year}-{quarter * 3:02d}"
+
+    # Skip the run when the SEC has not published a newer quarter. Compared
+    # against the table's coverage, which is a competência like max_date — not
+    # against Table.Update, which is a wall clock.
+    has_new_data = poll_source_for_update_task(
+        dataset_id=DATASET_ID,
+        table_id="numeric_fact",
+        source_max_date=max_date,
+        env="prod",
+        date_format="%Y-%m",
+        compare_against="coverage",
+    )
+    if not has_new_data and not force_run:
+        return
+
+    # Committed here, right after the poll confirms, rather than at the end:
+    # poll_source_for_update never reads the source Update (it compares against
+    # Coverage), so an early commit cannot strand a later run, and if this flow
+    # dies mid-way the source metadata still records that the SEC published.
+    commit_source_update_task(
+        dataset_id=DATASET_ID,
+        table_id="numeric_fact",
+        source_max_date=max_date,
+        env="prod",
+        date_format="%Y-%m",
+        update_metadata=update_metadata,
+        materialize_after_dump=materialize_to_prod,
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="us_sec_edgar_")
+    try:
+        result = download_and_clean(
+            work_dir=work_dir, year=year, quarter=quarter
+        )
+        tables = constants.TABLES.value
+
+        for environment, bucket, dbt_target in (
+            ("dev", "basedosdados-dev", "dev"),
+            ("prod", "basedosdados", "prod"),
+        ):
+            if environment == "prod" and not materialize_to_prod:
+                return
+
+            # Rebuilt per environment so the union starts from that project's
+            # own published table rather than the other one's copy of it.
+            result["dicionario"] = build_dicionario_task(
+                work_dir=work_dir,
+                observed=result["observed"],
+                billing_project_id=bucket,
+            )
+
+            # Build every table before testing any of them. The tests are
+            # cross-table — numeric_fact and presentation have relationships
+            # onto submission, and three tables check custom_dictionary_coverage
+            # against dicionario — so testing inside this loop would run a
+            # table's tests before its sibling exists.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name=bucket,
+                    dump_mode=_DUMP_MODE.get(table, "append"),
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run",
+                    target=dbt_target,
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
+                    target=dbt_target,
+                )
+
+        if update_metadata:
+            for table, coverage in _COVERAGE.items():
+                register_table_materialization_task(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    coverage=coverage,
+                    env="prod",
+                    bq_project="basedosdados",
+                )
+    finally:
+        # Covers both early returns and any exception. One quarter is ~700 MB
+        # of TSV plus its parquet; a process worker reuses its filesystem.
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# The SEC posts a quarter roughly five weeks after it ends: 2026Q1 landed
+# 2026-04-09 and 2026Q2 on 2026-07-06. Poll across the first half of the month
+# after each quarter's release window; the source-poll guard no-ops until a new
+# quarter actually appears.
+# pyrefly: ignore [missing-attribute]
+us_sec_edgar_flow.deploy_schedules = [
+    {
+        "cron": "0 16 5,8,11,14,17,20 1,4,7,10 *",
+        "timezone": "America/Sao_Paulo",
+    }
+]
+# num.txt alone is ~600 MB of TSV, held as an arrow table while it is written.
+# pyrefly: ignore [missing-attribute]
+us_sec_edgar_flow.job_variables = {"memory": "8Gi"}

--- a/pipelines/datasets/us_sec_edgar/flows.py
+++ b/pipelines/datasets/us_sec_edgar/flows.py
@@ -97,9 +97,15 @@ def us_sec_edgar_flow(
         prefix="Dump: ", dataset_id=DATASET_ID, table_id="numeric_fact"
     )
 
+    # Both or neither: `year=2020, quarter=None` silently ingesting the latest
+    # quarter into production is not a backfill anyone asked for.
+    if (year is None) != (quarter is None):
+        raise ValueError("pass both year and quarter, or neither")
     if year is None or quarter is None:
         latest = resolve_latest_quarter()
         year, quarter = int(latest["year"]), int(latest["quarter"])
+    if not 1 <= quarter <= 4:
+        raise ValueError(f"quarter must be 1-4, got {quarter}")
     max_date = f"{year}-{quarter * 3:02d}"
 
     # Skip the run when the SEC has not published a newer quarter. Compared
@@ -120,15 +126,21 @@ def us_sec_edgar_flow(
     # poll_source_for_update never reads the source Update (it compares against
     # Coverage), so an early commit cannot strand a later run, and if this flow
     # dies mid-way the source metadata still records that the SEC published.
-    commit_source_update_task(
-        dataset_id=DATASET_ID,
-        table_id="numeric_fact",
-        source_max_date=max_date,
-        env="prod",
-        date_format="%Y-%m",
-        update_metadata=update_metadata,
-        materialize_after_dump=materialize_to_prod,
-    )
+    #
+    # Only when the poll actually saw something newer. A forced run and an
+    # explicit backfill of an older quarter both reach here with
+    # has_new_data=False, and committing then would move
+    # RawDataSource.Update.latest *backwards*.
+    if has_new_data:
+        commit_source_update_task(
+            dataset_id=DATASET_ID,
+            table_id="numeric_fact",
+            source_max_date=max_date,
+            env="prod",
+            date_format="%Y-%m",
+            update_metadata=update_metadata,
+            materialize_after_dump=materialize_to_prod,
+        )
 
     work_dir = tempfile.mkdtemp(prefix="us_sec_edgar_")
     try:

--- a/pipelines/datasets/us_sec_edgar/tasks.py
+++ b/pipelines/datasets/us_sec_edgar/tasks.py
@@ -3,6 +3,7 @@
 import os
 
 import basedosdados as bd
+from pandas_gbq.exceptions import GenericGBQException
 from prefect import task
 
 from pipelines.datasets.us_sec_edgar.constants import constants
@@ -86,6 +87,47 @@ def download_and_clean(work_dir: str, year: int, quarter: int) -> dict:
     return result
 
 
+def _read_published_dicionario(
+    billing_project_id: str,
+) -> list[dict[str, str]]:
+    """Read the currently published dictionary rows.
+
+    Args:
+        billing_project_id: GCP project holding the table and billing the read.
+
+    Returns:
+        One dict per row with keys ``id_tabela``, ``nome_coluna`` and ``chave``;
+        empty when the table does not exist yet.
+
+    Raises:
+        GenericGBQException: for anything other than a missing table. The
+            caller **overwrites** the published dictionary with what it builds,
+            so swallowing an auth, quota or transport error here would rebuild
+            from the current quarter alone and silently drop every code last
+            seen in an earlier one. Only a genuine 404 is a safe empty result.
+    """
+    try:
+        frame = bd.read_sql(
+            f"select id_tabela, nome_coluna, chave "
+            f"from `{billing_project_id}.{DATASET_ID}.dicionario`",
+            billing_project_id=billing_project_id,
+            from_file=True,
+        )
+    except GenericGBQException as error:
+        # pandas_gbq collapses every BigQuery error into this one class, so the
+        # 404 has to be recognised from the message.
+        if "Not found" not in str(error):
+            raise
+        print(
+            f"dicionario not materialized yet in {billing_project_id}: {error}"
+        )
+        return []
+    return [
+        {str(k): str(v) for k, v in record.items()}
+        for record in frame.to_dict("records")
+    ]
+
+
 @task
 def build_dicionario_task(
     work_dir: str, observed: list, billing_project_id: str
@@ -109,23 +151,7 @@ def build_dicionario_task(
         (row["id_tabela"], row["nome_coluna"]): set(row["chaves"])
         for row in observed
     }
-    try:
-        frame = bd.read_sql(
-            f"select id_tabela, nome_coluna, chave "
-            f"from `{billing_project_id}.{DATASET_ID}.dicionario`",
-            billing_project_id=billing_project_id,
-            from_file=True,
-        )
-        published = [
-            {str(k): str(v) for k, v in record.items()}
-            for record in frame.to_dict("records")
-        ]
-    except Exception as error:
-        # First run, or the table is not materialized yet in this project.
-        print(
-            f"could not read the published dicionario ({error}); rebuilding from this quarter only"
-        )
-        published: list[dict[str, str]] = []
+    published = _read_published_dicionario(billing_project_id)
 
     merged = merge_observed(observed_from_rows(published), fresh)
     output_dir = os.path.join(work_dir, "output")

--- a/pipelines/datasets/us_sec_edgar/tasks.py
+++ b/pipelines/datasets/us_sec_edgar/tasks.py
@@ -1,0 +1,136 @@
+"""Prefect 3 tasks for us_sec_edgar — thin wrappers over utils.py."""
+
+import os
+
+import basedosdados as bd
+from prefect import task
+
+from pipelines.datasets.us_sec_edgar.constants import constants
+from pipelines.datasets.us_sec_edgar.utils import (
+    build_dicionario,
+    clean_quarter,
+    download_quarter,
+    latest_source_quarter,
+    merge_observed,
+    observed_from_rows,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+
+
+@task(retries=2, retry_delay_seconds=60)
+def resolve_latest_quarter() -> dict:
+    """Find the newest quarter the SEC actually serves.
+
+    Not the newest one it *links*: the landing page lags the files, so this
+    goes through `latest_source_quarter`, which probes forward by URL. See
+    `list_source_quarters`.
+
+    Returns:
+        ``{"year": int, "quarter": int, "max_date": "YYYY-MM"}``. ``max_date``
+        is the quarter's last month, matching how `read_max_date` reads a
+        year/quarter column (``DATE(year, quarter * 3, 1)``), so the source
+        poll compares like with like against the table's coverage.
+    """
+    year, quarter = latest_source_quarter()
+    return {
+        "year": year,
+        "quarter": quarter,
+        "max_date": f"{year}-{quarter * 3:02d}",
+    }
+
+
+@task(retries=2, retry_delay_seconds=60)
+def download_and_clean(work_dir: str, year: int, quarter: int) -> dict:
+    """Download one quarterly ZIP and write its partitioned parquet.
+
+    Only the new quarter is cleaned; earlier quarters already sit in the
+    staging bucket, which is why the upload appends rather than overwrites.
+
+    Args:
+        work_dir: Directory to work in; input lands in ``<work_dir>/input`` and
+            output under ``<work_dir>/output``.
+        year: Release year.
+        quarter: Release quarter, 1-4.
+
+    Returns:
+        A mapping of table slug to its partitioned output directory, plus
+        ``"counts"`` (rows written per table) and ``"observed"`` (the distinct
+        dictionary-covered values seen in this quarter, as JSON-safe lists).
+    """
+    input_dir = os.path.join(work_dir, "input")
+    output_dir = os.path.join(work_dir, "output")
+    os.makedirs(input_dir, exist_ok=True)
+
+    zip_path = download_quarter(year, quarter, input_dir)
+    observed: dict = {}
+    counts = clean_quarter(
+        zip_path, year, quarter, output_dir, observed=observed
+    )
+    os.remove(zip_path)
+
+    result: dict[str, object] = {
+        table: os.path.join(output_dir, table)
+        for table in constants.SOURCE_FILES.value.values()
+    }
+    result["counts"] = counts
+    # Prefect serializes task results, so the tuple keys and sets have to go.
+    result["observed"] = [
+        {"id_tabela": table, "nome_coluna": column, "chaves": sorted(values)}
+        for (table, column), values in sorted(observed.items())
+    ]
+    print(
+        f"{year}Q{quarter}: "
+        + ", ".join(f"{t}={c:,}" for t, c in counts.items())
+    )
+    return result
+
+
+@task
+def build_dicionario_task(
+    work_dir: str, observed: list, billing_project_id: str
+) -> str:
+    """Rebuild the dictionary as the union of the published one and this quarter.
+
+    The published table is the accumulated record of every code seen so far;
+    this quarter may add new ones. Rebuilding from the quarter alone would drop
+    codes last seen years ago and break `custom_dictionary_coverage` on the
+    older partitions.
+
+    Args:
+        work_dir: Same directory used by :func:`download_and_clean`.
+        observed: The ``"observed"`` list from :func:`download_and_clean`.
+        billing_project_id: GCP project to bill the read of the current table.
+
+    Returns:
+        The dictionary's output directory.
+    """
+    fresh = {
+        (row["id_tabela"], row["nome_coluna"]): set(row["chaves"])
+        for row in observed
+    }
+    try:
+        frame = bd.read_sql(
+            f"select id_tabela, nome_coluna, chave "
+            f"from `{billing_project_id}.{DATASET_ID}.dicionario`",
+            billing_project_id=billing_project_id,
+            from_file=True,
+        )
+        published = [
+            {str(k): str(v) for k, v in record.items()}
+            for record in frame.to_dict("records")
+        ]
+    except Exception as error:
+        # First run, or the table is not materialized yet in this project.
+        print(
+            f"could not read the published dicionario ({error}); rebuilding from this quarter only"
+        )
+        published: list[dict[str, str]] = []
+
+    merged = merge_observed(observed_from_rows(published), fresh)
+    output_dir = os.path.join(work_dir, "output")
+    rows = build_dicionario(output_dir, merged)
+    print(
+        f"dicionario: {rows:,} rows ({len(published):,} published + this quarter)"
+    )
+    return os.path.join(output_dir, "dicionario")

--- a/pipelines/datasets/us_sec_edgar/utils.py
+++ b/pipelines/datasets/us_sec_edgar/utils.py
@@ -418,6 +418,15 @@ def observed_from_rows(
     still has to resolve, or `custom_dictionary_coverage` fails on that
     partition. Rebuilding from the new quarter alone would silently drop those,
     so the pipeline reads the current table and unions it with the new quarter.
+
+    Args:
+        rows: Published dictionary rows, each carrying at least `id_tabela`,
+            `nome_coluna` and `chave`.
+
+    Returns:
+        A mapping of (table slug, column name) to the set of coded values seen
+        for that column — the same shape `clean_quarter` accumulates and
+        `build_dicionario` consumes.
     """
     observed: dict[tuple[str, str], set[str]] = {}
     for row in rows:
@@ -429,7 +438,17 @@ def observed_from_rows(
 def merge_observed(
     *sources: Mapping[tuple[str, str], Iterable[str]],
 ) -> dict[tuple[str, str], set[str]]:
-    """Union several observed mappings."""
+    """Union several observed mappings.
+
+    Args:
+        *sources: Observed mappings to merge, as produced by `clean_quarter` or
+            `observed_from_rows`. Later sources add to earlier ones; none wins
+            over another, since the result is a union of the value sets.
+
+    Returns:
+        A mapping of (table slug, column name) to the union of the coded values
+        each source held for that column.
+    """
     merged: dict[tuple[str, str], set[str]] = {}
     for source in sources:
         for key, values in source.items():

--- a/pipelines/datasets/us_sec_edgar/utils.py
+++ b/pipelines/datasets/us_sec_edgar/utils.py
@@ -408,6 +408,35 @@ def _derive_label(value: str) -> str:
     return spaced[:1].upper() + spaced[1:] if spaced else value
 
 
+def observed_from_rows(
+    rows: Iterable[Mapping[str, str]],
+) -> dict[tuple[str, str], set[str]]:
+    """Turn already-published `dicionario` rows back into an observed mapping.
+
+    The recurring pipeline cleans one quarter, but the dictionary must keep
+    covering every code seen in *any* quarter — a `datatype` used only in 2011
+    still has to resolve, or `custom_dictionary_coverage` fails on that
+    partition. Rebuilding from the new quarter alone would silently drop those,
+    so the pipeline reads the current table and unions it with the new quarter.
+    """
+    observed: dict[tuple[str, str], set[str]] = {}
+    for row in rows:
+        key = (row["id_tabela"], row["nome_coluna"])
+        observed.setdefault(key, set()).add(row["chave"])
+    return observed
+
+
+def merge_observed(
+    *sources: Mapping[tuple[str, str], Iterable[str]],
+) -> dict[tuple[str, str], set[str]]:
+    """Union several observed mappings."""
+    merged: dict[tuple[str, str], set[str]] = {}
+    for source in sources:
+        for key, values in source.items():
+            merged.setdefault(key, set()).update(values)
+    return merged
+
+
 def build_dicionario(
     output_dir: str, observed: Mapping[tuple[str, str], Iterable[str]]
 ) -> int:

--- a/pipelines/datasets/us_sec_edgar/utils.py
+++ b/pipelines/datasets/us_sec_edgar/utils.py
@@ -21,7 +21,7 @@ import re
 import shutil
 import time
 import zipfile
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -290,15 +290,30 @@ def _read_tsv(handle, columns: list[str]) -> pa.Table:
 
 def _to_iso_date(array: pa.Array) -> pa.Array:
     """yyyymmdd -> YYYY-MM-DD, so `safe_cast(col as date)` resolves in dbt."""
+    # pyarrow.compute generates its kernels at import time, so pyrefly cannot
+    # see any of them.
+    # pyrefly: ignore [missing-attribute]
     trimmed = pc.utf8_trim_whitespace(array)
+    # pyrefly: ignore [missing-attribute]
     iso = pc.binary_join_element_wise(
+        # pyrefly: ignore [missing-attribute]
         pc.utf8_slice_codeunits(trimmed, 0, 4),
+        # pyrefly: ignore [missing-attribute]
         pc.utf8_slice_codeunits(trimmed, 4, 6),
+        # pyrefly: ignore [missing-attribute]
         pc.utf8_slice_codeunits(trimmed, 6, 8),
         "-",
     )
+    # pyrefly: ignore [missing-attribute]
     return pc.if_else(
-        pc.equal(pc.utf8_length(trimmed), 8), iso, pa.scalar(None, pa.string())
+        # pyrefly: ignore [missing-attribute]
+        pc.equal(
+            # pyrefly: ignore [missing-attribute]
+            pc.utf8_length(trimmed),
+            8,
+        ),
+        iso,
+        pa.scalar(None, pa.string()),
     )
 
 
@@ -394,7 +409,7 @@ def _derive_label(value: str) -> str:
 
 
 def build_dicionario(
-    output_dir: str, observed: dict[tuple[str, str], Iterable[str]]
+    output_dir: str, observed: Mapping[tuple[str, str], Iterable[str]]
 ) -> int:
     """Write the `dicionario` parquet covering every observed coded value."""
     rows = []


### PR DESCRIPTION
## Descrição do PR

Pipeline Prefect 3 recorrente para `us_sec_edgar`, a etapa 12 do onboarding feito em #1850.

- **Motivação/Contexto:** a SEC publica um ZIP por trimestre civil, cerca de cinco semanas depois do fim do trimestre, e **nunca reescreve** um trimestre anterior. Cada execução acrescenta uma partição em vez de refazer o histórico.

> **Depende de #1851** (correção do `pyrefly` que deixou o `main` vermelho). Este branch sai de lá, então o commit da correção aparece aqui também; some quando #1851 entrar.

## Detalhes Técnicos

- **Principais alterações na pipeline/scripts:** `flows.py` e `tasks.py` novos, mais dois helpers puros em `utils.py` (`observed_from_rows`, `merge_observed`). A transformação em si é a mesma de #1850 — `utils.py` é compartilhado entre o bootstrap e a pipeline, não duplicado.

Quatro escolhas que divergem do flow de referência (`us_bls_cpi`), cada uma por um motivo:

1. **`dump_mode="append"`** nas quatro tabelas de dados; a SEC nunca reescreve um trimestre. Só `dicionario` sobrescreve.
2. **`dicionario` é reconstruído como a UNIÃO** da tabela publicada com o trimestre novo. Reconstruir só a partir do trimestre derrubaria códigos vistos pela última vez anos atrás — um `datatype` usado só em 2011 ainda precisa resolver, ou o `custom_dictionary_coverage` falha naquela partição.
3. **Materializa todas as tabelas e só então testa todas**, por ambiente. O `us_bls_cpi` usa `run/test` dentro do laço por tabela, o que as regras do repositório hoje proíbem: aqui os testes são cross-table (`relationships` de `numeric_fact` e `presentation` para `submission`; três tabelas checam `custom_dictionary_coverage` contra `dicionario`), então interpolar testaria uma tabela antes de a irmã existir — o bug de us_fed_fred #1826 / au_geoscape_gnaf #1833.
4. **O trimestre é resolvido sondando além da página de índice.** A listagem da SEC atrasa em relação aos arquivos: `2026q2.zip` está servido desde 06/07/2026 enquanto a página ainda listava 2026Q1. Raspar só a página faria a pipeline terminar verde sem ingerir nada.

- **Mudanças nos dados e no schema:** nenhuma; os modelos dbt e a arquitetura vêm de #1850 sem alteração.
- **Impacto no desempenho:** `num.txt` de um trimestre tem ~600 MB, mantido como tabela arrow enquanto é escrito — `job_variables = {"memory": "8Gi"}`.

### Poll e cobertura

O poll compara `max_date` (o último mês do trimestre, `2026-06` para 2026Q2 — que é como `read_max_date` lê uma coluna ano/trimestre, `DATE(year, quarter * 3, 1)`) contra a **cobertura**, não contra `Table.Update`, que é relógio de parede. O `Update` da fonte é gravado logo depois do poll confirmar, seguindo o contrato do próprio `commit_source_update_task`: o poll nunca lê o Update da fonte, então a gravação antecipada não trava execuções futuras e uma falha no meio ainda registra que a SEC publicou.

As quatro tabelas de dados usam `PartBdpro` com `free_lag` de 6 meses, o que dá exatamente uma janela pro de dois trimestres, que anda sozinha a cada divulgação.

## Teste e Validações

- [x] Testado localmente
- [ ] Testado na Cloud

Verificado localmente:

- imports e descoberta pelo `deploy_flows.load_flows_from_file` (encontra `us_sec_edgar_flow`);
- **paridade da transformação pelo caminho da task**: 2026Q2 reproduz exatamente as contagens do onboarding — 7.714 / 3.608.711 / 92.731 / 785.490;
- a união do dicionário preservando um código presente só na tabela publicada;
- a janela de cobertura rolando dois trimestres a cada divulgação, em quatro releases seguidas, e `assert_coverage_topology` rejeitando a topologia só-free;
- `pyrefly` e `ruff` limpos.

**Falta a execução no pool de dev**, que é o que de fato fecha a etapa 12. Precisa da label `deploy-flow` e depois de um disparo manual com:

```
{"materialize_to_prod": false, "update_metadata": false, "force_run": true}
```

Os três importam: os defaults são `materialize_to_prod=True` e `update_metadata=True`, e as tasks de metadados são fixadas em `env="prod"` mesmo a partir do pool de dev — um disparo com `{}` escreveria dados e metadados de **produção** e aplicaria o paywall. `force_run` é necessário porque hoje o poll não vê novidade (o máximo da fonte, 2026-06, é igual à cobertura registrada).

## Riscos e Mitigações

- **Riscos conhecidos:**
  - O merge deixa o deployment em produção **pausado**; armar é um passo manual no admin do Django (`/admin/admin_data_tools/disabledflowschedule/`). A primeira execução armada é também a primeira vez que o upload de produção roda e que as Row Access Policies do BD Pro são emitidas — ou seja, o paywall entra em vigor ali. Vale acompanhar essa execução.
  - Verde não quer dizer ingeriu: o guarda do poll retorna cedo e o Prefect reporta `COMPLETED`. Para distinguir, ler os logs ou checar se a cobertura andou.
- **Planos de rollback:** desmarcar `is_schedule_active` no admin (kill switch) e reverter o merge.

## Dependencias

- [x]  Dependências: #1851


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated quarterly SEC EDGAR data processing.
  * Added support for downloading, cleaning, and publishing new quarterly data.
  * Added cumulative dictionary updates that preserve previously observed values.
  * Added configurable quarter selection, force-run options, coverage checks, and production registration.
  * Added scheduled processing for recurring data updates.

* **Documentation**
  * Documented SEC recurring-run behavior, including quarterly appends and coverage polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->