### PR TITLE
docs(pipelines): CLAUDE.md para os 18 datasets recorrentes que não tinham

### DIFF
--- a/models/au_abs_cpi/CLAUDE.md
+++ b/models/au_abs_cpi/CLAUDE.md
@@ -1,0 +1,52 @@
+# au_abs_cpi
+
+Australian Consumer Price Index (ABS). Every release ships the full history in the time-
+series spreadsheets, so each run is a **full replace** (``dump_mode="overwrite"``), not
+an incremental append. A single flow downloads the current release, rebuilds the
+quarterly and monthly tables, and materializes them. The source poll short-circuits the
+run until ABS publishes a newer month, which makes a scheduled run a cheap no-op between
+releases.
+
+## Refresh cadence
+- `0 16 22,23,24,25,26,27,28 * *` — 16:00 America/Sao_Paulo, day 22,23,24,25,26,27,28
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `monthly` | `year` (int64) | table | PartBdpro | 9 |
+| `quarterly` | `year` (int64) | table | AllFree | 9 |
+
+## Where the code lives
+- `pipelines/datasets/au_abs_cpi/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/au_abs_cpi/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/au_abs_cpi/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://www.abs.gov.au/statistics/economy/price-indexes-and-inflation/
+
+## Design notes
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``au_abs_cpi_flow``; the dev
+pool ignores the schedule, the prod pool activates it.
+
+No Prefect imports here. The one-shot onboarding bootstrap
+(models/au_abs_cpi/code/clean_data.py) and the recurring Prefect pipeline both import
+these functions, so the cleaning transform lives in exactly one place.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/au_abs_labour_force/CLAUDE.md
+++ b/models/au_abs_labour_force/CLAUDE.md
@@ -1,0 +1,79 @@
+# au_abs_labour_force
+
+Labour Force, Australia (ABS cat. 6202.0), monthly. Both sources ship the full history
+every release — the SDMX ``all`` query returns every period, and each ABS Excel
+spreadsheet carries the whole series — so every run is a **full replace**
+(``dump_mode="overwrite"``), not an incremental append. A single flow downloads once and
+rebuilds all four tables. The source poll short-circuits the run until the ABS publishes
+a newer reference month, so a scheduled run is a cheap no-op between releases.
+
+## Refresh cadence
+- `0 6 14-27 * *` — 06:00 America/Sao_Paulo, day 14-27
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "6Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `hours_worked` | `year` (int64) | table | — | 8 |
+| `labour_force_status` | `year` (int64) | table | — | 20 |
+| `status_in_employment` | `year` (int64) | table | — | 8 |
+| `underutilisation` | `year` (int64) | table | — | 10 |
+
+## Where the code lives
+- `pipelines/datasets/au_abs_labour_force/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/au_abs_labour_force/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/au_abs_labour_force/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://data.api.abs.gov.au/rest/data
+- https://www.abs.gov.au/statistics/labour/employment-and-unemployment/
+
+## Design notes
+Every table refreshes monthly, so each carries the BD Pro rolling window
+(``PartBdpro``): the most recent six months are pro-only, older data is free, and the
+window rolls forward on its own each run.
+
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``au_abs_labour_force_flow``;
+the dev pool ignores the schedule, the prod pool activates it (paused until armed).
+
+Pure functions (no Prefect) so they are importable and unit-testable. Schema and column
+order come from the architecture CSVs (the single source of truth).
+
+Sources ------- - SDMX-CSV (ABS Data API), ``labels=both`` so each cell is ``"code:
+label"``: * ``labour_force_status`` <- ``LF`` (states, age total) + ``LF_AGES``
+(national, all ages, adds Not-in-labour-force + Civilian population). *
+``underutilisation`` <- ``LF_UNDER`` (state and age). - ABS time-series Excel
+spreadsheets (curated API does not serve these): * ``hours_worked`` <- Table 18
+(national, by sex). * ``status_in_employment`` <- Table 19 (national) + SEM1 (states
+pivot).
+
+ABS reports counts in thousands and hours in thousands of hours; every value is scaled
+by ``10 ** UNIT_MULT`` (SDMX) or by the Index unit (Excel) to absolute persons / hours,
+so the ``person`` / ``hour`` measurement units are truthful. Rates are left untouched.
+National totals come from the national sources; states from the state sources — ABS
+benchmarks national separately, so national is never derived by summing states.
+
+- the ABS Data API (SDMX-CSV) for the status and underutilisation cubes — one ``all``
+query returns the full monthly history, so the pipeline query is month-agnostic; - the
+ABS time-series Excel spreadsheets for the hours-worked distribution and status-in-
+employment, which the curated API does not serve; these live under a month-stamped
+release path.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/au_ato_abr/CLAUDE.md
+++ b/models/au_ato_abr/CLAUDE.md
@@ -1,0 +1,73 @@
+# au_ato_abr
+
+Australian Business Register "ABN Bulk Extract" (data.gov.au, ATO). The source
+republishes a **full snapshot weekly**. We stack snapshots (CNPJ model): each run
+uploads the new snapshot to staging with ``dump_mode="overwrite"`` and the
+**incremental** dbt models append its ``extraction_date`` partition to the prod tables,
+so history accumulates.
+
+## Refresh cadence
+- `0 16 * * 1,2,3,4` — 16:00 America/Sao_Paulo, Mon/Tue/Wed/Thu
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "8Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `dgr` | `extraction_date` (date) | incremental | — | 5 |
+| `dicionario` | — | table | — | 5 |
+| `entity` | `extraction_date` (date) | incremental | — | 15 |
+| `other_name` | `extraction_date` (date) | incremental | — | 5 |
+
+## Where the code lives
+- `pipelines/datasets/au_ato_abr/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/au_ato_abr/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/au_ato_abr/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://data.gov.au/data/api/3/action/package_show?id=abn-bulk-extract
+- https://data.gov.au/data/dataset/5bd7fcab-e315-42cb-8daf-50b7efc2027e/
+
+## Design notes
+The run polls cheaply first (an HTTP HEAD on the ZIPs, compared against
+``Table.Update.latest``) and only downloads the ~1 GB payload when the source has
+actually republished — so a scheduled run is a cheap no-op between weekly releases.
+
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers ``au_ato_abr_flow``; the dev
+pool ignores the schedule, the prod pool activates it (deployed paused).
+
+Pure functions (no Prefect) so they are importable and unit-testable. The recurring
+pipeline wraps them in @task (see tasks.py); the bootstrap CLI imports ``clean_all`` /
+``download_zips`` directly.
+
+Records are streamed straight out of the two source ZIPs with ``lxml.iterparse`` (no
+full extraction to disk). Output is **all-STRING** hive-partitioned parquet:
+``upload_to_gcs`` infers the staging schema from a stringified header, so typed parquet
+is rejected; the dbt models ``safe_cast`` every column back to its real type.
+``extraction_date`` is encoded in the path only, never in the file body. Dates are built
+as real ``date32`` first, then arrow-cast to string (so NULLs stay NULL rather than
+becoming the literal ``"nan"``).
+
+Australian Business Register "ABN Bulk Extract" (data.gov.au, ATO). The source
+republishes a full snapshot **weekly**; we stack each snapshot, partitioned by
+``extraction_date`` (see models/au_ato_abr/ONBOARDING_PLAN.md). Each run uploads the new
+snapshot to staging with ``dump_mode="overwrite"`` and the incremental dbt models append
+the new ``extraction_date`` partition to the prod tables.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/au_ato_taxation_statistics/CLAUDE.md
+++ b/models/au_ato_taxation_statistics/CLAUDE.md
@@ -1,0 +1,61 @@
+# au_ato_taxation_statistics
+
+ATO Taxation Statistics (data.gov.au). The ATO reissues the whole collection once a year
+and revises earlier years in place, so each run refetches every in-scope release and
+does a **full replace** (``dump_mode="overwrite"``) rather than appending the newest
+year.
+
+## Refresh cadence
+- `0 16 20 * *` — 16:00 America/Sao_Paulo, day 20
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "8Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `company_industry` | `year` (int64) | table | — | 8 |
+| `dicionario` | — | table | — | 5 |
+| `gst_industry` | `year` (int64) | table | — | 8 |
+| `individuals_income_state` | `year` (int64) | table | — | 11 |
+| `individuals_industry` | `year` (int64) | table | — | 8 |
+| `individuals_postcode` | `year` (int64) | table | — | 9 |
+
+## Where the code lives
+- `pipelines/datasets/au_ato_taxation_statistics/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/au_ato_taxation_statistics/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/au_ato_taxation_statistics/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://data.gov.au/data/api/3/action/package_search
+- https://data.gov.au/data/api/3/action/package_show
+
+## Design notes
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers
+`au_ato_taxation_statistics_flow`; the dev pool ignores the schedule, the prod pool
+activates it.
+
+No Prefect imports here: this module is shared verbatim between the one-shot onboarding
+bootstrap (``models/au_ato_taxation_statistics/code``) and the recurring Prefect flow.
+
+The ATO publishes one CKAN package per financial year, each holding ~96 Excel workbooks.
+Every detailed table has the same shape: a few leading dimension columns followed by
+measure columns that come in ``<item> no.`` / ``<item> $`` pairs. The transform melts
+those pairs into a long ``item`` / ``record_count`` / ``amount`` triple.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/au_geoscape_gnaf/CLAUDE.md
+++ b/models/au_geoscape_gnaf/CLAUDE.md
@@ -1,0 +1,78 @@
+# au_geoscape_gnaf
+
+Geoscape **G-NAF** (Geocoded National Address File, data.gov.au). The source republishes
+a **full snapshot quarterly** (Feb/May/Aug/Nov). We stack snapshots (CNPJ model): each
+run uploads the new snapshot to staging with ``dump_mode="overwrite"`` and the
+**incremental** dbt models append its ``snapshot_date`` partition to the prod tables, so
+history accumulates.
+
+## Refresh cadence
+- `0 16 14,17,20,23,26 2,5,8,11 *` — 16:00 America/Sao_Paulo, day 14,17,20,23,26, Feb/May/Aug/Nov
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "16Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `address_detail` | `snapshot_date` (date) | incremental | — | 44 |
+| `dicionario` | — | table | — | 5 |
+| `locality` | `snapshot_date` (date) | incremental | — | 14 |
+| `street_locality` | `snapshot_date` (date) | incremental | — | 16 |
+
+## Where the code lives
+- `pipelines/datasets/au_geoscape_gnaf/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/au_geoscape_gnaf/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/au_geoscape_gnaf/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://data.gov.au/data/api/3/action/package_show
+
+## Design notes
+G-NAF is Open-G-NAF/CC-BY, so every table is ``AllFree`` — no BD Pro rolling window, no
+Row Access Policies. The quarterly cadence is well below the monthly-or-more paywall
+threshold.
+
+The run resolves the current release from the CKAN API and polls cheaply first (the
+resolved ``snapshot_date`` vs the free ``Coverage``), only downloading the ~1.6 GB
+payload when a newer quarterly snapshot has actually been published — so a scheduled run
+is a cheap no-op between quarterly releases.
+
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers ``au_geoscape_gnaf_flow``; the
+dev pool ignores the schedule, the prod pool activates it (deployed paused).
+
+Shared by the recurring pipeline (wrapped in ``@task`` in ``tasks.py``) and the one-shot
+bootstrap in ``models/au_geoscape_gnaf/code/clean.py`` (which imports ``clean_all``
+directly). Pure functions, no Prefect imports, so they are importable and unit-testable.
+
+Each quarterly G-NAF release is a full snapshot. The per-state PSV tables are read
+straight out of the downloaded all-states zip (no full extraction); the default geocode,
+locality/street points, and ABS mesh-block codes are folded into the three backbone
+tables; output is written as parquet partitioned by ``snapshot_date`` + ``id_state``
+(CNPJ-style stacking).
+
+- ``stringify=False`` — typed parquet (dates/floats/int). Used by the one-shot
+bootstrap, which uploads with an explicit typed hive schema. - ``stringify=True`` — all-
+STRING parquet + a 0-row ``00_header.parquet`` guard per partition. Required by the
+pipeline: ``upload_to_gcs`` infers the staging schema from a stringified header, so
+typed parquet is rejected, and the dbt models ``safe_cast`` every column back to its
+real type. The raw PSV values are already ISO dates / plain decimals / small ints, so
+the string path keeps them verbatim (empty -> NULL); it never round-trips through float,
+so no ``"1959.0"`` / ``"nan"`` artifacts appear.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/au_rba_statistical_tables/CLAUDE.md
+++ b/models/au_rba_statistical_tables/CLAUDE.md
@@ -1,0 +1,70 @@
+# au_rba_statistical_tables
+
+Reserve Bank of Australia statistical tables. Every CSV carries the full history of its
+series, so each run is a **full replace** (``dump_mode="overwrite"``), not an
+incremental append. A single flow downloads all ~220 CSVs once and rebuilds all four
+tables.
+
+## Refresh cadence
+- `0 9 * * *` — 09:00 America/Sao_Paulo, daily
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "4Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `data` | `year` (int64) | table | AllFree | 5 |
+| `dicionario` | — | table | — | 5 |
+| `series` | — | table | AllFree | 12 |
+| `series_break` | — | table | AllFree | 6 |
+
+## Where the code lives
+- `pipelines/datasets/au_rba_statistical_tables/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/au_rba_statistical_tables/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/au_rba_statistical_tables/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- (none literal in `constants.py`)
+
+## Design notes
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers
+`au_rba_statistical_tables_flow`; the dev pool ignores the schedule, the prod pool
+activates it.
+
+No Prefect imports here — this module is the single source of truth for the transform,
+shared by the recurring pipeline (``tasks.py``) and the one-shot onboarding bootstrap
+under ``models/au_rba_statistical_tables/code/``.
+
+The RBA publishes each statistical table as a CSV with a metadata block keyed by row
+label (``Title``, ``Description``, ``Frequency``, ``Type``, ``Units``, ``Source``,
+``Publication date``, ``Series ID``) above a dated data block. Each data column is one
+series; the transform pivots that wide block into long ``(table_id, series_id, date,
+value)`` rows and lifts the metadata block into a series catalogue.
+
+1. ``series_id`` is NOT globally unique. 228 mnemonics appear in both the ``b13.1.2-*``
+and ``b13.2.1-*`` tables carrying different values (827 of 834 overlapping cells
+differ). The key is therefore ``(table_id, series_id)``.
+
+2. Four file families are not ``(series_id, date)`` time series at all and are excluded
+— see ``NON_TIMESERIES_PREFIXES``.
+
+Licence gate: only series every one of whose named sources publishes under CC BY 4.0
+(RBA, APRA, ABS) are kept. See ``models/au_rba_statistical_tables/LICENCE.md``.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/br_bcb_ifdata/CLAUDE.md
+++ b/models/br_bcb_ifdata/CLAUDE.md
@@ -1,0 +1,53 @@
+# br_bcb_ifdata
+
+Compartilhado entre o onboarding estático (`models/br_bcb_ifdata/code/`) e o pipeline
+recorrente trimestral. Sem imports do Prefect.
+
+## Refresh cadence
+- `0 16 1,2,3,4,5 * *` — 16:00 America/Sao_Paulo, day 1,2,3,4,5
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "4Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `coluna` | `ano` (int64) | table | — | 10 |
+| `dicionario` | — | table | — | 5 |
+| `instituicao` | `ano` (int64) | table | — | 15 |
+| `relatorio` | `ano` (int64) | table | — | 5 |
+
+## Where the code lives
+- `pipelines/datasets/br_bcb_ifdata/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/br_bcb_ifdata/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/br_bcb_ifdata/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- (none literal in `constants.py`)
+
+## Design notes
+A API documentada do IF.data (Olinda OData, `servico/IFDATA`) respondia 500 em todas as
+chamadas de dados em 2026-08-18, então o download usa a API do próprio aplicativo
+IF.data (`www3.bcb.gov.br/ifdata/rest/`). Ela não é documentada, mas é a que o site usa.
+O formato é decodificado assim:
+
+trel<p>_<rel>.json -> c[] -> ifd --(info[].id)--> info entry info entry.ty == 0 -> valor
+vem do cadastro, coluna `c<lid>` info entry.ty == 1 -> valor vem de dados<p>_<n>.json,
+célula `lid` info entry.lid == -1 -> coluna não disponível nesta competência/tipo
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/br_cgu_sancoes/CLAUDE.md
+++ b/models/br_cgu_sancoes/CLAUDE.md
@@ -1,0 +1,79 @@
+# br_cgu_sancoes
+
+CGU sanctions registries (CEIS, CNEP, CEPIM, Acordos de Leniência) from the Portal da
+Transparência. Each registry is an on-demand live snapshot with no historical archive,
+so every run fetches the latest available snapshot and does a full replace
+(``dump_mode="overwrite"``), stamping ``data_extracao``. A single flow downloads all
+registries once and rebuilds all six tables.
+
+## Refresh cadence
+- `0 8 * * 1,2` — 08:00 America/Sao_Paulo, Mon/Tue
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `acordos_leniencia` | `data_extracao` (date) | table | PartBdpro | 12 |
+| `acordos_leniencia_efeitos` | `data_extracao` (date) | table | AllFree | 4 |
+| `ceis` | `data_extracao` (date) | table | PartBdpro | 25 |
+| `cepim` | `data_extracao` (date) | table | AllFree | 6 |
+| `cnep` | `data_extracao` (date) | table | PartBdpro | 26 |
+| `dicionario` | — | table | — | 5 |
+
+## Where the code lives
+- `pipelines/datasets/br_cgu_sancoes/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/br_cgu_sancoes/` — dbt models and `schema.yml`.
+
+## Source
+- https://portaldatransparencia.gov.br/download-de-dados/{registry}/{date}
+
+## Design notes
+BD Pro rolling window: the high-value compliance tables (ceis, cnep, acordos_leniencia)
+paywall their recent window keyed on the *sanction start* date (``data_inicio_sancao`` /
+``data_inicio_acordo``), so a sanction ages out of Pro six months after it starts. The
+remaining tables (cepim, acordos_leniencia_efeitos) stay fully free (coverage keyed on
+the snapshot date, their only date column); ``dicionario`` has no date column and takes
+no spec.
+
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers `br_cgu_sancoes_flow`; the dev
+pool ignores the schedule, the prod pool activates it.
+
+Pure functions (no Prefect) shared by the recurring pipeline (wrapped in @task in
+tasks.py) and the one-shot bootstrap in ``models/br_cgu_sancoes/code/clean.py`` (which
+imports the column specs and transform from here). This module is the schema source of
+truth for the dataset — there are no architecture CSVs; the per-column ``(name, kind)``
+specs below define the output column order and types, and the dbt models ``safe_cast``
+to those types.
+
+The registries are cumulative on-demand snapshots (each snapshot contains the full past
++ active history), so the pipeline keeps a single current snapshot per table
+(``dump_mode="overwrite"``) with ``data_extracao`` as the freshness stamp.
+
+CGU sanctions registries published by the Portal da Transparência: CEIS, CNEP, CEPIM and
+Acordos de Leniência (which ships two CSVs, Acordos + Efeitos). Each registry is an on-
+demand live snapshot behind AWS WAF: requesting ``/download-de-
+dados/<registry>/<YYYYMMDD>`` triggers generation and 302-redirects to the S3 zip once
+ready. There is no historical archive — only the current snapshot is retrievable — so
+every run fetches the latest available snapshot and overwrites
+(``dump_mode="overwrite"``), stamping ``data_extracao`` with the snapshot date.
+
+The cleaning transform and column schema live in ``utils.py`` (the schema source of
+truth for this dataset, since there are no architecture CSVs); the one-shot bootstrap in
+``models/br_cgu_sancoes/code/clean.py`` imports the same functions.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/br_mf_divida_ativa/CLAUDE.md
+++ b/models/br_mf_divida_ativa/CLAUDE.md
@@ -1,0 +1,69 @@
+# br_mf_divida_ativa
+
+PGFN "Dados Abertos da Dívida Ativa da União": three quarterly tables (SIDA /
+previdenciário / FGTS). Each release adds ONE new quarter as an immutable snapshot, so
+the pipeline is **incremental append**, not full replace — only quarters newer than the
+registered ``RawDataSource.Update`` boundary are downloaded and appended to staging
+(partitioned by ano/trimestre), which keeps each quarter's partition from being ingested
+twice. All three tables paywall their most recent two quarters (``PartBdpro``, free_lag
+6 months = 2 quarters); the rolling window and its BigQuery Row Access Policies are re-
+applied on every prod run by ``register_table_materialization_task``.
+
+## Refresh cadence
+- No cron literal found in `flows.py` — check `deploy_schedules` before assuming it is scheduled.
+
+Staging upload: dump mode `append`, `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "8Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `fgts` | `ano` (int64) | table | — | 17 |
+| `nao_previdenciario` | `ano` (int64) | table | — | 15 |
+| `previdenciario` | `ano` (int64) | table | — | 15 |
+
+## Where the code lives
+- `pipelines/datasets/br_mf_divida_ativa/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/br_mf_divida_ativa/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/br_mf_divida_ativa/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- (none literal in `constants.py`)
+
+## Design notes
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers ``br_mf_divida_ativa_flow``
+(defined at module level here); the dev pool ignores the schedule, the prod pool
+activates it (paused until armed).
+
+Pure functions (no Prefect), importable and unit-testable, shared by the recurring
+pipeline (``tasks.py``/``flows.py``) and the one-shot onboarding bootstrap under
+``models/br_mf_divida_ativa/code/`` (which imports from here). The source publishes one
+quarterly ZIP per system (SIDA / PREV / FGTS); each ZIP holds several ``;``-delimited,
+Latin-1 CSV parts. The SIDA (nao_previdenciario) table is ~40-50M rows per quarter, so
+every part is processed in row chunks and streamed to Parquet — the whole table is never
+held in memory.
+
+Schema and column order come from the architecture CSVs (the single source of truth, at
+``constants.ARCHITECTURE_DIR``). Staging Parquet is all-STRING by Data Basis convention;
+the dbt model ``safe_cast``s each column to its real type.
+
+PGFN "Dados Abertos da Dívida Ativa da União" — quarterly stock of active-debt
+registrations across three systems (SIDA / previdenciário / FGTS). See
+models/br_mf_divida_ativa/ONBOARDING_PLAN.md for the full design.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/br_sedec_desastres/CLAUDE.md
+++ b/models/br_sedec_desastres/CLAUDE.md
@@ -1,0 +1,65 @@
+# br_sedec_desastres
+
+Relatório "Reconhecimentos vigentes" do S2ID (SEDEC/MIDR): os reconhecimentos federais
+de situação de emergência e estado de calamidade pública em vigor.
+
+## Refresh cadence
+- `0 9 1 * *` — 09:00 America/Sao_Paulo, day 1
+
+Staging upload: dump mode —, source format `parquet`.
+Worker sizing: `"memory": "4Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `reconhecimentos_vigentes` | `data_extracao` (date) | table | — | 8 |
+
+## Where the code lives
+- `pipelines/datasets/br_sedec_desastres/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/br_sedec_desastres/` — dbt models and `schema.yml`.
+
+## Source
+- https://s2id.mi.gov.br/paginas/relatorios/
+
+## Design notes
+A tabela é uma série de retratos — cada execução grava o conjunto vigente na data da
+extração. As decisões de desenho e o que ainda está aberto estão no README do diretório.
+
+**Este flow não roda hoje.** O S2ID barra o IP de saída do cluster por geolocalização e
+a raspagem morre no download. Decidido em 2026-08-10, com a supervisão: o retrato é
+gerado na máquina de quem mantém a base, pelo `run_local.py` deste diretório, e
+promovido por PR com a label `table-approve`. A receita mensal está no README. O flow
+fica aqui porque o código é o mesmo — se o IP for liberado, basta devolver o
+`deploy_schedules`.
+
+Deploy: `.github/scripts/deploy_flows.py` descobre `br_sedec_desastres_flow`
+automaticamente, desde que o flow esteja definido neste arquivo (o script filtra por
+`obj.fn.__code__.co_filename`). O pool de dev ignora o schedule; o de prod o ativa, mas
+entra pausado.
+
+Funções puras: nada aqui importa Prefect no nível do módulo. Quem embala em `@task` é o
+`tasks.py`. O `log()` vem de `pipelines.utils.utils` e resolve o logger do Prefect só em
+tempo de chamada — dentro de uma task ele escreve no log do run, fora dela cai no
+`logging` padrão —, então o módulo segue importável sem o Prefect instalado.
+
+O schema (ordem das colunas, tipos, nome de origem) vem de `constants.COLUNAS`, não de
+arquivo — a planilha de arquitetura fica fora do repo, em `task_davi/`.
+
+Relatório "Reconhecimentos vigentes" do S2ID (Sistema Integrado de Informações sobre
+Desastres), mantido pela SEDEC, vinculada ao MIDR.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/br_senado_dados_abertos/CLAUDE.md
+++ b/models/br_senado_dados_abertos/CLAUDE.md
@@ -1,0 +1,73 @@
+# br_senado_dados_abertos
+
+Senado Federal legislative open data. One flow refreshes all 18 tables from the public
+Legislative Open Data API each day: the ten dimensions in full, the eight time-series
+tables (votacao, votacao_parlamentar, votacao_orientacao_bancada, processo, relatoria,
+votacao_comissao, votacao_comissao_parlamentar, discurso) for the recent window only —
+uploaded with ``dump_mode="append"``, which replaces just those ``ano=`` partitions and
+leaves history in place. Like the Câmara pipeline, there is no source-poll gate:
+legislative activity changes continuously, so a daily run is always meaningful.
+
+## Refresh cadence
+- `0 8 * * *` — 08:00 America/Sao_Paulo, daily
+
+Staging upload: dump mode `append`, source format `parquet`.
+Worker sizing: `"memory": "4Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `bloco` | — | table | — | 5 |
+| `comissao` | — | table | — | 9 |
+| `discurso` | `ano` (int64) | table | PartBdpro | 16 |
+| `lideranca` | — | table | — | 16 |
+| `mesa` | — | table | — | 9 |
+| `partido` | — | table | — | 5 |
+| `processo` | `ano` (int64) | table | PartBdpro | 24 |
+| `relatoria` | `ano` (int64) | table | PartBdpro | 18 |
+| `senador` | — | table | — | 12 |
+| `senador_cargo` | — | table | — | 7 |
+| `senador_comissao` | — | table | — | 7 |
+| `senador_filiacao` | — | table | — | 5 |
+| `senador_mandato` | — | table | — | 10 |
+| `votacao` | `ano` (int64) | table | PartBdpro | 27 |
+| `votacao_comissao` | `ano` (int64) | table | PartBdpro | 19 |
+| `votacao_comissao_parlamentar` | `ano` (int64) | table | PartBdpro | 8 |
+| `votacao_orientacao_bancada` | `ano` (int64) | table | PartBdpro | 10 |
+| `votacao_parlamentar` | `ano` (int64) | table | PartBdpro | 8 |
+
+## Where the code lives
+- `pipelines/datasets/br_senado_dados_abertos/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/br_senado_dados_abertos/` — dbt models and `schema.yml`.
+
+## Source
+- (none literal in `constants.py`)
+
+## Design notes
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers `br_senado_dados_abertos_flow`;
+the dev pool ignores the schedule, the prod pool activates it.
+
+Builds the same all-STRING partitioned parquet the one-shot onboarding produces, reusing
+the cleaning transform in `senado_clean`. Shared by the recurring pipeline (`tasks.py`)
+and the onboarding bootstrap (`models/.../code/`).
+
+Senado Federal legislative open data (senators, votes, bills, committees, parties,
+blocs, leaderships, Directing Board), sourced from the public Legislative Open Data API.
+See models/br_senado_dados_abertos/ for the design and the architecture source of truth
+(code/architecture_spec.py).
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/us_bea/CLAUDE.md
+++ b/models/us_bea/CLAUDE.md
@@ -1,0 +1,84 @@
+# us_bea
+
+US Bureau of Economic Analysis (BEA) economic accounts, pulled from the BEA REST API.
+BEA benchmark revisions rewrite historical values, so each run re-fetches the full
+history and overwrites staging (``dump_mode="overwrite"``), rather than appending. A
+single flow downloads once and rebuilds all six tables.
+
+## Refresh cadence
+- `0 16 25,26,27,28 * *` — 16:00 America/Sao_Paulo, day 25,26,27,28
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "8Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `dicionario` | — | table | — | 5 |
+| `gdp_by_industry` | `year` (int64) | table | AllFree | 9 |
+| `nipa` | `year` (int64) | table | AllFree | 13 |
+| `regional_county` | `year` (int64) | table | AllFree | 13 |
+| `regional_metro` | `year` (int64) | table | AllFree | 12 |
+| `regional_state` | `year` (int64) | table | AllFree | 14 |
+
+## Where the code lives
+- `pipelines/datasets/us_bea/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/us_bea/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/us_bea/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://apps.bea.gov/api/
+- https://apps.bea.gov/api/data/
+
+## Design notes
+Coverage tier: all six tables are ``AllFree``. ``nipa`` is a mixed-frequency table
+(annual/quarterly rows have a NULL ``month``), so a monthly Row Access Policy would
+paywall those rows forever (``DATE(year, month, 1)`` is NULL) — it is therefore NOT
+paywalled. ``nipa``'s ``(year, month)`` coverage still drives the monthly source poll;
+it just does not gate access. ``dicionario`` has no date column, so it takes no coverage
+spec. If a rolling BD Pro paywall is wanted later, add an end-of-period ``date`` column
+to ``nipa`` and key the policy on it.
+
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``us_bea_flow``; the dev pool
+ignores the schedule, the prod pool activates it (paused).
+
+Pure functions (no Prefect) so they are importable and unit-testable. The recurring
+pipeline wraps them in @task (see tasks.py); the bootstrap
+``models/us_bea/code/clean.py`` imports the same row-builders and fetch helpers, so the
+two cannot drift apart.
+
+- ``STAGING_SCHEMAS`` (here) — the RAW STAGING schema this pipeline writes: ``year``
+INT64, ``value`` FLOAT64, everything else STRING (including ``quarter``/``month``), with
+staging column names ``table_name``/``series_code``. - the architecture CSVs under
+``models/us_bea/code/architecture/`` — the FINAL post-dbt schema
+(``table_id``/``series_id``, ``quarter``/``month`` INT64). The dbt models rename and
+recast staging into that shape.
+
+The bootstrap uploads STAGING_SCHEMAS as TYPED parquet (the one-shot onboarding path
+accepts it). The recurring pipeline instead writes ALL-STRING parquet: the
+``dump_header`` parquet bug makes ``upload_to_gcs`` infer every staging column as
+STRING, so typed parquet is rejected on read. Values pass through the typed staging
+schema FIRST (so ``year`` serializes as ``"1959"`` not ``"1959.0"``) and are only then
+cast to string via arrow — never ``astype(str)``, which would turn NULL into the literal
+``"nan"`` and defeat the dbt ``safe_cast``.
+
+US Bureau of Economic Analysis (BEA) economic accounts, pulled directly from the BEA
+REST API (https://apps.bea.gov/api/). Six tables: nipa, gdp_by_industry, regional_state,
+regional_county, regional_metro, dicionario.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/us_bls_cpi/CLAUDE.md
+++ b/models/us_bls_cpi/CLAUDE.md
@@ -1,0 +1,57 @@
+# us_bls_cpi
+
+US Consumer Price Index (BLS), CPI-U + CPI-W. The BLS flat files carry the full history
+every month, so each run is a **full replace** (dump_mode="overwrite"), not an
+incremental append. A single flow downloads once and rebuilds all four tables. Schedule
+targets the BLS monthly release window (~2nd week).
+
+## Refresh cadence
+- `0 16 10,11,12,13,14,15 * *` — 16:00 America/Sao_Paulo, day 10,11,12,13,14,15
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "8Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `annual` | `year` (int64) | table | AllFree | 8 |
+| `dicionario` | — | table | — | 5 |
+| `monthly` | `year` (int64) | table | PartBdpro | 10 |
+| `semiannual` | `year` (int64) | table | AllFree | 9 |
+
+## Where the code lives
+- `pipelines/datasets/us_bls_cpi/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/us_bls_cpi/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/us_bls_cpi/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://download.bls.gov/pub/time.series
+
+## Design notes
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers `us_bls_cpi_flow`; the dev pool
+ignores the schedule, the prod pool activates it.
+
+Pure functions (no Prefect) so they are importable and unit-testable. The recurring
+pipeline wraps them in @task (see tasks.py); the bootstrap CLI imports `clean_all`
+directly. Schema/column order come from the architecture CSVs (the single source of
+truth).
+
+US Consumer Price Index (BLS), CPI-U (`cu`) + CPI-W (`cw`) time.series flat files. See
+models/us_bls_cpi/ONBOARDING_PLAN.md for the full design.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/us_fec_campaign_finance/CLAUDE.md
+++ b/models/us_fec_campaign_finance/CLAUDE.md
@@ -1,0 +1,81 @@
+# us_fec_campaign_finance
+
+FEC bulk campaign-finance data. The FEC republishes the **current** election cycle daily
+and freezes past cycles, so a scheduled run re-pulls only the current cycle and
+overwrites that one partition. Every frozen cycle stays in the staging bucket untouched,
+and the dbt models — plain `materialized="table"` — rebuild the full 1980-present table
+from all of them.
+
+## Refresh cadence
+- `0 5 * * 0` — 05:00 America/Sao_Paulo, Sun
+
+Staging upload: dump mode `append`, source format `parquet`.
+Worker sizing: `"memory": "8Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `candidate` | `year` (int64) | table | AllFree | 16 |
+| `candidate_committee_link` | `year` (int64) | table | AllFree | 8 |
+| `committee` | `year` (int64) | table | AllFree | 16 |
+| `committee_transaction` | `year` (int64) | table | PartBdpro | 24 |
+| `contribution_committee` | `year` (int64) | table | PartBdpro | 25 |
+| `contribution_individual` | `year` (int64) | table | PartBdpro | 24 |
+| `dicionario` | — | table | — | 5 |
+| `disbursement` | `year` (int64) | table | PartBdpro | 28 |
+
+## Where the code lives
+- `pipelines/datasets/us_fec_campaign_finance/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/us_fec_campaign_finance/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/us_fec_campaign_finance/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://basedosdados.org
+- https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1
+
+## Design notes
+That is why the upload uses ``dump_mode="append"``. "overwrite" would delete the whole
+staging table and, via ``tb.delete(mode="all")``, the prod table with it — throwing away
+45 years of frozen cycles to refresh one. "append" with a deterministic blob path
+(``staging/<ds>/<table>/year=<CYCLE>/data.parquet``) replaces exactly the current
+cycle's partition, which is the intended semantics.
+
+The four transaction tables are high-frequency, so they carry the BD Pro rolling window:
+the most recent 6 months are pro-only, everything older is free. The registration tables
+(candidate, committee, candidate_committee_link) have no date column and stay fully
+free.
+
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers
+``us_fec_campaign_finance_flow``; the dev pool ignores the schedule, the prod pool
+activates it.
+
+No Prefect imports: the recurring pipeline in pipelines/datasets/us_fec_campaign_finance
+imports these functions rather than duplicating them (.claude/rules/prefect-pipeline-
+conventions.md, "DRY with the onboarding code").
+
+The FEC publishes one ZIP per file type per two-year election cycle, each holding a
+single pipe-delimited text file with no header row. Layouts are documented and stable;
+the only per-file quirks are:
+
+* ``oppexp`` carries a trailing delimiter, so every line has 26 fields for 25 documented
+columns. The 26th is dropped. * ``oppexp`` dates are ``MM/DD/YYYY``; every other
+transaction file uses ``MMDDYYYY``. * Files are not quoted and contain stray double
+quotes inside names, so they must be parsed with QUOTE_NONE or lines get swallowed. *
+Encoding is latin-1, not UTF-8.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/us_fed_fred/CLAUDE.md
+++ b/models/us_fed_fred/CLAUDE.md
@@ -1,0 +1,70 @@
+# us_fed_fred
+
+FRED (Federal Reserve Bank of St. Louis) public-domain economic series. FRED serves the
+full history of each series on every call (latest revision only), so each run is a
+**full replace** (``dump_mode="overwrite"``), not an incremental append. A single flow
+downloads the seed series, rebuilds both tables, and materializes them. The source poll
+short-circuits the run when no series has a newer observation, making a scheduled daily
+run a cheap no-op between releases.
+
+## Refresh cadence
+- `0 21 * * *` — 21:00 America/Sao_Paulo, daily
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `observation` | `year` (int64) | table | PartBdpro | 4 |
+| `series` | — | table | NonHistorical | 14 |
+
+## Where the code lives
+- `pipelines/datasets/us_fed_fred/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/us_fed_fred/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/us_fed_fred/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://api.stlouisfed.org/fred
+
+## Design notes
+``observation`` is high-frequency (daily/weekly series), so it carries the BD Pro
+rolling window: the most recent 6 months are pro-only, everything older is free.
+``series`` is a metadata catalog and stays fully free (``NonHistorical`` coverage from
+the table's last-modified time).
+
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``us_fed_fred_flow``; the dev
+pool ignores the schedule, the prod pool activates it.
+
+Pure functions (no Prefect) so they are importable and unit-testable. The recurring
+pipeline wraps them in ``@task`` (see ``tasks.py``); the bootstrap CLI imports
+``download_all``/``clean_all`` directly. Schema/column order come from the architecture
+CSVs (the single source of truth).
+
+``download_all(input_dir)`` fetch each seed series' metadata + observations, apply the
+public-domain license gate, and persist the kept series as raw JSON under ``input_dir``.
+``clean_all(input_dir, out)`` read that raw JSON and write the two tables as all-STRING
+partitioned parquet under ``out``.
+
+Splitting them lets ``clean_all`` be re-run (and transform-parity-tested) against a
+cached ``input/`` without re-hitting the FRED API.
+
+License gate (both applied at download): 1. Source allowlist — keep only U.S.-federal-
+agency sources (public domain). 2. "Copyright" in ``/series`` notes — FRED's own marker
+for restricted series. Every dropped series is logged to ``input_dir/_excluded.csv``.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/us_sec_edgar/CLAUDE.md
+++ b/models/us_sec_edgar/CLAUDE.md
@@ -1,0 +1,65 @@
+# us_sec_edgar
+
+SEC EDGAR Financial Statement Data Sets. The SEC publishes one ZIP per calendar quarter,
+roughly five weeks after quarter end, and never rewrites an earlier one — so each run
+**appends one partition** (``dump_mode="append"``) rather than replacing the history the
+way us_bls_cpi does.
+
+## Refresh cadence
+- `0 16 5,8,11,14,17,20 1,4,7,10 *` — 16:00 America/Sao_Paulo, day 5,8,11,14,17,20, Jan/Apr/Jul/Oct
+
+Staging upload: dump mode `append`, `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "8Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `dicionario` | — | table | — | 5 |
+| `numeric_fact` | `year` (int64) | table | — | 12 |
+| `presentation` | `year` (int64) | table | — | 12 |
+| `submission` | `year` (int64) | table | — | 38 |
+| `tag` | `year` (int64) | table | — | 11 |
+
+## Where the code lives
+- `pipelines/datasets/us_sec_edgar/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/us_sec_edgar/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/us_sec_edgar/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://www.sec.gov/data-research/sec-markets-data/
+- https://www.sec.gov/files/dera/data/financial-statement-data-sets/
+- https://www.sec.gov/os/webmaster-faq#developers
+
+## Design notes
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers `us_sec_edgar_flow`; the dev
+pool ignores the schedule, the prod pool activates it.
+
+No Prefect imports here: `models/us_sec_edgar/code/clean.py` (the one-shot onboarding
+bootstrap) and `tasks.py` (the recurring pipeline) both import these, so the cleaning
+transform exists in exactly one place.
+
+Source: SEC Financial Statement Data Sets, one ZIP per calendar quarter holding four
+tab-delimited files (sub, num, tag, pre). The published tables mirror them one-to-one,
+stacked by release quarter (`year`, `quarter`).
+
+Staging parquet is written **all-STRING** with the column order taken from the
+architecture CSVs; the dbt models `safe_cast` each column to its real type. See the
+"Staging parquet must be all-STRING" note in `.claude/rules/prefect-pipeline-
+conventions.md`.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/world_cricsheet/CLAUDE.md
+++ b/models/world_cricsheet/CLAUDE.md
@@ -1,0 +1,74 @@
+# world_cricsheet
+
+Cricsheet global cricket. The full-history bundle ``all_csv2.zip`` ships the entire
+history on every (near-daily) release, so each run is a **full replace**
+(``dump_mode="overwrite"``), not an incremental append — this sidesteps the duplicate-
+on-append problem the overlapping recent windows would otherwise cause. A single flow
+downloads once, rebuilds all four tables, and materializes them. Because each run re-
+ingests the whole 11.4M-row history, it is scheduled **weekly** (not daily).
+
+## Refresh cadence
+- `0 6 * * 1` — 06:00 America/Sao_Paulo, Mon
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "12Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `deliveries` | `year` (int64) | table | PartBdpro | 28 |
+| `match_players` | `year` (int64) | table | AllFree | 5 |
+| `matches` | `year` (int64) | table | PartBdpro | 33 |
+| `people` | — | table | — | 22 |
+
+## Where the code lives
+- `pipelines/datasets/world_cricsheet/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/world_cricsheet/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/world_cricsheet/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://cricsheet.org/downloads/all_csv2.zip
+- https://cricsheet.org/register/people.csv
+
+## Design notes
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``world_cricsheet_flow``; the
+dev pool ignores the schedule, the prod pool activates it (paused until armed).
+
+Pure functions (no Prefect) so they are importable and unit-testable. The recurring
+pipeline wraps them in @task (see tasks.py); the bootstrap CLI imports ``clean_all``
+directly. Column order / types come from the architecture CSVs (the single source of
+truth) for ``deliveries`` and ``matches``; ``match_players`` and ``people`` were renamed
+in the dbt models via SELECT aliases, so their **staging** column names (what the dbt
+``from staging`` reads) differ from the architecture's final names — see STAGING_COLUMNS
+below.
+
+Staging parquet is written **all-STRING** (values pass through the real types first,
+then cast via arrow): ``upload_to_gcs`` infers the staging schema from a one-row header
+that ``gcs.dump_header`` stringifies, so typed parquet is rejected by BigQuery. This
+differs from the onboarding upload, which used typed parquet. See
+[[project_dump_header_parquet_bug]]. The dbt model ``safe_cast``s every column back to
+its real type, so nothing downstream changes.
+
+Cricsheet global cricket. The full-history bundle ``all_csv2.zip`` ships the entire
+history on every (near-daily) release, so each run is a full replace
+(``dump_mode="overwrite"``). Because that rebuilds the whole 11.4M-row dataset, the
+pipeline runs **weekly** rather than daily (see ``flows.py`` schedule). See
+models/world_cricsheet/ for the onboarding design and the architecture CSVs (the schema
+source of truth).
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->

--- a/models/world_wb_wdi/CLAUDE.md
+++ b/models/world_wb_wdi/CLAUDE.md
@@ -1,0 +1,71 @@
+# world_wb_wdi
+
+World Bank World Development Indicators (WDI). The bulk WDI_CSV.zip carries the full
+history on every release, so each run is a **full replace** (dump_mode="overwrite"), not
+an incremental append. A single flow downloads once and rebuilds all six tables.
+
+## Refresh cadence
+- `0 16 15 3,6,9,12 *` — 16:00 America/Sao_Paulo, day 15, Mar/Jun/Sep/Dec
+
+Staging upload: dump mode `overwrite`, source format `parquet`.
+Worker sizing: `"memory": "16Gi"`
+
+## Tables
+| table | partition | materialization | coverage tier | cast columns |
+|---|---|---|---|---|
+| `country_indicator` | — | table | NonHistorical | 3 |
+| `data` | `year` (int64) | table | — | 4 |
+| `dicionario` | — | table | NonHistorical | 5 |
+| `footnote` | `year` (int64) | table | — | 4 |
+| `indicator_time` | — | table | — | 3 |
+| `indicators` | — | table | NonHistorical | 19 |
+
+## Where the code lives
+- `pipelines/datasets/world_wb_wdi/` — `constants.py` (URLs, table list), `utils.py`
+  (pure download + cleaning transform), `tasks.py` (Prefect wrappers),
+  `flows.py` (the flow + its inline schedule).
+- `models/world_wb_wdi/` — dbt models and `schema.yml`.
+  The architecture CSVs under `models/world_wb_wdi/code/architecture/` are the
+  schema source of truth.
+
+## Source
+- https://databank.worldbank.org/data/download/WDI_CSV.zip
+
+## Design notes
+The data is annual: the source poll compares the latest year in the source against what
+is registered and short-circuits the run when the World Bank has not published a new
+year, which makes a scheduled run a cheap no-op between the yearly updates. WDI is CC BY
+4.0 and fully open, so every table is AllFree — no BD Pro paywall (the rolling-window
+paywall applies only to monthly-or-faster tables).
+
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers `world_wb_wdi_flow`; the dev
+pool ignores the schedule, the prod pool activates it.
+
+Pure functions (no Prefect) so they are importable and unit-testable. The recurring
+pipeline wraps them in @task (see tasks.py); the bootstrap imports ``clean_all``
+directly. Column order and BigQuery types come from the architecture CSVs (the single
+source of truth), never from the raw headers.
+
+Staging output is **all-STRING** by Data Basis convention: ``gcs.dump_header``
+stringifies the one-row header BigQuery infers the staging schema from, so typed parquet
+is rejected. The dbt model ``safe_cast``s every column to its real type. Raw source
+value strings are preserved verbatim (never round-tripped through float), so no
+precision is lost and a NULL never becomes the literal ``"nan"``.
+
+World Bank World Development Indicators (WDI). The bulk ``WDI_CSV.zip`` carries the full
+history on every release, so each run is a full replace (``dump_mode="overwrite"``). See
+models/world_wb_wdi/ for the one-shot bootstrap.
+
+## Operating reminders
+- A `COMPLETED` run is not proof of an ingest: the source poll returns early and
+  still completes. Check the logs, or run
+  `uv run python -m pipelines.diagnostics health`.
+- The dev materialization runs only when `materialize_to_prod=False`. That is the
+  pre-arm validation path; an armed run goes straight to prod.
+- Validate with
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`
+  on the dev pool, and remember the PR needs the `deploy-flow` label to deploy at
+  all.
+
+<!-- Generated from constants.py / flows.py / the dbt models. Extend by hand with
+     source-specific gotchas as they are discovered. -->


### PR DESCRIPTION
## Descrição do PR

Dos 23 datasets novos com pipeline, só 4 tinham CLAUDE.md (br_me_siconfi,
us_bls_qcew, mx_sesnsp_incidencia_delictiva, us_cfpb_hmda) e nenhum diretório
`pipelines/datasets/<ds>/` tinha. Quinze datasets não tinham markdown nenhum, o
que significa que cada sessão nova recomeça lendo o código.

Cada arquivo traz: o que a fonte é, a cadência (cron traduzido para horário e
dias), a tabela de tabelas com partição, materialização, tier de cobertura e
número de colunas convertidas, onde o código vive, as URLs da fonte, e as notas
de design.

Os arquivos são gerados a partir de constants.py, flows.py e dos modelos dbt —
não de memória — então cada afirmação é verificável no repo. As notas de design
vêm das docstrings de módulo, que é onde as sessões de construção registraram o
que não é óbvio. O rodapé marca os arquivos como gerados e convida a estender à
mão conforme novos gotchas aparecem.

Duas anomalias apareceram na geração e ficaram registradas em vez de escondidas:
`br_mf_divida_ativa` não tem literal de cron em flows.py (o doc manda conferir
`deploy_schedules` antes de assumir que está agendado), e sete datasets não
expõem `CoverageSpec` num dict literal, então a coluna de tier fica "—" neles em
vez de chutada.

Os "Operating reminders" assumem o PR que restringe a materialização em dev ao
caminho de validação; se este entrar antes, esse trecho fica correto só depois.

## Nota

Os arquivos são gerados a partir de `constants.py`, `flows.py` e dos modelos dbt,
então cada afirmação é verificável no repo. O rodapé marca isso e convida a
estender à mão.

Os "Operating reminders" assumem `pipeline/skip-dev-dbt-on-prod-runs`; se este PR
entrar antes, esse trecho fica correto só depois.
