### PR TITLE
fix(br_senado_dados_abertos): legislatura sem roster devolve 200 vazio, não é erro

### DIFF
--- a/pipelines/datasets/br_senado_dados_abertos/senado_api.py
+++ b/pipelines/datasets/br_senado_dados_abertos/senado_api.py
@@ -143,15 +143,26 @@ def get_xml_records(
     headers = {**HEADERS, "Accept": "application/xml"}
     last_exc: Exception | None = None
     last_status: int | None = None
+    saw_empty_200 = False
     for attempt in range(retries):
         try:
             r = requests.get(url, headers=headers, timeout=timeout)
             last_status = r.status_code
-            if r.status_code == 200 and r.text.strip():
-                return _parse_xml_records(r.text, record_tag)
+            if r.status_code == 200:
+                body = r.text.strip()
+                if body:
+                    return _parse_xml_records(body, record_tag)
+                saw_empty_200 = True
         except requests.RequestException as exc:
             last_exc = exc
         time.sleep(backoff * (attempt + 1))
+    if saw_empty_200:
+        # Mirrors `get_json`: a persistent 200 with an empty body is a
+        # legitimately-empty list endpoint, not a failure. The roster endpoint
+        # answers exactly this for legislatures that predate the API's coverage
+        # (36 returns 200 with 0 bytes; 40 returns ~92 KB). Raising here aborted
+        # the whole run on the first such legislature.
+        return []
     if last_exc is not None:
         raise last_exc
     raise RuntimeError(

--- a/pipelines/datasets/br_senado_dados_abertos/senado_clean.py
+++ b/pipelines/datasets/br_senado_dados_abertos/senado_clean.py
@@ -305,8 +305,10 @@ def _legislatura_parlamentares(leg: int) -> list[dict]:
     2026-08-20, and its JSON form now collapses the whole roster into a single
     `Parlamentar` object. See `get_xml_records`.
 
-    The old enveloped JSON is still accepted, so a restored endpoint needs no
-    change here.
+    `get_xml_records` parses the enveloped form too, so a restored endpoint needs
+    no change here. The JSON call is not attempted first: it cannot distinguish a
+    lost envelope from an empty roster, and every legislature that is legitimately
+    empty would pay a second full retry-and-backoff cycle (~30s) for nothing.
 
     Args:
         leg: Legislature number.
@@ -314,17 +316,6 @@ def _legislatura_parlamentares(leg: int) -> list[dict]:
     Returns:
         One dict per parlamentar; empty when the legislature has no roster.
     """
-    enveloped = get_json_safe(f"/senador/lista/legislatura/{leg}")
-    parlamentares = _as_list(
-        dig(
-            enveloped,
-            "ListaParlamentarLegislatura",
-            "Parlamentares",
-            "Parlamentar",
-        )
-    )
-    if parlamentares:
-        return parlamentares
     return get_xml_records(
         f"/senador/lista/legislatura/{leg}", record_tag="Parlamentar"
     )

--- a/pipelines/datasets/br_senado_dados_abertos/tests/test_legislatura_envelope.py
+++ b/pipelines/datasets/br_senado_dados_abertos/tests/test_legislatura_envelope.py
@@ -111,3 +111,40 @@ def test_empty_roster_raises_instead_of_shipping_a_thin_table(monkeypatch):
 
     with pytest.raises(RuntimeError, match="no parlamentares returned"):
         senado_clean.clean_senador()
+
+
+def test_persistent_empty_200_is_an_empty_roster_not_a_failure(monkeypatch):
+    """Legislatures predating the API answer 200 with a zero-byte body.
+
+    Verified live: legislature 36 returns HTTP 200 / 0 bytes, legislature 40
+    returns ~92 KB. Treating the empty one as an error aborted the whole run on
+    the first such legislature — `get_json` already documented this case as a
+    legitimately-empty list endpoint.
+    """
+    from pipelines.datasets.br_senado_dados_abertos import senado_api
+
+    class _Empty:
+        status_code = 200
+        text = ""
+
+    monkeypatch.setattr(senado_api.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(senado_api.requests, "get", lambda *a, **k: _Empty())
+
+    assert senado_api.get_xml_records("/x", "Parlamentar", retries=2) == []
+
+
+def test_persistent_non_200_still_raises(monkeypatch):
+    """An empty body is benign; a real HTTP failure must not be swallowed."""
+    from pipelines.datasets.br_senado_dados_abertos import senado_api
+
+    class _ServerError:
+        status_code = 503
+        text = ""
+
+    monkeypatch.setattr(senado_api.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(
+        senado_api.requests, "get", lambda *a, **k: _ServerError()
+    )
+
+    with pytest.raises(RuntimeError, match="503"):
+        senado_api.get_xml_records("/x", "Parlamentar", retries=2)


### PR DESCRIPTION
## Descrição do PR

Regressão introduzida por #1874 e encontrada no primeiro run real: a legislatura
36 responde HTTP 200 com corpo vazio, e `get_xml_records` tratava isso como
falha — 6 tentativas e então `RuntimeError`, abortando o flow inteiro.

```
RuntimeError('GET .../senador/lista/legislatura/36 (xml) failed: HTTP 200 after 6 attempts')
```

`get_json` já documentava esse caso ("persistent 200-empty: legitimately-empty
list endpoint") e devolvia None; a versão XML não replicou o comportamento.
Agora um 200 vazio persistente devolve `[]`, e só transporte quebrado ou não-200
levanta.

Verificado ao vivo nas legislaturas 30–42: só a 36 vem vazia (0 bytes); as
demais trazem 32–95 KB. É um buraco isolado, não o limite de cobertura da API,
então o custo de backoff fica em uma legislatura por run — não vale trocar
robustez de retry por velocidade aqui.

Também remove a tentativa via JSON antes do XML em `_legislatura_parlamentares`.
Ela não distinguia "envelope perdido" de "roster vazio", e fazia cada legislatura
vazia pagar um segundo ciclo completo de retry (~30s) para nada.
`get_xml_records` já parseia a forma com envelope, então um endpoint restaurado
continua funcionando.

Verificado ao vivo: leg 36 -> 0 parlamentares (sem exceção), leg 40 -> 124,
leg 57 -> 245. 10 testes passam.


## Como foi encontrado

Primeiro run real do #1874 depois de mergeado (`effective-coua`), no pool de dev com
`{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`.
Nenhum teste local pegaria: o caso só existe contra a API real.

## Verificação

```
leg 36:   0 parlamentares  (sem exceção)
leg 40: 124 parlamentares
leg 57: 245 parlamentares
```

Sondagem das legislaturas 30–42: só a 36 responde 0 bytes.

10 testes, incluindo os dois novos — 200 vazio persistente devolve `[]`, e 503
persistente segue levantando.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of successful API responses with empty bodies, returning empty results after retries instead of failing.
  * Continued to raise errors for persistent unsuccessful responses.
  * Improved reliability when loading legislature rosters by using the more dependable XML response format.

* **Tests**
  * Added regression coverage for empty successful responses and persistent API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->