### PR TITLE
chore(pipelines): distribui os horários de disparo dentro da hora de release

### DIFF
--- a/pipelines/datasets/au_abs_cpi/flows.py
+++ b/pipelines/datasets/au_abs_cpi/flows.py
@@ -182,5 +182,5 @@ def au_abs_cpi_flow(
 # source-poll guard no-ops until a new month lands.
 # pyrefly: ignore [missing-attribute]
 au_abs_cpi_flow.deploy_schedules = [
-    {"cron": "0 16 22,23,24,25,26,27,28 * *", "timezone": "America/Sao_Paulo"}
+    {"cron": "15 16 22,23,24,25,26,27,28 * *", "timezone": "America/Sao_Paulo"}
 ]

--- a/pipelines/datasets/au_abs_labour_force/flows.py
+++ b/pipelines/datasets/au_abs_labour_force/flows.py
@@ -200,7 +200,7 @@ def au_abs_labour_force_flow(
 # after the morning release); the source-poll guard no-ops until a new month lands.
 # pyrefly: ignore [missing-attribute]
 au_abs_labour_force_flow.deploy_schedules = [
-    {"cron": "0 6 14-27 * *", "timezone": "America/Sao_Paulo"}
+    {"cron": "30 6 14-27 * *", "timezone": "America/Sao_Paulo"}
 ]
 # openpyxl reads the ~38 MB SEM1 pivot; give the worker headroom.
 # pyrefly: ignore [missing-attribute]

--- a/pipelines/datasets/au_ato_abr/flows.py
+++ b/pipelines/datasets/au_ato_abr/flows.py
@@ -192,7 +192,7 @@ def au_ato_abr_flow(
 # snapshot actually appears.
 # pyrefly: ignore [missing-attribute]
 au_ato_abr_flow.deploy_schedules = [
-    {"cron": "0 16 * * 1,2,3,4", "timezone": "America/Sao_Paulo"}
+    {"cron": "30 16 * * 1,2,3,4", "timezone": "America/Sao_Paulo"}
 ]
 # The clean step streams from the ZIPs and flushes in 400k-row chunks, but the
 # download is ~1 GB; give the worker headroom.

--- a/pipelines/datasets/au_ato_taxation_statistics/flows.py
+++ b/pipelines/datasets/au_ato_taxation_statistics/flows.py
@@ -180,7 +180,7 @@ def au_ato_taxation_statistics_flow(
 # no-ops until a new financial year actually appears.
 # pyrefly: ignore [missing-attribute]
 au_ato_taxation_statistics_flow.deploy_schedules = [
-    {"cron": "0 16 20 * *", "timezone": "America/Sao_Paulo"}
+    {"cron": "45 16 20 * *", "timezone": "America/Sao_Paulo"}
 ]
 # The clean step holds ~4.5M rows in pandas before writing partitions.
 # pyrefly: ignore [missing-attribute]

--- a/pipelines/datasets/au_geoscape_gnaf/flows.py
+++ b/pipelines/datasets/au_geoscape_gnaf/flows.py
@@ -207,7 +207,10 @@ def au_geoscape_gnaf_flow(
 # coverage-based source poll no-ops (no download) until a new snapshot appears.
 # pyrefly: ignore [missing-attribute]
 au_geoscape_gnaf_flow.deploy_schedules = [
-    {"cron": "0 16 14,17,20,23,26 2,5,8,11 *", "timezone": "America/Sao_Paulo"}
+    {
+        "cron": "35 16 14,17,20,23,26 2,5,8,11 *",
+        "timezone": "America/Sao_Paulo",
+    }
 ]
 # The clean step builds one state's frames at a time (NSW is the largest) and the
 # download is ~1.6 GB; give the worker headroom.

--- a/pipelines/datasets/au_rba_statistical_tables/flows.py
+++ b/pipelines/datasets/au_rba_statistical_tables/flows.py
@@ -208,7 +208,7 @@ def au_rba_statistical_tables_flow(
 # the source-poll guard makes weekends and quiet days a no-op.
 # pyrefly: ignore [missing-attribute]
 au_rba_statistical_tables_flow.deploy_schedules = [
-    {"cron": "0 9 * * *", "timezone": "America/Sao_Paulo"}
+    {"cron": "40 9 * * *", "timezone": "America/Sao_Paulo"}
 ]
 # The clean step holds ~1.5M parsed observations in memory before writing.
 # pyrefly: ignore [missing-attribute]

--- a/pipelines/datasets/br_bcb_ifdata/flows.py
+++ b/pipelines/datasets/br_bcb_ifdata/flows.py
@@ -181,7 +181,7 @@ def br_bcb_ifdata_flow(
 # BRT; a trava do poll no-opa até uma competência nova aparecer de fato.
 # pyrefly: ignore [missing-attribute]
 br_bcb_ifdata_flow.deploy_schedules = [
-    {"cron": "0 16 1,2,3,4,5 * *", "timezone": "America/Sao_Paulo"}
+    {"cron": "50 16 1,2,3,4,5 * *", "timezone": "America/Sao_Paulo"}
 ]
 # A limpeza percorre 105 competências, mantendo no máximo uma na memória
 # (~1M células), mas o crosswalk do IBGE e o índice ficam residentes.

--- a/pipelines/datasets/br_cgu_sancoes/flows.py
+++ b/pipelines/datasets/br_cgu_sancoes/flows.py
@@ -227,5 +227,5 @@ def br_cgu_sancoes_flow(
 # idempotent.
 # pyrefly: ignore [missing-attribute]
 br_cgu_sancoes_flow.deploy_schedules = [
-    {"cron": "0 8 * * 1,2", "timezone": "America/Sao_Paulo"}
+    {"cron": "30 8 * * 1,2", "timezone": "America/Sao_Paulo"}
 ]

--- a/pipelines/datasets/br_sedec_desastres/flows.py
+++ b/pipelines/datasets/br_sedec_desastres/flows.py
@@ -171,7 +171,7 @@ def br_sedec_desastres_flow(
 # executada à mão pelo run_local.py. Se o IP for liberado, descomentar:
 #
 # br_sedec_desastres_flow.deploy_schedules = [
-#     {"cron": "0 9 1 * *", "timezone": "America/Sao_Paulo"}
+#     {"cron": "10 9 1 * *", "timezone": "America/Sao_Paulo"}
 # ]
 
 

--- a/pipelines/datasets/br_senado_dados_abertos/flows.py
+++ b/pipelines/datasets/br_senado_dados_abertos/flows.py
@@ -188,7 +188,7 @@ def br_senado_dados_abertos_flow(
 # Legislative activity updates on business days; refresh every morning (BRT).
 # pyrefly: ignore [missing-attribute]
 br_senado_dados_abertos_flow.deploy_schedules = [
-    {"cron": "0 8 * * *", "timezone": "America/Sao_Paulo"}
+    {"cron": "15 8 * * *", "timezone": "America/Sao_Paulo"}
 ]
 # pyrefly: ignore [missing-attribute]
 br_senado_dados_abertos_flow.job_variables = {"memory": "4Gi"}

--- a/pipelines/datasets/mx_sesnsp_incidencia_delictiva/flows.py
+++ b/pipelines/datasets/mx_sesnsp_incidencia_delictiva/flows.py
@@ -181,7 +181,7 @@ def mx_sesnsp_incidencia_delictiva_flow(
 # few days; the source-poll guard no-ops until a new month actually appears.
 # pyrefly: ignore [missing-attribute]
 mx_sesnsp_incidencia_delictiva_flow.deploy_schedules = [
-    {"cron": "0 9 20,21,22,23,24 * *", "timezone": "America/Mexico_City"}
+    {"cron": "20 9 20,21,22,23,24 * *", "timezone": "America/Mexico_City"}
 ]
 # The municipal melt holds ~1.7M rows in pandas; give the worker headroom.
 # pyrefly: ignore [missing-attribute]

--- a/pipelines/datasets/us_bea/flows.py
+++ b/pipelines/datasets/us_bea/flows.py
@@ -194,7 +194,7 @@ def us_bea_flow(
 # the source-poll guard no-ops until a new month actually appears.
 # pyrefly: ignore [missing-attribute]
 us_bea_flow.deploy_schedules = [
-    {"cron": "0 16 25,26,27,28 * *", "timezone": "America/Sao_Paulo"}
+    {"cron": "40 16 25,26,27,28 * *", "timezone": "America/Sao_Paulo"}
 ]
 # The clean step streams the ~50M-row county family through pandas/arrow in
 # 500k-row flushes; give the worker headroom.

--- a/pipelines/datasets/us_bls_cpi/flows.py
+++ b/pipelines/datasets/us_bls_cpi/flows.py
@@ -186,7 +186,7 @@ def us_bls_cpi_flow(
 # actually appears.
 # pyrefly: ignore [missing-attribute]
 us_bls_cpi_flow.deploy_schedules = [
-    {"cron": "0 16 10,11,12,13,14,15 * *", "timezone": "America/Sao_Paulo"}
+    {"cron": "5 16 10,11,12,13,14,15 * *", "timezone": "America/Sao_Paulo"}
 ]
 # The clean step holds ~4M rows in pandas; give the worker headroom.
 # pyrefly: ignore [missing-attribute]

--- a/pipelines/datasets/us_bls_qcew/flows.py
+++ b/pipelines/datasets/us_bls_qcew/flows.py
@@ -197,7 +197,7 @@ def us_bls_qcew_flow(
 # guard no-ops until a new quarter actually appears in the singlefiles.
 # pyrefly: ignore [missing-attribute]
 us_bls_qcew_flow.deploy_schedules = [
-    {"cron": "0 16 1-10 3,6,9,12 *", "timezone": "America/Sao_Paulo"}
+    {"cron": "10 16 1-10 3,6,9,12 *", "timezone": "America/Sao_Paulo"}
 ]
 # The clean step streams ~15M-row singlefiles one chunk at a time (peak ~1.75GB
 # in pandas); give the worker headroom above that.

--- a/pipelines/datasets/us_cfpb_hmda/flows.py
+++ b/pipelines/datasets/us_cfpb_hmda/flows.py
@@ -152,7 +152,7 @@ def us_cfpb_hmda_flow(
 # source-poll guard no-ops until a new year actually appears.
 # pyrefly: ignore [missing-attribute]
 us_cfpb_hmda_flow.deploy_schedules = [
-    {"cron": "0 16 8,9,10 3,4,5,6,7,8 *", "timezone": "America/Sao_Paulo"}
+    {"cron": "25 16 8,9,10 3,4,5,6,7,8 *", "timezone": "America/Sao_Paulo"}
 ]
 # Clean is out-of-core (~0.8 GB), but the download is several GB per year; give
 # the worker headroom. Peak disk ~ one raw CSV (~5 GB) + all-year parquet (~6 GB).

--- a/pipelines/datasets/us_fec_campaign_finance/flows.py
+++ b/pipelines/datasets/us_fec_campaign_finance/flows.py
@@ -243,7 +243,7 @@ def us_fec_campaign_finance_flow(
 # source-poll guard makes a run with nothing new a cheap no-op.
 # pyrefly: ignore [missing-attribute]
 us_fec_campaign_finance_flow.deploy_schedules = [
-    {"cron": "0 5 * * 0", "timezone": "America/Sao_Paulo"}
+    {"cron": "20 5 * * 0", "timezone": "America/Sao_Paulo"}
 ]
 
 # The current cycle's individual-contributions file is ~2 GB compressed and is parsed

--- a/pipelines/datasets/us_fed_fred/flows.py
+++ b/pipelines/datasets/us_fed_fred/flows.py
@@ -202,5 +202,5 @@ def us_fed_fred_flow(
 # observation, so a plain daily cron is cheap.
 # pyrefly: ignore [missing-attribute]
 us_fed_fred_flow.deploy_schedules = [
-    {"cron": "0 21 * * *", "timezone": "America/Sao_Paulo"}
+    {"cron": "25 21 * * *", "timezone": "America/Sao_Paulo"}
 ]

--- a/pipelines/datasets/us_sec_edgar/flows.py
+++ b/pipelines/datasets/us_sec_edgar/flows.py
@@ -226,7 +226,7 @@ def us_sec_edgar_flow(
 # pyrefly: ignore [missing-attribute]
 us_sec_edgar_flow.deploy_schedules = [
     {
-        "cron": "0 16 5,8,11,14,17,20 1,4,7,10 *",
+        "cron": "55 16 5,8,11,14,17,20 1,4,7,10 *",
         "timezone": "America/Sao_Paulo",
     }
 ]

--- a/pipelines/datasets/world_cricsheet/flows.py
+++ b/pipelines/datasets/world_cricsheet/flows.py
@@ -221,7 +221,7 @@ def world_cricsheet_flow(
 # the full-replace dump means overlapping windows never duplicate.
 # pyrefly: ignore [missing-attribute]
 world_cricsheet_flow.deploy_schedules = [
-    {"cron": "0 6 * * 1", "timezone": "America/Sao_Paulo"}
+    {"cron": "15 6 * * 1", "timezone": "America/Sao_Paulo"}
 ]
 # The deliveries build streams 11.4M rows and the bundle extracts to several GB;
 # give the worker headroom.

--- a/pipelines/datasets/world_wb_wdi/flows.py
+++ b/pipelines/datasets/world_wb_wdi/flows.py
@@ -181,7 +181,7 @@ def world_wb_wdi_flow(
 # this ingests the annual update whenever the World Bank publishes it.
 # pyrefly: ignore [missing-attribute]
 world_wb_wdi_flow.deploy_schedules = [
-    {"cron": "0 16 15 3,6,9,12 *", "timezone": "America/Sao_Paulo"}
+    {"cron": "20 16 15 3,6,9,12 *", "timezone": "America/Sao_Paulo"}
 ]
 # The clean step melts the wide file into ~26M rows in pandas; give the worker
 # headroom.


### PR DESCRIPTION
## Descrição do PR

Doze das pipelines novas disparavam exatamente às 16:00 BRT, e outras se
acumulavam às 06:00, 08:00, 09:00 e 21:00. Quando várias coincidem no mesmo dia,
elas competem por slots do BigQuery e, se a quota diária estoura naquele
instante, caem juntas — o que também dificulta atribuir a falha à pipeline certa.

Cada pipeline ganha um minuto distinto dentro da sua hora. **A hora não muda**:
cada uma foi escolhida pelo horário de publicação da fonte, e mexer nela adiaria
a ingestão.

Segunda passada moveu cinco pipelines que ainda dividiam slot com flows antigos
(us_fed_fred com br_ans_beneficiario/br_denatran_frota/br_sfb_sicar,
us_fec_campaign_finance com br_ibge_pnadc, world_cricsheet com br_bndes,
br_senado_dados_abertos com br_bcb_taxa_cambio/selic, br_sedec_desastres com
fundacao_lemann). Só as pipelines em escopo foram movidas; as antigas ficaram
como estavam.

Verificado: zero colisões hora:minuto envolvendo qualquer pipeline em escopo
(restam 4 entre flows antigos, fora do escopo deste PR); os flows importam.

Nota de expectativa: isto reduz contenção e o efeito-manada numa quebra de
quota. **Não reduz bytes faturados por dia** — a quota diária é um teto de
bytes, e quem ataca isso são os PRs que cortam a materialização em dev e limitam
os testes à partição mais recente.

## Como validar

- Zero colisões hora:minuto envolvendo qualquer pipeline em escopo (restam 4
  entre flows antigos, fora do escopo deste PR).
- Os flows importam.

Sem label `deploy-flow`: o pool de dev descarta schedules de qualquer forma.
