### PR TITLE
[Fix] us_fec_campaign_finance: specs de cobertura ainda usavam a coluna "cycle" pré-renomeação

### DIFF
--- a/pipelines/datasets/us_fec_campaign_finance/flows.py
+++ b/pipelines/datasets/us_fec_campaign_finance/flows.py
@@ -10,7 +10,7 @@ untouched, and the dbt models — plain `materialized="table"` — rebuild the f
 That is why the upload uses ``dump_mode="append"``. "overwrite" would delete the whole
 staging table and, via ``tb.delete(mode="all")``, the prod table with it — throwing
 away 45 years of frozen cycles to refresh one. "append" with a deterministic blob path
-(``staging/<ds>/<table>/cycle=<CYCLE>/data.parquet``) replaces exactly the current
+(``staging/<ds>/<table>/year=<CYCLE>/data.parquet``) replaces exactly the current
 cycle's partition, which is the intended semantics.
 
 The four transaction tables are high-frequency, so they carry the BD Pro rolling
@@ -93,16 +93,17 @@ _COVERAGE = {
         date_format=DateFormat.YEAR_MD,
         free_lag=_FREE_LAG,
     ),
-    # Registration snapshots: their only temporal column is the cycle, so coverage
-    # is expressed on it at year granularity.
+    # Registration snapshots: their only temporal column is `year`, the two-year
+    # election cycle labelled by the even year it ends in, so coverage is
+    # expressed on it at year granularity.
     "candidate": AllFree(
-        date_column=YearOnly(col="cycle"), date_format=DateFormat.YEAR
+        date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
     ),
     "committee": AllFree(
-        date_column=YearOnly(col="cycle"), date_format=DateFormat.YEAR
+        date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
     ),
     "candidate_committee_link": AllFree(
-        date_column=YearOnly(col="cycle"), date_format=DateFormat.YEAR
+        date_column=YearOnly(col="year"), date_format=DateFormat.YEAR
     ),
 }
 

--- a/pipelines/datasets/us_fec_campaign_finance/tests/test_coverage_columns.py
+++ b/pipelines/datasets/us_fec_campaign_finance/tests/test_coverage_columns.py
@@ -1,0 +1,61 @@
+"""Every coverage spec must name a column the table actually has.
+
+This exists because of a real failure. The partition was renamed `cycle` -> `year`
+across the architecture, the dbt models, the parquet and the backend, but the three
+`AllFree` specs in flows.py kept `YearOnly(col="cycle")`. Nothing caught it:
+
+- `pyrefly` cannot: "cycle" is a valid string.
+- The dev validation run cannot: it is triggered with `update_metadata=False`, which
+  skips `register_table_materialization_task` — the only caller that reads these
+  columns. The whole dev run went green with the bug in place.
+- It surfaced only on the prod run, as
+  `400 ... Unrecognized name: cycle`, from `MAX(DATE(cycle,1,1))`.
+
+The architecture CSVs are the source of truth for column names, so comparing the
+specs against them closes the gap without needing BigQuery.
+"""
+
+import pytest
+
+from pipelines.datasets.us_fec_campaign_finance.constants import constants
+from pipelines.datasets.us_fec_campaign_finance.flows import _COVERAGE
+from pipelines.datasets.us_fec_campaign_finance.utils import (
+    architecture_columns,
+)
+
+
+def _spec_columns(spec) -> list[str]:
+    """Column names a coverage spec will query, whatever its date_column shape."""
+    dc = spec.date_column
+    return [
+        getattr(dc, attr)
+        for attr in ("col", "year", "month", "quarter", "day")
+        if getattr(dc, attr, None) is not None
+    ]
+
+
+@pytest.mark.parametrize("table", sorted(_COVERAGE))
+def test_coverage_column_exists_in_architecture(table):
+    columns = set(architecture_columns(table))
+    for name in _spec_columns(_COVERAGE[table]):
+        assert name in columns, (
+            f"{table}: coverage spec references column {name!r}, which is not in "
+            f"the architecture. register_table_materialization_task would fail at "
+            f"runtime with 'Unrecognized name: {name}'."
+        )
+
+
+def test_every_refreshed_table_has_a_coverage_spec():
+    """The flow indexes `_COVERAGE[table]`, so a missing spec is a KeyError mid-run."""
+    missing = set(constants.ALL_TABLES.value) - set(_COVERAGE)
+    assert not missing, (
+        f"tables refreshed with no coverage spec: {sorted(missing)}"
+    )
+
+
+def test_no_coverage_spec_for_tables_the_flow_never_refreshes():
+    """A spec for an unrefreshed table is dead config and usually a typo."""
+    extra = set(_COVERAGE) - set(constants.ALL_TABLES.value)
+    assert not extra, (
+        f"coverage specs for tables not in ALL_TABLES: {sorted(extra)}"
+    )


### PR DESCRIPTION
## Descrição do PR

A execução em produção do pipeline falhou na etapa de metadados:

```
400 ... Unrecognized name: cycle at [3:18]
```

Run: `ancient-bonobo` (`dd2de989-1066-4c65-aec3-29ea4ed525a8`), `Failed`.

**Motivação/Contexto:** a coluna de partição foi renomeada `cycle` -> `year` em toda parte — arquitetura, modelos dbt, parquet, prefixo no GCS e backend — mas as três specs `AllFree` em `flows.py` continuaram com `YearOnly(col="cycle")`. `register_table_materialization_task` monta `MAX(DATE(cycle,1,1))` a partir dessa coluna, e o BigQuery recusou.

**Por que nada pegou antes de produção** — esta é a parte que importa:

- **`pyrefly` não pega:** `"cycle"` é uma string perfeitamente válida.
- **A execução de verificação em dev não pega:** ela é disparada com `update_metadata=False`, o que pula justamente `register_table_materialization_task` — a única chamadora que lê essas colunas. A run de dev (`ebony-fulmar`) passou de ponta a ponta, 7/7 `dbt run` e 7/7 `dbt test`, com o defeito presente.

Ou seja: o portão de dev tem um ponto cego estrutural para as specs de cobertura.

## Detalhes Técnicos

**Principais alterações:** `YearOnly(col="cycle")` -> `YearOnly(col="year")` nas três tabelas de cadastro (`candidate`, `committee`, `candidate_committee_link`).

**A correção não é só de três linhas.** `tests/test_coverage_columns.py` confere cada spec de cobertura contra os CSVs de arquitetura — que são a fonte de verdade dos nomes de coluna — e não precisa de BigQuery. Verifica também as duas direções do mapeamento `ALL_TABLES` <-> `_COVERAGE`: uma tabela atualizada sem spec vira `KeyError` no meio da run (a indexação é deliberada, ver #1845), e uma spec para tabela que o flow nunca atualiza é configuração morta.

Corrige ainda o docstring do módulo, que descrevia o caminho do blob como `staging/<ds>/<table>/cycle=<CYCLE>/data.parquet`.

**Mudanças nos dados e no schema:** nenhuma.

## Teste e Validações

- [x] Testado localmente
- [ ] Testado na Cloud

O teste foi validado **reintroduzindo o defeito**, para garantir que ele de fato pega e não apenas passa:

```
WITH THE BUG REINTRODUCED: 3 failed, 6 passed
exit code: 1 -> test CATCHES it
```

```
pytest pipelines/datasets/us_fec_campaign_finance/tests/ pipelines/utils/tests/metadata/ -q
151 passed

pyrefly check pipelines/datasets/us_fec_campaign_finance/
INFO 0 diagnostics (5 suppressed)
```

## Estado de produção após a falha

A falha ocorreu na **primeira** chamada de registro (`candidate`, primeira em `ALL_TABLES`), então nada ficou pela metade:

- **Dados em produção estão íntegros e mais recentes.** Uploads e `dbt run`/`test` com `target=prod` passaram antes: `candidate` 130.402 (+40), `committee` 298.071 (+10), `candidate_committee_link` 82.392 (+41). As quatro tabelas transacionais seguem iguais — a FEC não publicou transações novas desde o onboarding.
- **Nenhuma cobertura foi reescrita e nenhuma Row Access Policy foi emitida.** O paywall continua não aplicado, exatamente como antes da run.
- O `Update` da fonte foi gravado (2026-08-12), o que é correto e inofensivo.

Depois deste merge, a run de produção precisa ser disparada de novo para efetivamente aplicar a janela BD Pro.

## Riscos e Mitigações

- Riscos conhecidos: nenhum. A mudança faz as specs apontarem para a coluna que de fato existe.
- Planos de rollback: reverter o commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated US FEC campaign finance data partitions to use year-based paths.
  * Improved coverage tracking by using each table’s year field.

* **Tests**
  * Added validation to ensure refreshed tables have accurate coverage configurations.
  * Added checks confirming coverage columns match available table metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->