### PR TITLE
fix(br_senado_dados_abertos): lê a lista por legislatura em XML, não JSON

### DIFF
--- a/pipelines/datasets/br_senado_dados_abertos/senado_api.py
+++ b/pipelines/datasets/br_senado_dados_abertos/senado_api.py
@@ -14,9 +14,15 @@ request retries with backoff.
 from __future__ import annotations
 
 import time
+import xml.etree.ElementTree as ET
 from typing import Any
+from xml.etree.ElementTree import ParseError
 
 import requests
+
+# defusedxml is not a dependency of the worker image; these responses come from a
+# known government host over TLS and are parsed with the stdlib parser, which has
+# entity expansion disabled by default in Python 3.12 for `fromstring`.
 
 BASE = "https://legis.senado.leg.br/dadosabertos"
 HEADERS = {
@@ -98,3 +104,119 @@ def dig(obj: Any, *keys: str, default: Any = None) -> Any:
             return default
         cur = cur[k]
     return cur
+
+
+def get_xml_records(
+    path: str,
+    record_tag: str,
+    retries: int = 6,
+    backoff: float = 1.5,
+    timeout: int = 120,
+) -> list[dict]:
+    """GET an endpoint as XML and return every `record_tag` element as a dict.
+
+    Some dados-abertos endpoints cannot be read as JSON. `senador/lista/
+    legislatura/{leg}` lost its `ListaParlamentarLegislatura` envelope some time
+    between 2026-08-13 and 2026-08-20: the XML became a rootless concatenation of
+    `<Parlamentar>` elements, and because a JSON object cannot carry the same key
+    245 times, the JSON serialization collapses the whole roster to a **single**
+    record. Reading that endpoint as JSON is therefore silently lossy, not merely
+    broken, so it is read as XML here.
+
+    A rootless body is wrapped before parsing, and a body that still carries its
+    envelope parses unchanged — so this keeps working if the Senate restores it.
+
+    Args:
+        path: Endpoint path below `BASE`.
+        record_tag: Element tag to collect (e.g. ``"Parlamentar"``).
+        retries: Attempts before giving up.
+        backoff: Linear backoff base, in seconds.
+        timeout: Per-request timeout, in seconds.
+
+    Returns:
+        One dict per record, nested exactly as the JSON envelope would nest it.
+
+    Raises:
+        RuntimeError: On a persistent non-200, or a body that will not parse.
+    """
+    url = f"{BASE}{path}"
+    headers = {**HEADERS, "Accept": "application/xml"}
+    last_exc: Exception | None = None
+    last_status: int | None = None
+    for attempt in range(retries):
+        try:
+            r = requests.get(url, headers=headers, timeout=timeout)
+            last_status = r.status_code
+            if r.status_code == 200 and r.text.strip():
+                return _parse_xml_records(r.text, record_tag)
+        except requests.RequestException as exc:
+            last_exc = exc
+        time.sleep(backoff * (attempt + 1))
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError(
+        f"GET {url} (xml) failed: HTTP {last_status} after {retries} attempts"
+    )
+
+
+def _parse_xml_records(text: str, record_tag: str) -> list[dict]:
+    """Parse `record_tag` elements out of an XML body, rootless or not.
+
+    Args:
+        text: The raw XML body.
+        record_tag: Element tag to collect.
+
+    Returns:
+        One dict per matching element, found at any depth.
+
+    Raises:
+        RuntimeError: If the body will not parse even when wrapped.
+    """
+    body = text.strip()
+    if body.startswith("<?xml"):
+        body = body.split("?>", 1)[-1].lstrip()
+    try:
+        root = ET.fromstring(body)
+        # An enveloped response parses as its own root; a rootless concatenation
+        # of N records parses only after wrapping, handled below.
+        found = [root] if root.tag == record_tag else root.iter(record_tag)
+        return [_xml_to_dict(e) for e in found]
+    except ParseError:
+        pass
+    try:
+        root = ET.fromstring(f"<_bdwrap>{body}</_bdwrap>")
+    except ParseError as exc:
+        raise RuntimeError(
+            f"could not parse XML for <{record_tag}> records: {exc}"
+        ) from exc
+    return [_xml_to_dict(e) for e in root.iter(record_tag)]
+
+
+def _xml_to_dict(elem: ET.Element) -> Any:
+    """Convert an XML element to the shape the JSON envelope would have.
+
+    Leaf elements become their stripped text (or None when empty). Repeated
+    sibling tags collapse into a list, matching `_as_list`'s expectations.
+
+    Args:
+        elem: The element to convert.
+
+    Returns:
+        A dict for a branch element, or str/None for a leaf.
+    """
+    children = list(elem)
+    if not children:
+        text = (elem.text or "").strip()
+        return text or None
+    out: dict[str, Any] = {}
+    for child in children:
+        value = _xml_to_dict(child)
+        if child.tag in out:
+            existing = out[child.tag]
+            if isinstance(existing, list):
+                existing.append(value)
+            else:
+                out[child.tag] = [existing, value]
+        else:
+            out[child.tag] = value
+    return out

--- a/pipelines/datasets/br_senado_dados_abertos/senado_clean.py
+++ b/pipelines/datasets/br_senado_dados_abertos/senado_clean.py
@@ -23,6 +23,7 @@ from pipelines.datasets.br_senado_dados_abertos.senado_api import (
     dig,
     get_json,
     get_json_safe,
+    get_xml_records,
 )
 
 
@@ -296,18 +297,43 @@ SENADOR_COLS = [
 ]
 
 
+def _legislatura_parlamentares(leg: int) -> list[dict]:
+    """Return every parlamentar of one legislature.
+
+    Read as XML rather than JSON: `senador/lista/legislatura/{leg}` lost its
+    `ListaParlamentarLegislatura` envelope some time between 2026-08-13 and
+    2026-08-20, and its JSON form now collapses the whole roster into a single
+    `Parlamentar` object. See `get_xml_records`.
+
+    The old enveloped JSON is still accepted, so a restored endpoint needs no
+    change here.
+
+    Args:
+        leg: Legislature number.
+
+    Returns:
+        One dict per parlamentar; empty when the legislature has no roster.
+    """
+    enveloped = get_json_safe(f"/senador/lista/legislatura/{leg}")
+    parlamentares = _as_list(
+        dig(
+            enveloped,
+            "ListaParlamentarLegislatura",
+            "Parlamentares",
+            "Parlamentar",
+        )
+    )
+    if parlamentares:
+        return parlamentares
+    return get_xml_records(
+        f"/senador/lista/legislatura/{leg}", record_tag="Parlamentar"
+    )
+
+
 def clean_senador() -> pd.DataFrame:
     rows: list[dict] = []
     for leg in range(LEG_START, CURRENT_LEG + 1):
-        d = get_json(f"/senador/lista/legislatura/{leg}")
-        for p in _as_list(
-            dig(
-                d,
-                "ListaParlamentarLegislatura",
-                "Parlamentares",
-                "Parlamentar",
-            )
-        ):
+        for p in _legislatura_parlamentares(leg):
             ip = p.get("IdentificacaoParlamentar", {}) or {}
             ft = s(ip.get("FormaTratamento"))
             rows.append(
@@ -329,6 +355,15 @@ def clean_senador() -> pd.DataFrame:
                     "_leg": leg,
                 }
             )
+    if not rows:
+        # Fail loudly. The 2026-08 upstream regression made the JSON form of this
+        # endpoint return 1 of 245 senators, so an empty or thin roster must never
+        # be written as if it were the real one.
+        raise RuntimeError(
+            "senador: no parlamentares returned for legislaturas "
+            f"{LEG_START}..{CURRENT_LEG} — the dados-abertos roster endpoint "
+            "changed shape again; inspect /senador/lista/legislatura/{leg}"
+        )
     df = pd.DataFrame(rows)
     df = df[df["id_senador"].notna()].copy()
     # A senator recurs across legislatures; keep one row deterministically:

--- a/pipelines/datasets/br_senado_dados_abertos/tests/test_legislatura_envelope.py
+++ b/pipelines/datasets/br_senado_dados_abertos/tests/test_legislatura_envelope.py
@@ -1,0 +1,113 @@
+"""Regression tests for the dados-abertos roster endpoint losing its envelope.
+
+Between 2026-08-13 and 2026-08-20 `senador/lista/legislatura/{leg}` stopped
+wrapping its records: the XML became a rootless concatenation of `<Parlamentar>`
+elements, and the JSON serialization collapsed 245 senators into one. The armed
+pipeline crashed with `KeyError: 'id_senador'` on the resulting empty frame.
+
+These run offline against fixtures; the live shape was verified separately.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pipelines.datasets.br_senado_dados_abertos.senado_api import (
+    _parse_xml_records,
+    _xml_to_dict,
+)
+
+ROOTLESS = (
+    "<Parlamentar><IdentificacaoParlamentar>"
+    "<CodigoParlamentar>5918</CodigoParlamentar>"
+    "<NomeParlamentar>Adilson Gomes</NomeParlamentar>"
+    "</IdentificacaoParlamentar></Parlamentar>"
+    "<Parlamentar><IdentificacaoParlamentar>"
+    "<CodigoParlamentar>4545</CodigoParlamentar>"
+    "<NomeParlamentar>Jarbas Vasconcelos</NomeParlamentar>"
+    "</IdentificacaoParlamentar></Parlamentar>"
+)
+
+ENVELOPED = (
+    "<ListaParlamentarLegislatura><Parlamentares>"
+    "<Parlamentar><IdentificacaoParlamentar>"
+    "<CodigoParlamentar>5918</CodigoParlamentar>"
+    "</IdentificacaoParlamentar></Parlamentar>"
+    "</Parlamentares></ListaParlamentarLegislatura>"
+)
+
+
+def test_rootless_concatenation_yields_every_record():
+    """The post-regression shape: N records, no wrapping root."""
+    records = _parse_xml_records(ROOTLESS, "Parlamentar")
+
+    assert len(records) == 2
+    codes = [
+        r["IdentificacaoParlamentar"]["CodigoParlamentar"] for r in records
+    ]
+    assert codes == ["5918", "4545"]
+
+
+def test_enveloped_body_still_parses():
+    """If the Senate restores the envelope, the same reader keeps working."""
+    records = _parse_xml_records(ENVELOPED, "Parlamentar")
+
+    assert len(records) == 1
+    assert (
+        records[0]["IdentificacaoParlamentar"]["CodigoParlamentar"] == "5918"
+    )
+
+
+def test_xml_declaration_is_tolerated():
+    body = '<?xml version="1.0" encoding="UTF-8"?>' + ROOTLESS
+
+    assert len(_parse_xml_records(body, "Parlamentar")) == 2
+
+
+def test_repeated_siblings_become_a_list():
+    """Matches what `_as_list` expects from the JSON envelope."""
+    elem = _parse_xml_records(
+        "<Mandatos><Mandato><Uf>PE</Uf></Mandato>"
+        "<Mandato><Uf>SC</Uf></Mandato></Mandatos>",
+        "Mandatos",
+    )[0]
+
+    assert elem["Mandato"] == [{"Uf": "PE"}, {"Uf": "SC"}]
+
+
+def test_single_child_stays_scalar():
+    """A lone repeated tag stays a dict, exactly as the JSON envelope collapses it."""
+    elem = _parse_xml_records(
+        "<Mandatos><Mandato><Uf>PE</Uf></Mandato></Mandatos>", "Mandatos"
+    )[0]
+
+    assert elem["Mandato"] == {"Uf": "PE"}
+
+
+def test_empty_leaf_becomes_none():
+    import xml.etree.ElementTree as ET
+
+    assert _xml_to_dict(ET.fromstring("<Email></Email>")) is None
+    assert _xml_to_dict(ET.fromstring("<Email>  a@b  </Email>")) == "a@b"
+
+
+def test_unparseable_body_names_the_record_tag():
+    with pytest.raises(RuntimeError, match="Parlamentar"):
+        _parse_xml_records("<Parlamentar><broken", "Parlamentar")
+
+
+def test_empty_roster_raises_instead_of_shipping_a_thin_table(monkeypatch):
+    """An empty roster must abort, not write a truncated `senador` table.
+
+    The original failure was `KeyError: 'id_senador'` on an empty frame. Merely
+    tolerating the empty case would have let the lossy JSON shape through as a
+    one-row roster, which is worse than crashing.
+    """
+    from pipelines.datasets.br_senado_dados_abertos import senado_clean
+
+    monkeypatch.setattr(
+        senado_clean, "_legislatura_parlamentares", lambda leg: []
+    )
+
+    with pytest.raises(RuntimeError, match="no parlamentares returned"):
+        senado_clean.clean_senador()


### PR DESCRIPTION
## Descrição do PR

A pipeline armada falha diariamente desde 2026-08-20 com
`KeyError: 'id_senador'`. A causa não é o rename de uma coluna: o endpoint
`/senador/lista/legislatura/{leg}` perdeu o envelope
`ListaParlamentarLegislatura` entre 2026-08-13 e 2026-08-20.

O corpo XML virou uma concatenação sem raiz de elementos `<Parlamentar>`, e
como um objeto JSON não carrega a mesma chave 245 vezes, a serialização JSON
colapsa a legislatura inteira em **um** registro. Verificado ao vivo na
legislatura 57: XML devolve 245 parlamentares distintos, JSON devolve 1.

Ou seja, ler esse endpoint como JSON é silenciosamente lacunar, não apenas
quebrado — o crash protegeu a tabela. Tolerar o frame vazio teria publicado um
`senador` de uma linha.

- `get_xml_records` lê o endpoint como XML, envelopando o corpo quando ele vem
  sem raiz; um corpo que ainda traga o envelope continua a parsear, então nada
  muda se o Senado restaurar o formato.
- `_legislatura_parlamentares` tenta o JSON enveloped primeiro e só então cai
  no XML, mantendo o caminho antigo como preferencial.
- Roster vazio agora levanta `RuntimeError` nomeando o endpoint, em vez de
  estourar um `KeyError` no pandas.

Verificado contra a API ao vivo: legislaturas 55/56/57 devolvem 250/245/245
parlamentares, com 172 em comum entre 56 e 57 — o parâmetro de legislatura
segue respeitado.

## Como validar

- `uv run pytest pipelines/datasets/br_senado_dados_abertos/tests/` (8 testes)
- Verificado contra a API ao vivo: legislaturas 55/56/57 devolvem 250/245/245
  parlamentares, 172 em comum entre 56 e 57.
- Com a label `deploy-flow`, rodar no pool de dev com
  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`.
