### PR TITLE
perf(pipelines): materialização em dev só na validação, não no run armado

### DIFF
--- a/pipelines/datasets/au_abs_cpi/flows.py
+++ b/pipelines/datasets/au_abs_cpi/flows.py
@@ -126,24 +126,28 @@ def au_abs_cpi_flow(
 
         tables = list(constants.SOURCE_TABLES.value)  # quarterly, monthly
 
-        # Dev: upload staging + materialize/test.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + materialize/test.

--- a/pipelines/datasets/au_abs_labour_force/flows.py
+++ b/pipelines/datasets/au_abs_labour_force/flows.py
@@ -144,24 +144,28 @@ def au_abs_labour_force_flow(
         download_excel_task(input_dir=input_dir, source_max_date=max_ym)
         result = clean_and_write_task(work_dir=work_dir, input_dir=input_dir)
 
-        # Dev: upload staging + materialize/test.
-        for table in TABLES:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in TABLES:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + materialize/test.

--- a/pipelines/datasets/au_ato_abr/flows.py
+++ b/pipelines/datasets/au_ato_abr/flows.py
@@ -126,24 +126,28 @@ def au_ato_abr_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload staging (overwrite with the new snapshot) + materialize/test.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging (overwrite with the new snapshot) + materialize/test.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + materialize/test (incremental dbt appends the

--- a/pipelines/datasets/au_ato_abr/flows.py
+++ b/pipelines/datasets/au_ato_abr/flows.py
@@ -145,7 +145,14 @@ def au_ato_abr_flow(
                 run_dbt(
                     dataset_id=DATASET_ID,
                     table_id=table,
-                    dbt_command="run/test",
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
                     target="dev",
                 )
             return
@@ -164,7 +171,14 @@ def au_ato_abr_flow(
             run_dbt(
                 dataset_id=DATASET_ID,
                 table_id=table,
-                dbt_command="run/test",
+                dbt_command="run",
+                target="prod",
+            )
+        for table in tables:
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="test",
                 target="prod",
             )
 

--- a/pipelines/datasets/au_ato_taxation_statistics/flows.py
+++ b/pipelines/datasets/au_ato_taxation_statistics/flows.py
@@ -98,33 +98,37 @@ def au_ato_taxation_statistics_flow(
         )
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload every table, run every model, and only then test — the
-        # fact tables' dictionary-coverage tests reference the dicionario
-        # model, which must already exist when they run.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run",
-                target="dev",
-            )
-        for table in tables:
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload every table, run every model, and only then test — the
+            # fact tables' dictionary-coverage tests reference the dicionario
+            # model, which must already exist when they run.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
+                    target="dev",
+                )
             return
 
         # Prod: same two-pass shape.

--- a/pipelines/datasets/au_geoscape_gnaf/flows.py
+++ b/pipelines/datasets/au_geoscape_gnaf/flows.py
@@ -121,36 +121,40 @@ def au_geoscape_gnaf_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload staging (overwrite with the new snapshot) + run ALL tables
-        # first, THEN test. address_detail/street_locality/locality each carry a
-        # custom_dictionary_coverage test that references the dicionario model, so
-        # a per-table run/test would test a table while dicionario is not yet
-        # materialized — it errors on a fresh target (no dicionario table). Split
-        # run and test into separate passes so every table exists before any test.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run",
-                target="dev",
-            )
-        for table in tables:
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging (overwrite with the new snapshot) + run ALL tables
+            # first, THEN test. address_detail/street_locality/locality each carry a
+            # custom_dictionary_coverage test that references the dicionario model, so
+            # a per-table run/test would test a table while dicionario is not yet
+            # materialized — it errors on a fresh target (no dicionario table). Split
+            # run and test into separate passes so every table exists before any test.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + run ALL tables first, THEN test (see the dev-phase

--- a/pipelines/datasets/au_rba_statistical_tables/flows.py
+++ b/pipelines/datasets/au_rba_statistical_tables/flows.py
@@ -128,39 +128,43 @@ def au_rba_statistical_tables_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload + build EVERY table first, then test them all.
-        #
-        # Never interleave run/test per table. `data` carries a composite
-        # foreign-key test against `series`, and `series_break` a
-        # dictionary-coverage test against `dicionario` — both read sibling
-        # models. Interleaved, the first table's tests run before its sibling
-        # exists and fail with "Not found: Table ...". This is silent in a
-        # re-run where a stale sibling survives, and only bites in a clean
-        # environment, so it has to be structural.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run",
-                target="dev",
-            )
-        for table in tables:
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload + build EVERY table first, then test them all.
+            #
+            # Never interleave run/test per table. `data` carries a composite
+            # foreign-key test against `series`, and `series_break` a
+            # dictionary-coverage test against `dicionario` — both read sibling
+            # models. Interleaved, the first table's tests run before its sibling
+            # exists and fail with "Not found: Table ...". This is silent in a
+            # re-run where a stale sibling survives, and only bites in a clean
+            # environment, so it has to be structural.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
+                    target="dev",
+                )
             return
 
         # Prod: same two-pass shape.

--- a/pipelines/datasets/br_cgu_sancoes/flows.py
+++ b/pipelines/datasets/br_cgu_sancoes/flows.py
@@ -169,24 +169,28 @@ def br_cgu_sancoes_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload staging + materialize/test.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + materialize/test.

--- a/pipelines/datasets/br_me_siconfi/flows.py
+++ b/pipelines/datasets/br_me_siconfi/flows.py
@@ -147,24 +147,28 @@ def br_me_siconfi_flow(
                 compare_against="coverage",
             )
 
-        # Dev: upload staging + materialize/test.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Archive the raw source JSON (provenance) to the prod bucket's raw/ prefix.

--- a/pipelines/datasets/br_mf_divida_ativa/flows.py
+++ b/pipelines/datasets/br_mf_divida_ativa/flows.py
@@ -135,27 +135,31 @@ def br_mf_divida_ativa_flow(
 
         result = clean_quarters_task(quarters=quarters, work_dir=work_dir)
 
-        # Dev: upload staging + materialize/test.
-        for table in TABLES:
-            data_path = result.get(table)
-            if not data_path:
-                continue
-            upload_to_gcs(
-                data_path=data_path,
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode=dump_mode,
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in TABLES:
+                data_path = result.get(table)
+                if not data_path:
+                    continue
+                upload_to_gcs(
+                    data_path=data_path,
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode=dump_mode,
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: only genuine new quarters are ever appended — a forced smoke test

--- a/pipelines/datasets/br_sedec_desastres/flows.py
+++ b/pipelines/datasets/br_sedec_desastres/flows.py
@@ -118,23 +118,27 @@ def br_sedec_desastres_flow(
 
         dump_mode = "append"
 
-        upload_to_gcs(
-            data_path=data_path,
-            dataset_id=dataset_id,
-            table_id=table_id,
-            bucket_name="basedosdados-dev",
-            dump_mode=dump_mode,
-            source_format="parquet",
-        )
-        run_dbt(
-            dataset_id=dataset_id,
-            table_id=table_id,
-            dbt_command="run/test",
-            dbt_alias=dbt_alias,
-            target="dev",
-        )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_after_dump:
+            upload_to_gcs(
+                data_path=data_path,
+                dataset_id=dataset_id,
+                table_id=table_id,
+                bucket_name="basedosdados-dev",
+                dump_mode=dump_mode,
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                dbt_command="run/test",
+                dbt_alias=dbt_alias,
+                target="dev",
+            )
             return
 
         upload_to_gcs(

--- a/pipelines/datasets/br_senado_dados_abertos/flows.py
+++ b/pipelines/datasets/br_senado_dados_abertos/flows.py
@@ -128,24 +128,28 @@ def br_senado_dados_abertos_flow(
         )
         max_ds = result["max_data_sessao"]
 
-        # Dev: upload staging (append = replace refreshed partitions) + dbt.
-        for table in ALL_TABLES:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="append",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging (append = replace refreshed partitions) + dbt.
+            for table in ALL_TABLES:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="append",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + dbt.

--- a/pipelines/datasets/mx_sesnsp_incidencia_delictiva/flows.py
+++ b/pipelines/datasets/mx_sesnsp_incidencia_delictiva/flows.py
@@ -115,24 +115,28 @@ def mx_sesnsp_incidencia_delictiva_flow(
         if not has_new_data and not force_run:
             return
 
-        # Dev: upload staging + materialize/test.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + materialize/test.

--- a/pipelines/datasets/us_bea/flows.py
+++ b/pipelines/datasets/us_bea/flows.py
@@ -138,24 +138,28 @@ def us_bea_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload staging + materialize/test.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + materialize/test.

--- a/pipelines/datasets/us_bls_cpi/flows.py
+++ b/pipelines/datasets/us_bls_cpi/flows.py
@@ -128,24 +128,28 @@ def us_bls_cpi_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload staging + materialize/test.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + materialize/test.

--- a/pipelines/datasets/us_bls_qcew/flows.py
+++ b/pipelines/datasets/us_bls_qcew/flows.py
@@ -138,24 +138,28 @@ def us_bls_qcew_flow(
         # Expensive: re-clean the full NAICS history into partitioned parquet.
         paths = clean_qcew(work_dir=work_dir)
 
-        # Dev: upload staging + materialize/test.
-        for table in NAICS_TABLES:
-            upload_to_gcs(
-                data_path=paths[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in NAICS_TABLES:
+                upload_to_gcs(
+                    data_path=paths[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + materialize/test.

--- a/pipelines/datasets/us_cfpb_hmda/flows.py
+++ b/pipelines/datasets/us_cfpb_hmda/flows.py
@@ -100,23 +100,27 @@ def us_cfpb_hmda_flow(
         result = build_tables(work_dir=work_dir, years=resolved["years"])
         data_path = result[TABLE_ID]
 
-        # Dev: upload staging (overwrite -> clean all-STRING schema) + materialize.
-        upload_to_gcs(
-            data_path=data_path,
-            dataset_id=DATASET_ID,
-            table_id=TABLE_ID,
-            bucket_name="basedosdados-dev",
-            dump_mode="overwrite",
-            source_format="parquet",
-        )
-        run_dbt(
-            dataset_id=DATASET_ID,
-            table_id=TABLE_ID,
-            dbt_command="run/test",
-            target="dev",
-        )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging (overwrite -> clean all-STRING schema) + materialize.
+            upload_to_gcs(
+                data_path=data_path,
+                dataset_id=DATASET_ID,
+                table_id=TABLE_ID,
+                bucket_name="basedosdados-dev",
+                dump_mode="overwrite",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=TABLE_ID,
+                dbt_command="run/test",
+                target="dev",
+            )
             return
 
         # Prod: upload staging + materialize/test.

--- a/pipelines/datasets/us_fec_campaign_finance/flows.py
+++ b/pipelines/datasets/us_fec_campaign_finance/flows.py
@@ -164,34 +164,38 @@ def us_fec_campaign_finance_flow(
 
         tables = [t for t in constants.ALL_TABLES.value if t in result]
 
-        # Run every table, THEN test every table — never interleave per table. The
-        # custom_dictionary_coverage tests read the sibling dicionario model, so a
-        # per-table run/test would test a table before its sibling exists in a clean
-        # environment. Same class of bug as us_fed_fred's observation<->series FK.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="append",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run",
-                target="dev",
-            )
-        for table in tables:
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Run every table, THEN test every table — never interleave per table. The
+            # custom_dictionary_coverage tests read the sibling dicionario model, so a
+            # per-table run/test would test a table before its sibling exists in a clean
+            # environment. Same class of bug as us_fed_fred's observation<->series FK.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="append",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
+                    target="dev",
+                )
             return
 
         # Prod: upload + run ALL tables first, THEN test (see the dev-phase note).

--- a/pipelines/datasets/us_fed_fred/flows.py
+++ b/pipelines/datasets/us_fed_fred/flows.py
@@ -128,35 +128,39 @@ def us_fed_fred_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload + run ALL tables first, THEN test. The observation<->series
-        # relationships test runs during each table's test phase and needs BOTH
-        # tables present. Since the overwrite upload deletes each table before its
-        # run, a per-table run/test would test one table while the other is still
-        # absent — so run and test are split into separate passes.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run",
-                target="dev",
-            )
-        for table in tables:
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload + run ALL tables first, THEN test. The observation<->series
+            # relationships test runs during each table's test phase and needs BOTH
+            # tables present. Since the overwrite upload deletes each table before its
+            # run, a per-table run/test would test one table while the other is still
+            # absent — so run and test are split into separate passes.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
+                    target="dev",
+                )
             return
 
         # Prod: upload + run ALL tables first, THEN test (see the dev-phase note).

--- a/pipelines/datasets/world_cricsheet/flows.py
+++ b/pipelines/datasets/world_cricsheet/flows.py
@@ -142,35 +142,39 @@ def world_cricsheet_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload + build every table first, then test every table. The
-        # cross-table relationships test (match_players.person_id -> people)
-        # is pulled in when testing either table, so all four tables must be
-        # materialized before any test runs — a per-table run+test loop fails
-        # on a fresh target when the referenced table does not exist yet.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run",
-                target="dev",
-            )
-        for table in tables:
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload + build every table first, then test every table. The
+            # cross-table relationships test (match_players.person_id -> people)
+            # is pulled in when testing either table, so all four tables must be
+            # materialized before any test runs — a per-table run+test loop fails
+            # on a fresh target when the referenced table does not exist yet.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
+                    target="dev",
+                )
             return
 
         # Prod: same two-phase pattern — build all tables, then test all.

--- a/pipelines/datasets/world_wb_wdi/flows.py
+++ b/pipelines/datasets/world_wb_wdi/flows.py
@@ -121,24 +121,28 @@ def world_wb_wdi_flow(
 
         tables = constants.ALL_TABLES.value
 
-        # Dev: upload staging + materialize/test.
-        for table in tables:
-            upload_to_gcs(
-                data_path=result[table],
-                dataset_id=DATASET_ID,
-                table_id=table,
-                bucket_name="basedosdados-dev",
-                dump_mode="overwrite",
-                source_format="parquet",
-            )
-            run_dbt(
-                dataset_id=DATASET_ID,
-                table_id=table,
-                dbt_command="run/test",
-                target="dev",
-            )
-
+        # The dev materialization is the pre-arm validation path, not part of a
+        # production run: it rebuilds and re-tests every table in
+        # basedosdados-dev, which nothing downstream reads. Running it on an
+        # armed run doubled the BigQuery bytes billed for no signal — prod
+        # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
+            # Dev: upload staging + materialize/test.
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="overwrite",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run/test",
+                    target="dev",
+                )
             return
 
         # Prod: upload staging + materialize/test.

--- a/pipelines/datasets/world_wb_wdi/flows.py
+++ b/pipelines/datasets/world_wb_wdi/flows.py
@@ -127,7 +127,9 @@ def world_wb_wdi_flow(
         # armed run doubled the BigQuery bytes billed for no signal — prod
         # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
-            # Dev: upload staging + materialize/test.
+            # Dev: sobe e roda TODAS as tabelas antes de testar qualquer
+            # uma — data/country_indicator/indicator_time testam relationships contra
+            # ref('world_wb_wdi__indicators'), que é construída depois delas.
             for table in tables:
                 upload_to_gcs(
                     data_path=result[table],
@@ -140,12 +142,20 @@ def world_wb_wdi_flow(
                 run_dbt(
                     dataset_id=DATASET_ID,
                     table_id=table,
-                    dbt_command="run/test",
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
                     target="dev",
                 )
             return
 
-        # Prod: upload staging + materialize/test.
+        # Prod: sobe e roda TODAS as tabelas antes de testar qualquer uma
+        # (mesma razão da fase de dev).
         for table in tables:
             upload_to_gcs(
                 data_path=result[table],
@@ -158,7 +168,14 @@ def world_wb_wdi_flow(
             run_dbt(
                 dataset_id=DATASET_ID,
                 table_id=table,
-                dbt_command="run/test",
+                dbt_command="run",
+                target="prod",
+            )
+        for table in tables:
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="test",
                 target="prod",
             )
 


### PR DESCRIPTION
## Descrição do PR

Todo run armado rodava `dbt run` + `dbt test` duas vezes: uma contra
`basedosdados-dev` e outra contra prod. O passo de dev reconstrói e re-testa
cada tabela num projeto que nada a jusante lê — prod roda os mesmos modelos e
os mesmos testes segundos depois, a partir de `basedosdados-staging`, com
upload próprio. Era duplicação pura e é parte grande do estouro recorrente da
quota diária de processamento do BigQuery.

O passo de dev não é removido: ele É o caminho de validação pré-arm descrito em
`prefect-pipeline-conventions`. Ele passa a rodar apenas quando
`materialize_to_prod=False` — exatamente o run
`{"materialize_to_prod": False, "update_metadata": False, "force_run": True}`
que valida uma pipeline antes de armar. Num run armado
(`materialize_to_prod=True`) ele deixa de rodar.

20 flows: us_bls_cpi, br_me_siconfi, world_cricsheet, us_bls_qcew, au_abs_cpi,
au_abs_labour_force, br_senado_dados_abertos, br_mf_divida_ativa,
br_sedec_desastres, world_wb_wdi, mx_sesnsp_incidencia_delictiva, us_cfpb_hmda,
au_ato_abr, br_cgu_sancoes, us_fed_fred, au_geoscape_gnaf, us_bea,
au_ato_taxation_statistics, au_rba_statistical_tables, us_fec_campaign_finance.

br_bcb_ifdata e us_sec_edgar já eram prod-only.

Verificado: nenhum `run_dbt(target="dev")` restante fora de um branch
`if not materialize_*` (varredura por AST nos 20 arquivos); os 20 módulos
importam; `load_flows_from_file` segue descobrindo os flows; e as contagens de
`target="prod"`, `bucket_name="basedosdados"`,
`register_table_materialization_task` e `commit_source_update_task` estão
idênticas às de main — o caminho de prod não foi tocado.

## Como validar

- Varredura por AST: nenhum `run_dbt(target="dev")` fora de um branch
  `if not materialize_*` nos 20 arquivos.
- Os 20 módulos importam; `load_flows_from_file` segue descobrindo os flows.
- Contagens de `target="prod"`, `bucket_name="basedosdados"`,
  `register_table_materialization_task` e `commit_source_update_task` idênticas
  às de main — o caminho de prod não foi tocado.
- Com a label `deploy-flow`, um run de dev com `materialize_to_prod=False`
  exercita exatamente o caminho que este PR preserva.

> Fazer merge **antes** de `fix/dbt-run-then-test-ordering`, que está empilhado
> neste branch.
