### PR TITLE
[Data] br_tse_eleicoes: reprocessa 2026 apos encerramento do registro de candidaturas

### DIFF
--- a/models/br_tse_eleicoes/br_tse_eleicoes__bens_candidato.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__bens_candidato.sql
@@ -1,3 +1,5 @@
+-- Dados de 2026 reprocessados em 2026-08-21 a partir dos arquivos do TSE
+-- gerados em 19/08/2026, apos o encerramento do registro de candidaturas.
 {{
     config(
         schema="br_tse_eleicoes",

--- a/models/br_tse_eleicoes/br_tse_eleicoes__candidatos.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__candidatos.sql
@@ -1,3 +1,5 @@
+-- Dados de 2026 reprocessados em 2026-08-21 a partir dos arquivos do TSE
+-- gerados em 19/08/2026, apos o encerramento do registro de candidaturas.
 {{
     config(
         schema="br_tse_eleicoes",

--- a/models/br_tse_eleicoes/br_tse_eleicoes__partidos.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__partidos.sql
@@ -1,3 +1,5 @@
+-- Dados de 2026 reprocessados em 2026-08-21 a partir dos arquivos do TSE
+-- gerados em 19/08/2026, apos o encerramento do registro de candidaturas.
 {{
     config(
         schema="br_tse_eleicoes",

--- a/models/br_tse_eleicoes/br_tse_eleicoes__vagas.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__vagas.sql
@@ -1,3 +1,5 @@
+-- Dados de 2026 reprocessados em 2026-08-21 a partir dos arquivos do TSE
+-- gerados em 19/08/2026, apos o encerramento do registro de candidaturas.
 {{
     config(
         schema="br_tse_eleicoes",


### PR DESCRIPTION
## O que muda

Reprocessamento dos dados de **2026** de `br_tse_eleicoes` a partir dos arquivos do TSE gerados em **19/08/2026**, apos o encerramento do prazo de registro de candidaturas (15/08). A carga anterior (12/08) era um retrato de meio de periodo.

Nao ha mudanca de logica: o unico diff e um comentario nos quatro modelos, necessario para que a acao `table-approve` selecione as tabelas e promova os dados novos de `basedosdados-dev` para producao.

## Contagens (ano = 2026)

| tabela | producao (12/08) | novo | delta |
|---|---|---|---|
| candidatos | 15.573 | **20.580** | +5.007 |
| partidos | 2.967 | **4.274** | +1.307 |
| vagas | 189 | **189** | — |
| bens_candidato | 65.749 | **75.581** | +9.832 |

Alem das linhas novas, ha correcoes reais nas 15.555 linhas em comum (chave `sequencial`): `nome_urna` 205, `raca` 179, `ocupacao` 101, `instrucao` 98, `estado_civil` 87, `nome` 43, `numero` 39, `data_nascimento` 37, `idade` 17, `genero` 11. Foram removidas 18 candidaturas.

## Regressao conhecida e aceita

O TSE trocou a geracao do arquivo `consulta_cand` de 2026: agora e a versao de **50 colunas**, que move `nacionalidade`, `municipio_nascimento` e `situacao` para `consulta_cand_complementar_2026.zip` — **arquivo ainda nao publicado** (404).

Consequencia: `nacionalidade` e `municipio_nascimento` passam de 15.573/15.573 preenchidas em producao para **0/20.580**. A opcao foi priorizar a lista completa de candidaturas; as duas colunas serao preenchidas quando o TSE publicar o complementar.

`situacao` continua vazia de qualquer forma: no arquivo principal `DS_SITUACAO_CANDIDATURA` e `#NE` e `DS_SIT_TOT_TURNO` e `#NULO` — o encerramento do registro nao equivale ao julgamento do deferimento. Sera necessario um terceiro reprocessamento.

## Validacao em dev

- `dbt run`: PASS=4, ERROR=0
- `dbt test`: **PASS=25, WARN=0, ERROR=0**
- Demais anos verificados contra producao: contagem por ano identica em todas as 4 tabelas
  (17/18/17/11 anos), e checksum de linha completa identico nos 16 anos nao-2026 de
  `candidatos` (1994-2024). Os modelos sao `materialized="table"`, entao a rematerializacao
  reconstroi todos os anos - a verificacao confirma que apenas 2026 mudou
- `sigla_uf_nascimento` 20.580/20.580 preenchida, confirmando que a reordenacao posicional de colunas do staging foi aplicada corretamente

## Checklist

- [x] Dados carregados e validados em `basedosdados-dev`
- [x] Testes dbt verdes
- [x] Label `table-approve` aplicada
- [ ] Materializacao em producao verificada apos o merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added metadata documenting the 2026 election data reprocessing date and the source file generation date.
  * Clarified that the data reflects information collected after candidate registration closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
