### PR TITLE
[Bugfix] us_sec_edgar — dicionario deve usar append, não overwrite

### DIFF
--- a/models/us_sec_edgar/ONBOARDING_PLAN.md
+++ b/models/us_sec_edgar/ONBOARDING_PLAN.md
@@ -191,3 +191,35 @@ first armed prod run is also the first time the paywall is applied in BigQuery �
   `commit_source_update_task`'s own contract: the poll never reads the source Update, so an
   early commit cannot strand a later run, and a mid-flow failure still records that the SEC
   published.
+
+## Why `dicionario` uploads with `dump_mode="append"`
+
+`dicionario` is a full rebuild on every run — the union of the published table and the
+new quarter — so `dump_mode="overwrite"` looks like the obvious choice. It is wrong, and
+destructively so.
+
+The overwrite branch of `pipelines/utils/tasks.py::_upload_to_gcs` calls
+`tb.delete(mode="all")`. `mode="all"` drops the **materialized production table**
+(`basedosdados.us_sec_edgar.dicionario`), not just the staging external table. And it
+fires from the **dev** iteration of the environment loop as well, because `bd.Table`
+resolves its BigQuery projects from the worker's `config.toml` rather than from the
+`bucket_name` argument. A run with `materialize_to_prod=False` therefore deletes the
+prod table and then returns before the prod half that would have rebuilt it.
+
+This happened on 2026-08-19. The dev validation run reported every task `Completed()`
+with zero WARNING/ERROR logs while silently doing two things:
+
+1. deleting `basedosdados.us_sec_edgar.dicionario`;
+2. recreating `basedosdados-staging.us_sec_edgar_staging.dicionario` pointed at
+   `gs://basedosdados-dev/...` — its four siblings still point at `gs://basedosdados/...`
+   — so a later `dbt --target prod` would have built the prod table from dev blobs.
+
+The log signature is the pair `Tabela anterior removida: basedosdados-staging...`
+followed by `Tabela recriada: ... /basedosdados-dev/staging/...`.
+
+`append` gives identical semantics with no delete: `build_dicionario` writes a single
+fixed `dicionario/data.parquet`, and the append branch ends in
+`st.upload(..., if_exists="replace")`, which replaces that one blob wholesale.
+
+The underlying `tb.delete(mode="all")` remains a hazard for any dataset that uses
+`dump_mode="overwrite"`; the same class of bug previously bit `us_fed_fred`.

--- a/pipelines/datasets/us_sec_edgar/flows.py
+++ b/pipelines/datasets/us_sec_edgar/flows.py
@@ -60,9 +60,21 @@ _COVERAGE = {
     for table in constants.SOURCE_FILES.value.values()
 }
 
-# dicionario is a full rebuild every run — it is the union of the published
-# table and the new quarter — so it overwrites while the rest append.
-_DUMP_MODE = {"dicionario": "overwrite"}
+# Every table uploads with dump_mode="append", including dicionario.
+#
+# dicionario IS a full rebuild each run — it is the union of the published table
+# and the new quarter — but it must NOT use dump_mode="overwrite" to get that.
+# The overwrite branch of _upload_to_gcs calls `tb.delete(mode="all")`, and
+# mode="all" drops the MATERIALIZED PRODUCTION table, not just the staging
+# external table. bd.Table resolves its BigQuery projects from the pod config
+# rather than from bucket_name, so the dev half of the loop deletes the prod
+# table too; a run with materialize_to_prod=False then never rebuilds it. That
+# is exactly how basedosdados.us_sec_edgar.dicionario was lost on 2026-08-19,
+# and the same defect previously bit us_fed_fred.
+#
+# append gives identical semantics here without any delete: build_dicionario
+# writes a single fixed dicionario/data.parquet, and the append branch ends in
+# st.upload(..., if_exists="replace"), which replaces that one blob wholesale.
 
 
 @flow(name="us_sec_edgar", log_prints=True)
@@ -175,7 +187,7 @@ def us_sec_edgar_flow(
                     dataset_id=DATASET_ID,
                     table_id=table,
                     bucket_name=bucket,
-                    dump_mode=_DUMP_MODE.get(table, "append"),
+                    dump_mode="append",
                     source_format="parquet",
                 )
                 run_dbt(


### PR DESCRIPTION
## O que

Troca `dump_mode` da tabela `dicionario` de `"overwrite"` para `"append"` no fluxo `us_sec_edgar`, e remove o dicionário `_DUMP_MODE` (agora todas as tabelas usam `append`).

## Por quê

`dump_mode="overwrite"` passa pelo ramo de `pipelines/utils/tasks.py::_upload_to_gcs` que chama **`tb.delete(mode="all")`**. `mode="all"` apaga a **tabela materializada de produção** (`basedosdados.<ds>.<tbl>`), não apenas a external table de staging.

E ela dispara também na iteração **dev** do loop de ambientes: `bd.Table` resolve os projetos do BigQuery pelo `config.toml` do worker, não pelo argumento `bucket_name`. Uma execução com `materialize_to_prod=False` portanto apaga a tabela de produção e retorna **antes** da metade prod que a reconstruiria.

### Foi o que aconteceu em 2026-08-19

A execução de validação no pool dev (`auspicious-moth`, `materialize_to_prod=False, update_metadata=False, force_run=True`) terminou **`Completed`**, com todas as tasks `Completed()` e **zero logs de WARNING/ERROR** — enquanto fazia dois estragos silenciosos:

1. apagou `basedosdados.us_sec_edgar.dicionario` (404; as outras quatro tabelas intactas);
2. recriou `basedosdados-staging.us_sec_edgar_staging.dicionario` apontando para `gs://basedosdados-dev/...`, divergindo das quatro irmãs, que apontam para `gs://basedosdados/...`. Um `dbt --target prod` posterior construiria a tabela de produção a partir de blobs do bucket de dev.

A assinatura nos logs é o par:

```
Tabela anterior removida: basedosdados-staging.us_sec_edgar_staging.dicionario
Tabela recriada: ...  https://console.cloud.google.com/storage/browser/basedosdados-dev/staging/us_sec_edgar/dicionario
```

O dataset em produção ainda está `under_review`, então nada ficou visível publicamente, e as 59 linhas são integralmente reprodutíveis a partir da fonte.

## Por que `append` resolve

`append` entrega semântica idêntica de reconstrução total, sem nenhum delete:

- `build_dicionario` escreve **um único arquivo fixo**, `dicionario/data.parquet`;
- o ramo `append` termina em `st.upload(..., if_exists="replace")`, que substitui esse blob por inteiro.

Não há acúmulo entre execuções porque o caminho do blob é determinístico.

## Escopo

Correção **restrita a este dataset**. O `tb.delete(mode="all")` compartilhado continua sendo um risco para qualquer dataset que use `dump_mode="overwrite"` (`au_ato_abr` usa hoje), e o mesmo tipo de bug já havia atingido `us_fed_fred`. Um PR separado deve avaliar trocar por `mode="staging"` em `_upload_to_gcs`, já que nenhum chamador quer derrubar a tabela materializada — mudança de uma linha, mas com raio de alcance amplo, então merece revisão própria.

## Verificação

- `uv run pyrefly check pipelines/datasets/us_sec_edgar/flows.py` → `0 diagnostics (3 suppressed)`
- `ruff check` / `ruff format --check` → limpos
- import do fluxo OK (`us_sec_edgar`)

O hook `pyrefly` do pre-commit falha neste worktree por motivo ambiental (o worktree fica sob `.claude/`, que está no `.gitignore`, então o padrão casa **zero** arquivos e sai com código 1 — "No Python files matched patterns"). Por isso o commit usou `--no-verify` e a checagem foi feita direto no arquivo.

Sem label `deploy-flow` de propósito: um deploy no pool dev a partir deste branch executaria de novo a metade dev — com o código antigo — e apagaria `dicionario` outra vez. O deploy no pool de produção acontece no merge, que é o que a execução de reparo precisa.

## Depois do merge

Uma execução de produção (`force_run=True`, defaults) reconstrói `basedosdados.us_sec_edgar.dicionario`, reaponta a external table de staging para `gs://basedosdados/...` e aplica as Row Access Policies do BD Pro — agora sem passar por `tb.delete`.

---

Relacionado: #1852 (pipeline trimestral), #1851 (pyrefly).
