### PR TITLE
fix:  br_ms_cnes e br_me_comex_stat usa compare_against="coverage" em vez do poll.py

### DIFF
--- a/pipelines/crawler/datasus/flows.py
+++ b/pipelines/crawler/datasus/flows.py
@@ -21,12 +21,9 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    check_source_is_ahead_of_table_task,
     commit_source_update_task,
     poll_source_for_update_task,
-    register_source_coverage_task,
     register_table_materialization_task,
-    sync_table_coverage_task,
 )
 from pipelines.utils.tasks import (
     rename_flow_run_dataset_table,
@@ -57,19 +54,31 @@ def _run_cnes(
     )
     source_max_date = get_datasus_source_max_date(ftp_files)
 
-    register_source_coverage_task(
+    if not force_run:
+        has_new_data = poll_source_for_update_task(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            source_max_date=source_max_date,
+            env="prod",
+            date_format="%Y-%m",
+            compare_against="coverage",
+        )
+        if not has_new_data:
+            print("Fonte CNES sem novidade — encerrando")
+            return
+
+    # Comita o Update da fonte já aqui, antes de baixar/materializar: se o
+    # flow falhar no meio, o metadado da fonte ainda reflete que havia dado
+    # novo publicado, mesmo que a tabela não tenha sido atualizada.
+    commit_source_update_task(
         dataset_id=dataset_id,
         table_id=table_id,
         source_max_date=source_max_date,
         env="prod",
         date_format="%Y-%m",
+        update_metadata=update_metadata,
+        materialize_after_dump=materialize_after_dump,
     )
-
-    if not force_run and not check_source_is_ahead_of_table_task(
-        dataset_id=dataset_id, table_id=table_id, env="prod"
-    ):
-        print("Tabela CNES já cobre a fonte — encerrando")
-        return
 
     if not ftp_files:
         print("force_run=True mas FTP não retornou arquivos — encerrando")
@@ -123,7 +132,7 @@ def _run_cnes(
     )
 
     if update_metadata:
-        sync_table_coverage_task(
+        register_table_materialization_task(
             dataset_id=dataset_id,
             table_id=table_id,
             coverage=PartBdpro(

--- a/pipelines/datasets/br_me_comex_stat/flows.py
+++ b/pipelines/datasets/br_me_comex_stat/flows.py
@@ -18,9 +18,9 @@ from pipelines.utils.metadata.domain import (
     YearMonth,
 )
 from pipelines.utils.metadata.tasks import (
-    check_source_is_ahead_of_table_task,
-    register_source_coverage_task,
-    sync_table_coverage_task,
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
 )
 from pipelines.utils.tasks import (
     rename_flow_run_dataset_table,
@@ -50,24 +50,32 @@ def _comex_flow(table_id: str, table_name: str, table_type: str, cron: str):
 
         last_date = parse_last_date(link=comex_constants.DOWNLOAD_LINK.value)
 
+        if not force_run:
+            has_new_data = poll_source_for_update_task(
+                dataset_id=dataset_id,
+                table_id=table_id,
+                source_max_date=last_date,
+                env="prod",
+                date_format="%Y-%m",
+                compare_against="coverage",
+            )
+            if not has_new_data:
+                print(f"Tabela {table_id} já cobre a fonte — encerrando")
+                return
+
         # A fonte é uma só para as quatro tabelas, então este Update é um
         # ponteiro compartilhado: quem rodar primeiro no dia o avança. O gate
-        # abaixo continua por tabela, porque compara contra o Table.Update.
-        register_source_coverage_task(
+        # acima continua por tabela, porque compara contra o Coverage de cada
+        # tabela, não contra este RawDataSource.Update.
+        commit_source_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
             source_max_date=last_date,
             env="prod",
             date_format="%Y-%m",
+            update_metadata=update_metadata,
+            materialize_after_dump=materialize_after_dump,
         )
-
-        if not force_run and not check_source_is_ahead_of_table_task(
-            dataset_id=dataset_id,
-            table_id=table_id,
-            env="prod",
-        ):
-            print(f"Tabela {table_id} já cobre a fonte — encerrando")
-            return
 
         download_br_me_comex_stat(
             table_name=table_name,
@@ -118,7 +126,7 @@ def _comex_flow(table_id: str, table_name: str, table_type: str, cron: str):
         )
 
         if update_metadata:
-            sync_table_coverage_task(
+            register_table_materialization_task(
                 dataset_id=dataset_id,
                 table_id=table_id,
                 coverage=PartBdpro(


### PR DESCRIPTION
## Contexto

Auditando `Table.Update.latest` (issue #1861, backend), achei que `br_ms_cnes` e `br_me_comex_stat` gravam esse campo com a **competência materializada** (ex.: `2026-07-01`) em vez do **`last_modified` real** da tabela — diferente de todo o resto do catálogo, onde `Table.Update.latest` é sempre o relógio da última materialização (é isso que aparece como "última atualização" no site).

Isso vinha do mecanismo `pipelines/utils/metadata/poll.py` (`register_source_coverage`/`check_source_is_ahead_of_table`/`sync_table_coverage`), criado especificamente pra corrigir o bug de `Table.Update` contaminado nesses dois datasets (documentado no README do `br_me_comex_stat`). O problema: comparando lado a lado, `sync_table_coverage` é estruturalmente idêntico a `register_table_materialization` (já usado por ~27 outros flows) — a única diferença é essa última linha, que troca o relógio pela competência.

O mesmo resultado (comparar cobertura contra cobertura, sem tocar em `Table.Update`) já era alcançável com o mecanismo existente: `poll_source_for_update(..., compare_against="coverage")` já compara contra `Coverage.DateTimeRange`, não contra `Table.Update`.

## O que mudou

- `pipelines/crawler/datasus/flows.py` (`_run_cnes`) e `pipelines/datasets/br_me_comex_stat/flows.py`: troca `register_source_coverage_task`/`check_source_is_ahead_of_table_task`/`sync_table_coverage_task` por `poll_source_for_update_task(compare_against="coverage")` + `commit_source_update_task` + `register_table_materialization_task` — o mesmo padrão de `sia`/`sih`/`ipca` e outros ~27 flows.
- Mesma lógica de negócio (mesmo gate "fonte à frente da tabela?", mesmo `CoverageSpec`), só troca de mecanismo.
- Sem patch manual de banco necessário: na próxima run bem-sucedida de cada tabela, `register_table_materialization` grava `Table.Update.latest` como relógio normalmente.

Segue relacionado: #1882 (remover o `poll.py`, que fica sem uso depois desta migração).

## Test plan

- [x] `ruff check`/`format` e Pyrefly passam (hooks de commit)
- [x] Suite de testes de `pipelines/utils/tests/metadata/` passa (148/148)
- [ ] Rodar `_run_cnes` e um dos flows de `br_me_comex_stat` com `force_run=True` em dev antes do deploy em prod, pra confirmar que o gate e a materialização continuam funcionando
