### PR TITLE
fix(world_wb_wdi, au_ato_abr): roda todas as tabelas antes de testar qualquer uma

### DIFF
--- a/pipelines/datasets/au_ato_abr/flows.py
+++ b/pipelines/datasets/au_ato_abr/flows.py
@@ -145,7 +145,14 @@ def au_ato_abr_flow(
                 run_dbt(
                     dataset_id=DATASET_ID,
                     table_id=table,
-                    dbt_command="run/test",
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
                     target="dev",
                 )
             return
@@ -164,7 +171,14 @@ def au_ato_abr_flow(
             run_dbt(
                 dataset_id=DATASET_ID,
                 table_id=table,
-                dbt_command="run/test",
+                dbt_command="run",
+                target="prod",
+            )
+        for table in tables:
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="test",
                 target="prod",
             )
 

--- a/pipelines/datasets/world_wb_wdi/flows.py
+++ b/pipelines/datasets/world_wb_wdi/flows.py
@@ -127,7 +127,9 @@ def world_wb_wdi_flow(
         # armed run doubled the BigQuery bytes billed for no signal — prod
         # runs the same models and the same tests seconds later.
         if not materialize_to_prod:
-            # Dev: upload staging + materialize/test.
+            # Dev: sobe e roda TODAS as tabelas antes de testar qualquer
+            # uma — data/country_indicator/indicator_time testam relationships contra
+            # ref('world_wb_wdi__indicators'), que é construída depois delas.
             for table in tables:
                 upload_to_gcs(
                     data_path=result[table],
@@ -140,12 +142,20 @@ def world_wb_wdi_flow(
                 run_dbt(
                     dataset_id=DATASET_ID,
                     table_id=table,
-                    dbt_command="run/test",
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
                     target="dev",
                 )
             return
 
-        # Prod: upload staging + materialize/test.
+        # Prod: sobe e roda TODAS as tabelas antes de testar qualquer uma
+        # (mesma razão da fase de dev).
         for table in tables:
             upload_to_gcs(
                 data_path=result[table],
@@ -158,7 +168,14 @@ def world_wb_wdi_flow(
             run_dbt(
                 dataset_id=DATASET_ID,
                 table_id=table,
-                dbt_command="run/test",
+                dbt_command="run",
+                target="prod",
+            )
+        for table in tables:
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="test",
                 target="prod",
             )
 


### PR DESCRIPTION
## Descrição do PR

Mesma classe de bug já corrigida em us_fed_fred (#1826) e au_geoscape_gnaf
(#1833): um `dbt_command="run/test"` dentro do laço por tabela testa a primeira
tabela antes de as irmãs existirem. Testes que leem modelos irmãos falham num
ambiente limpo e passam por sorte quando sobra uma versão antiga da irmã.

Os dois datasets têm referências a irmãs do mesmo dataset, e nos dois a irmã é
construída depois de quem a referencia:

- `world_wb_wdi`: `data`, `country_indicator` e `indicator_time` testam
  `relationships` contra `ref('world_wb_wdi__indicators')`, mas `data` é a
  primeira de ALL_TABLES e `indicators` a segunda.
- `au_ato_abr`: `entity` e `other_name` usam `custom_dictionary_coverage` contra
  `ref('au_ato_abr__dicionario')`, que é a última de ALL_TABLES.

Não é latente: au_ato_abr falhou exatamente assim em prod em 2026-08-18
("dbt test falhou para models/au_ato_abr/au_ato_abr__entity.sql (target=prod)").

`run` e `test` passam a ser dois laços separados, por ambiente — a forma que
`prefect-pipeline-conventions` já prescreve.

br_rf_cnpj também tem referências a irmãs, mas ficou de fora: o time já está
mexendo nele.

> **Base:** `pipeline/skip-dev-dbt-on-prod-runs` (empilhado — mexe nas mesmas
> linhas). Fazer merge daquele primeiro.

## Como validar

- Varredura por AST: nenhum `dbt_command="run/test"` restante nos dois flows.
- Os módulos importam.
- Com a label `deploy-flow`, rodar no pool de dev; o sintoma original só aparece
  em ambiente limpo.
