### PR TITLE
fix(mx_sesnsp_incidencia_delictiva): destrava o clean após mudança de header na fonte

### DIFF
--- a/models/mx_sesnsp_incidencia_delictiva/code/clean_data.py
+++ b/models/mx_sesnsp_incidencia_delictiva/code/clean_data.py
@@ -32,6 +32,7 @@ import pandas as pd
 # pipeline and this one-shot bootstrap must not drift apart.
 from pipelines.datasets.mx_sesnsp_incidencia_delictiva.utils import (
     MONTHS,  # noqa: F401 (re-exported for callers/tests of this module)
+    _read_source_csv,
     melt_wide,
     write_partition,
 )
@@ -73,11 +74,12 @@ def clean_table(table, sample=None):
     muni, victimas = TABLES[table]
     src = find_csv(table)
     log.info("%s <- %s", table, src.name)
-    # read all as string (embedded commas handled by csv quoting); latin-1
-    reader = pd.read_csv(
-        src, encoding="latin-1", dtype=str, nrows=sample, chunksize=None
-    )
-    df = reader
+    # All-string read (embedded commas handled by csv quoting). The encoding and
+    # header spelling are resolved by the shared reader — SESNSP is not stable
+    # across releases, and the bootstrap must not drift from the pipeline.
+    df = _read_source_csv(src)
+    if sample is not None:
+        df = df.head(sample)
     total = 0
     years = sorted(
         pd.to_numeric(df["Año"], errors="coerce").dropna().astype(int).unique()

--- a/pipelines/datasets/mx_sesnsp_incidencia_delictiva/tests/test_source_headers.py
+++ b/pipelines/datasets/mx_sesnsp_incidencia_delictiva/tests/test_source_headers.py
@@ -1,0 +1,86 @@
+"""Regression tests for the SESNSP source-header reader.
+
+The 2026-08 release broke the armed pipeline with ``KeyError: 'Año'``. The
+source is behind an Imperva challenge, so the exact change could not be
+observed; these tests pin the two plausible causes — an encoding flip and a
+header re-spelling — plus the diagnosable failure when it is neither.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from pipelines.datasets.mx_sesnsp_incidencia_delictiva.utils import (
+    _canonical_key,
+    _read_source_csv,
+    normalize_headers,
+)
+
+HEADER = (
+    "Año,Clave_Ent,Entidad,Bien jurídico afectado,Tipo de delito,"
+    "Subtipo de delito,Modalidad,Enero,Febrero"
+)
+ROW = "2026,01,Aguascalientes,La vida,Homicidio,Homicidio doloso,Con arma,3,5"
+
+
+def _write(tmp_path, text: str, encoding: str):
+    path = tmp_path / "RNID-sample.csv"
+    path.write_bytes(f"{text}\n".encode(encoding))
+    return path
+
+
+@pytest.mark.parametrize("encoding", ["latin-1", "utf-8"])
+def test_reads_either_encoding(tmp_path, encoding):
+    """A latin-1 or utf-8 export both resolve the accented year column."""
+    csv_path = _write(tmp_path, f"{HEADER}\n{ROW}", encoding)
+
+    df = _read_source_csv(csv_path)
+
+    assert "Año" in df.columns
+    assert "Bien jurídico afectado" in df.columns
+    assert df["Año"].tolist() == ["2026"]
+
+
+def test_utf8_is_not_silently_mojibaked(tmp_path):
+    """utf-8 is tried first, so its accents survive rather than becoming 'AÃ±o'."""
+    csv_path = _write(tmp_path, f"{HEADER}\n{ROW}", "utf-8")
+
+    df = _read_source_csv(csv_path)
+
+    assert not any("Ã" in c for c in df.columns)
+
+
+@pytest.mark.parametrize(
+    "raw, canonical",
+    [
+        ("AÑO", "Año"),
+        ("anio", "Año"),
+        ("  Año  ", "Año"),
+        ("BIEN JURIDICO AFECTADO", "Bien jurídico afectado"),
+        ("Cve Municipio", "Cve. Municipio"),
+        ("Rango de Edad", "Rango de edad"),
+    ],
+)
+def test_header_respelling_is_absorbed(raw, canonical):
+    """Case, accent and punctuation drift in the header resolves to canonical."""
+    df = pd.DataFrame({raw: ["2026"]})
+
+    assert canonical in normalize_headers(df).columns
+
+
+def test_unresolvable_header_names_the_actual_columns(tmp_path):
+    """A genuinely new header fails with the decoded columns, not a KeyError."""
+    csv_path = _write(tmp_path, "period,state,count\n2026,01,3", "utf-8")
+
+    with pytest.raises(ValueError, match="no year column"):
+        _read_source_csv(csv_path)
+
+    with pytest.raises(ValueError, match="period"):
+        _read_source_csv(csv_path)
+
+
+def test_canonical_key_collapses_punctuation_and_accents():
+    assert _canonical_key("Cve. Municipio") == "cvemunicipio"
+    assert _canonical_key("Año") == _canonical_key("AÑO") == "ano"
+    assert _canonical_key("anio") == "anio"  # alias, not a normalization

--- a/pipelines/datasets/mx_sesnsp_incidencia_delictiva/utils.py
+++ b/pipelines/datasets/mx_sesnsp_incidencia_delictiva/utils.py
@@ -71,6 +71,126 @@ MONTHS = {
 # `.../personal/cni_sspc_gob_mx/`.
 _TOKEN_RE = re.compile(r"/personal/cni_sspc_gob_mx/([^?/]+)")
 
+# Canonical spelling of every source header the melt reads. Matching is done on
+# the normalized key (see `_canonical_key`), so a case change, added whitespace
+# or dropped punctuation in a future SESNSP release still resolves.
+_SOURCE_COLUMNS = (
+    "Año",
+    "Clave_Ent",
+    "Entidad",
+    "Cve. Municipio",
+    "Municipio",
+    "Bien jurídico afectado",
+    "Tipo de delito",
+    "Subtipo de delito",
+    "Modalidad",
+    "Sexo",
+    "Rango de edad",
+    *MONTHS,
+)
+
+# Extra normalized keys that map onto a canonical header. Accent-stripping alone
+# cannot reach these: Spanish exports routinely spell "Año" as "anio" to dodge
+# the ñ, which normalizes to a different key.
+_HEADER_ALIASES = {
+    "anio": "Año",
+    "annio": "Año",
+    "cvemun": "Cve. Municipio",
+    "clavemunicipio": "Cve. Municipio",
+    "claveent": "Clave_Ent",
+    "cveent": "Clave_Ent",
+    "rangoedad": "Rango de edad",
+}
+
+# utf-8 first: it raises on latin-1 accented bytes, so a genuine latin-1 file
+# falls through. The reverse order would silently mojibake a utf-8 file, since
+# latin-1 decodes every byte sequence.
+_ENCODINGS = ("utf-8-sig", "latin-1")
+
+
+def _canonical_key(name: str) -> str:
+    """Reduce a header cell to an accent-, case- and punctuation-free key.
+
+    ``"Año"``, ``"AÑO"`` and ``"anio "`` all collapse to ``"ano"``; ``"Cve.
+    Municipio"`` collapses to ``"cvemunicipio"``.
+
+    Args:
+        name: A raw header cell.
+
+    Returns:
+        The normalized matching key.
+    """
+    text = unicodedata.normalize("NFKD", str(name))
+    text = "".join(c for c in text if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]+", "", text.lower())
+
+
+def normalize_headers(df: pd.DataFrame) -> pd.DataFrame:
+    """Rename raw headers to the canonical spelling the melt expects.
+
+    SESNSP re-exports these files monthly and the header spelling is not stable
+    across releases. Renaming through `_canonical_key` absorbs case changes,
+    stray whitespace and dropped punctuation without touching the melt.
+
+    Note this does *not* repair mojibake — a utf-8 file decoded as latin-1 turns
+    ``"Año"`` into ``"AÃ±o"``, whose key is ``"aao"``. That case is handled
+    upstream by `_read_source_csv` trying utf-8 first.
+
+    Args:
+        df: The wide frame as read from the raw CSV.
+
+    Returns:
+        The same frame with recognized headers renamed in place.
+    """
+    lookup = {_canonical_key(c): c for c in _SOURCE_COLUMNS}
+    lookup.update(_HEADER_ALIASES)
+    rename = {}
+    for actual in df.columns:
+        canonical = lookup.get(_canonical_key(actual))
+        if canonical is not None and canonical != actual:
+            rename[actual] = canonical
+    if rename:
+        log.info("normalized %s header(s): %s", len(rename), rename)
+    return df.rename(columns=rename)
+
+
+def _read_source_csv(csv_path: Path) -> pd.DataFrame:
+    """Read one wide SESNSP CSV, tolerating an encoding or header-spelling change.
+
+    The 2026-08 release broke the pipeline with ``KeyError: 'Año'`` — the
+    signature of an accented header that no longer resolves. Rather than pin a
+    second guess, try each candidate encoding and accept the first whose header
+    yields a usable year column after normalization.
+
+    Args:
+        csv_path: The raw wide CSV.
+
+    Returns:
+        The frame with canonical headers.
+
+    Raises:
+        ValueError: If no candidate encoding produces a year column. The message
+            carries the decoded header so the next source change is one log line
+            to diagnose, not a pandas traceback.
+    """
+    attempts: list[tuple[str, list[str]]] = []
+    for encoding in _ENCODINGS:
+        try:
+            df = pd.read_csv(csv_path, encoding=encoding, dtype=str)
+        except UnicodeDecodeError:
+            continue
+        df = normalize_headers(df)
+        if "Año" in df.columns:
+            log.info("%s: decoded as %s", csv_path.name, encoding)
+            return df
+        attempts.append((encoding, list(df.columns)[:12]))
+
+    detail = "; ".join(f"{enc} -> {cols}" for enc, cols in attempts)
+    raise ValueError(
+        f"{csv_path.name}: no year column after trying {list(_ENCODINGS)}. "
+        f"The SESNSP header changed. Decoded headers: {detail}"
+    )
+
 
 # ── download ────────────────────────────────────────────────────────────────
 def _norm(text: str) -> str:
@@ -270,7 +390,7 @@ def melt_wide(df: pd.DataFrame, muni: bool, victimas: bool) -> pd.DataFrame:
     they live in br_bd_diretorios_mx.
 
     Args:
-        df: A wide chunk read from the raw latin-1 CSV (all-string).
+        df: A wide chunk with canonical headers (all-string).
         muni: True for municipal tables (keeps ``id_municipio``).
         victimas: True for víctimas tables (keeps ``sexo``/``rango_edad``).
 
@@ -384,7 +504,7 @@ def clean_table(
     """Clean one table's wide CSV into partitioned parquet.
 
     Args:
-        csv_path: The raw latin-1 CSV.
+        csv_path: The raw wide CSV (encoding resolved by `_read_source_csv`).
         table: Table slug.
         output_dir: Root output directory.
 
@@ -394,7 +514,7 @@ def clean_table(
     """
     muni, victimas = ONGOING_TABLES[table]
     log.info("%s <- %s", table, csv_path.name)
-    df = pd.read_csv(csv_path, encoding="latin-1", dtype=str)
+    df = _read_source_csv(csv_path)
     total = 0
     max_ym: tuple[int, int] | None = None
     years = sorted(

--- a/pipelines/datasets/mx_sesnsp_incidencia_delictiva/utils.py
+++ b/pipelines/datasets/mx_sesnsp_incidencia_delictiva/utils.py
@@ -108,14 +108,16 @@ _HEADER_ALIASES = {
 _ENCODINGS = ("utf-8-sig", "latin-1")
 
 
-def _canonical_key(name: str) -> str:
+def _canonical_key(name: object) -> str:
     """Reduce a header cell to an accent-, case- and punctuation-free key.
 
     ``"Año"``, ``"AÑO"`` and ``"anio "`` all collapse to ``"ano"``; ``"Cve.
     Municipio"`` collapses to ``"cvemunicipio"``.
 
     Args:
-        name: A raw header cell.
+        name: A raw header cell. Typed `object` because a pandas column label is
+            not guaranteed to be a str — an all-numeric header row reads back as
+            ints — so the `str()` below is load-bearing, not redundant.
 
     Returns:
         The normalized matching key.


### PR DESCRIPTION
## Descrição do PR

A pipeline armada falha diariamente desde 2026-08-20 com `KeyError: 'Año'`.
O run de 2026-08-13 limpou normalmente, então o header mudou entre releases
do SESNSP. A fonte está atrás do desafio Imperva e não é inspecionável fora
do worker, então o reader passa a tolerar as duas causas plausíveis em vez de
apostar em uma:

- `_read_source_csv` tenta utf-8 antes de latin-1. utf-8 levanta em bytes
  acentuados latin-1, então um arquivo latin-1 legítimo cai no fallback; a
  ordem inversa produziria mojibake silencioso ("AÃ±o"), já que latin-1
  decodifica qualquer byte.
- `normalize_headers` casa os headers por uma chave sem acento, caixa ou
  pontuação, absorvendo re-grafias ("AÑO", "Cve Municipio", "anio" via alias).
- Se nenhuma tentativa resolve a coluna de ano, o erro nomeia os headers
  decodificados — a próxima mudança da fonte vira uma linha de log em vez de
  um traceback do pandas.

O bootstrap em models/ passa a importar o mesmo reader, para os dois caminhos
não divergirem.

## Como validar

A fonte está atrás do Imperva e não é inspecionável fora do worker, então a causa
exata não pôde ser observada — o fix cobre as duas hipóteses plausíveis e falha
com mensagem diagnosticável se for uma terceira.

- `uv run pytest pipelines/datasets/mx_sesnsp_incidencia_delictiva/tests/` (11 testes)
- Com a label `deploy-flow`, rodar no pool de dev com
  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`.
  É o único jeito de ver o header real.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SESNSP CSV files with UTF-8, BOM, or Latin-1 encoding.
  * Normalized variations in capitalization, accents, spacing, punctuation, and known header aliases.
  * Added clear diagnostic errors when required source headers, such as “Año,” are missing.
  * Preserved accented characters during data loading and cleaning.

* **Tests**
  * Added regression coverage for encoding detection, header normalization, aliases, and invalid headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->