### PR TITLE
fix(mx_sesnsp_incidencia_delictiva): não conta como cobertura o padding de meses futuros

### DIFF
--- a/pipelines/datasets/mx_sesnsp_incidencia_delictiva/tests/test_source_headers.py
+++ b/pipelines/datasets/mx_sesnsp_incidencia_delictiva/tests/test_source_headers.py
@@ -14,7 +14,9 @@ import pytest
 from pipelines.datasets.mx_sesnsp_incidencia_delictiva.utils import (
     _canonical_key,
     _read_source_csv,
+    melt_wide,
     normalize_headers,
+    trim_trailing_empty_months,
 )
 
 HEADER = (
@@ -84,3 +86,110 @@ def test_canonical_key_collapses_punctuation_and_accents():
     assert _canonical_key("Cve. Municipio") == "cvemunicipio"
     assert _canonical_key("Año") == _canonical_key("AÑO") == "ano"
     assert _canonical_key("anio") == "anio"  # alias, not a normalization
+
+
+# --------------------------------------------------------------- future periods
+def _wide_row(year: str, **months) -> pd.DataFrame:
+    """One wide source row for `year`, with the named months filled."""
+    base = {
+        "Año": [year],
+        "Clave_Ent": ["01"],
+        "Bien jurídico afectado": ["La vida"],
+        "Tipo de delito": ["Homicidio"],
+        "Subtipo de delito": ["Homicidio doloso"],
+        "Modalidad": ["Con arma"],
+    }
+    base.update({m: [v] for m, v in months.items()})
+    return pd.DataFrame(base)
+
+
+def test_months_after_max_period_are_dropped():
+    """The 2026-08 release pads the rest of the year with explicit 0.
+
+    Blank-means-unpublished no longer holds, so a zero for a month that has not
+    happened is padding and must not count as coverage.
+    """
+    df = _wide_row("2026", Enero="3", Junio="5", Agosto="0", Diciembre="0")
+
+    long = melt_wide(df, muni=False, victimas=False, max_period=(2026, 6))
+
+    assert sorted(long["mes"].tolist()) == [1, 6]
+    assert long["ano"].unique().tolist() == [2026]
+
+
+def test_the_boundary_month_is_kept():
+    """`max_period` is inclusive — the latest published month is real data."""
+    df = _wide_row("2026", Junio="5")
+
+    long = melt_wide(df, muni=False, victimas=False, max_period=(2026, 6))
+
+    assert long["mes"].tolist() == [6]
+
+
+def test_past_years_are_untouched_including_explicit_zeros():
+    """A zero in a past year is a real count of zero, not padding."""
+    df = _wide_row("2019", Enero="0", Diciembre="0")
+
+    long = melt_wide(df, muni=False, victimas=False, max_period=(2026, 6))
+
+    assert sorted(long["mes"].tolist()) == [1, 12]
+    assert long["cantidad"].tolist() == [0, 0]
+
+
+def test_blank_months_are_still_dropped():
+    """The original guard survives — blank is still unpublished."""
+    df = (
+        _wide_row("2026", Enero="3", Fevereiro_unused="")
+        if False
+        else _wide_row("2026", Enero="3", Marzo="")
+    )
+
+    long = melt_wide(df, muni=False, victimas=False, max_period=(2026, 6))
+
+    assert long["mes"].tolist() == [1]
+
+
+def test_defaults_to_the_current_month(monkeypatch):
+    """Without an explicit cutoff the transform uses today."""
+    df = _wide_row("2099", Enero="7")
+
+    long = melt_wide(df, muni=False, victimas=False)
+
+    assert long.empty
+
+
+# ------------------------------------------------------- trailing zero padding
+def test_trailing_all_zero_months_are_dropped():
+    """The measured 2026-08 shape: real data to July, zeros to December."""
+    long = pd.DataFrame(
+        {
+            "mes": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            "cantidad": [10, 10, 10, 10, 10, 10, 10, 0, 0, 0, 0, 0],
+        }
+    )
+
+    trimmed = trim_trailing_empty_months(long, "estatal_delitos", 2026)
+
+    assert trimmed["mes"].max() == 7
+    assert len(trimmed) == 7
+
+
+def test_a_zero_inside_the_series_is_kept():
+    """Only *trailing* zeros are padding; an interior zero is a real count."""
+    long = pd.DataFrame({"mes": [1, 2, 3, 4], "cantidad": [10, 0, 10, 0]})
+
+    trimmed = trim_trailing_empty_months(long, "t", 2026)
+
+    assert trimmed["mes"].tolist() == [1, 2, 3]
+
+
+def test_a_fully_zero_year_yields_nothing():
+    long = pd.DataFrame({"mes": [1, 2], "cantidad": [0, 0]})
+
+    assert trim_trailing_empty_months(long, "t", 2027).empty
+
+
+def test_a_year_with_no_padding_is_untouched():
+    long = pd.DataFrame({"mes": [1, 2, 3], "cantidad": [5, 5, 5]})
+
+    assert len(trim_trailing_empty_months(long, "t", 2025)) == 3

--- a/pipelines/datasets/mx_sesnsp_incidencia_delictiva/utils.py
+++ b/pipelines/datasets/mx_sesnsp_incidencia_delictiva/utils.py
@@ -383,7 +383,12 @@ def arch_order(table: str) -> list[str]:
 
 
 # ── transform (shared with the validated bootstrap) ─────────────────────────
-def melt_wide(df: pd.DataFrame, muni: bool, victimas: bool) -> pd.DataFrame:
+def melt_wide(
+    df: pd.DataFrame,
+    muni: bool,
+    victimas: bool,
+    max_period: tuple[int, int] | None = None,
+) -> pd.DataFrame:
     """Melt one wide chunk to the long architecture columns.
 
     Melts the 12 Spanish month columns (Enero..Diciembre) into ``mes`` (1..12) +
@@ -391,10 +396,20 @@ def melt_wide(df: pd.DataFrame, muni: bool, victimas: bool) -> pd.DataFrame:
     yet published). Drops the geography *name* columns (Entidad, Municipio) —
     they live in br_bd_diretorios_mx.
 
+    Rows for a period **after** ``max_period`` are dropped. Blank-means-unpublished
+    was the only guard until the 2026-08 release began padding the rest of the
+    calendar year with explicit ``0`` instead of leaving it blank, which pushed the
+    reported source coverage to 2026-12 while real data ended months earlier. A
+    count for a month that has not happened yet is padding, not an observation, and
+    letting it through makes the pipeline register coverage it does not have.
+
     Args:
         df: A wide chunk with canonical headers (all-string).
         muni: True for municipal tables (keeps ``id_municipio``).
         victimas: True for víctimas tables (keeps ``sexo``/``rango_edad``).
+        max_period: Latest ``(year, month)`` to keep, inclusive. Defaults to the
+            current month. Passed explicitly by tests so the transform stays
+            deterministic.
 
     Returns:
         The long frame with the architecture columns present.
@@ -426,6 +441,25 @@ def melt_wide(df: pd.DataFrame, muni: bool, victimas: bool) -> pd.DataFrame:
     long = long.rename(columns=id_map)
     long["ano"] = pd.to_numeric(long["Año"], errors="coerce").astype("Int64")
     long["mes"] = long["_mes"].map(MONTHS).astype("Int64")
+
+    if max_period is None:
+        today = pd.Timestamp.today()
+        max_period = (today.year, today.month)
+    max_year, max_month = max_period
+    # NA year/month are left untouched — `fillna(False)` keeps them out of the
+    # "future" mask so this only ever removes rows it can positively date.
+    is_future = (long["ano"] > max_year) | (
+        (long["ano"] == max_year) & (long["mes"] > max_month)
+    )
+    is_future = is_future.fillna(False).astype(bool)
+    if is_future.any():
+        log.info(
+            "dropped %s row(s) after %s-%02d (source pads future months with 0)",
+            f"{int(is_future.sum()):,}",
+            max_year,
+            max_month,
+        )
+        long = long[~is_future].copy()
     long["id_entidad"] = (
         long["id_entidad"].astype(str).str.strip().str.zfill(2)
     )
@@ -436,6 +470,56 @@ def melt_wide(df: pd.DataFrame, muni: bool, victimas: bool) -> pd.DataFrame:
     long["cantidad"] = pd.to_numeric(long["cantidad"], errors="coerce").astype(
         "Int64"
     )
+    return long
+
+
+def trim_trailing_empty_months(
+    long: pd.DataFrame, table: str = "", year: int | None = None
+) -> pd.DataFrame:
+    """Drop trailing months of the newest year that are entirely zero.
+
+    The future-period filter in `melt_wide` removes months that cannot have
+    happened. This removes the ones that *have* happened but are not published
+    yet — which used to be blank, and since the 2026-08 release are padded with an
+    explicit ``0`` on every row instead.
+
+    Measured on that release (``estatal_delitos``, ano=2026): months 1-7 carry
+    150k-175k events across ~2,000 non-zero rows each, while months 8-12 each
+    carry 3,648 rows summing to exactly 0, with no non-zero row at all. A
+    nationwide month of literally zero recorded crime is padding, not an
+    observation.
+
+    Only *trailing* months are dropped, and only for the year the caller passes as
+    newest, so no historical month can be removed and a genuine zero inside the
+    series is left alone.
+
+    Args:
+        long: One year's melted rows.
+        table: Table slug, for the log line.
+        year: The year being trimmed, for the log line.
+
+    Returns:
+        The frame with trailing all-zero months removed.
+    """
+    if long.empty:
+        return long
+    totals = long.groupby("mes")["cantidad"].sum()
+    non_zero = [m for m in sorted(totals.index) if totals[m] > 0]
+    if not non_zero:
+        log.info("%s: ano=%s is entirely zero, dropping", table, year)
+        return long.iloc[0:0]
+    last_real = max(non_zero)
+    dropped = [m for m in sorted(totals.index) if m > last_real]
+    if dropped:
+        log.info(
+            "%s: ano=%s dropping trailing all-zero month(s) %s (data ends %s-%02d)",
+            table,
+            year,
+            dropped,
+            year,
+            last_real,
+        )
+        long = long[long["mes"] <= last_real].copy()
     return long
 
 
@@ -522,15 +606,27 @@ def clean_table(
     years = sorted(
         pd.to_numeric(df["Año"], errors="coerce").dropna().astype(int).unique()
     )
+    written_years = 0
+    latest_year = years[-1] if years else None
     for y in years:
         chunk = df[pd.to_numeric(df["Año"], errors="coerce") == y]
         long = melt_wide(chunk, muni, victimas)
+        if y == latest_year:
+            long = trim_trailing_empty_months(long, table, y)
+        if not len(long):
+            # Every row of this year was dropped as a future period. Writing the
+            # partition anyway would create an empty ano=<year> in BigQuery and a
+            # year of "coverage" holding no observations.
+            log.info("%s: ano=%s has no published rows, skipping", table, y)
+            continue
         total += write_partition(long, table, y, output_dir)
-        if len(long):
-            mmax = int(long["mes"].dropna().max())
-            if max_ym is None or (y, mmax) > max_ym:
-                max_ym = (y, mmax)
-    log.info("%s: %s rows across %s year(s)", table, f"{total:,}", len(years))
+        written_years += 1
+        mmax = int(long["mes"].dropna().max())
+        if max_ym is None or (y, mmax) > max_ym:
+            max_ym = (y, mmax)
+    log.info(
+        "%s: %s rows across %s year(s)", table, f"{total:,}", written_years
+    )
     return total, max_ym
 
 

--- a/pipelines/datasets/mx_sesnsp_incidencia_delictiva/utils.py
+++ b/pipelines/datasets/mx_sesnsp_incidencia_delictiva/utils.py
@@ -455,7 +455,7 @@ def melt_wide(
     if is_future.any():
         log.info(
             "dropped %s row(s) after %s-%02d (source pads future months with 0)",
-            f"{int(is_future.sum()):,}",
+            f"{is_future.sum():,}",
             max_year,
             max_month,
         )


### PR DESCRIPTION
## Descrição do PR

O primeiro run bem-sucedido depois do #1873 reportou a fonte em **2026-12-01**
contra cobertura em 2026-06-01. Uma semana antes o mesmo código lia 2026-06: o
release de 2026-08 passou a preencher o resto do ano civil com `0` explícito em
vez de deixar em branco, e `melt_wide` mantém `0` explícito de propósito
("blank = não publicado"). Esse critério deixou de identificar o fim dos dados.

Medido na tabela materializada em dev (`estatal_delitos`, ano=2026):

| meses | linhas/mês | soma | linhas != 0 |
|---|---|---|---|
| 1-7   | 3.648 | 150k-175k | ~2.000 |
| 8-12  | 3.648 | **0** | **0** |

Ou seja, o dado real termina em **julho**; agosto a dezembro são padding.

Sem isto, o próximo run agendado (que roda com `update_metadata=True`) commitaria
`2026-12-01` como cobertura da fonte e registraria cinco meses de dados que não
existem.

Dois guards, para modos de falha diferentes:

- `melt_wide` descarta período **posterior ao mês corrente** — um mês que não
  aconteceu não tem dado, qualquer que seja o valor. Cutoff é parâmetro, com
  default "hoje", para o transform seguir determinístico em teste.
- `trim_trailing_empty_months` descarta os meses **finais do ano mais novo** cuja
  soma é zero — os que já aconteceram mas ainda não foram publicados. Só meses
  finais e só do ano mais novo, então nenhum mês histórico é afetado e um zero no
  meio da série é preservado.

`clean_table` também deixa de escrever partição de ano que ficou sem linha —
antes criaria um `ano=<X>` vazio no BigQuery.

Verificado na forma medida: fonte 2026-12 -> filtro de futuro 2026-08 -> trim
2026-07. 20 testes.


## Evidência

Consulta na tabela que o run `uptight-boobook` materializou em dev:

```sql
select mes, count(*) linhas, sum(cantidad) total, countif(cantidad > 0) nao_zero
from `basedosdados-dev.mx_sesnsp_incidencia_delictiva.estatal_delitos`
where ano = 2026 group by mes order by mes
```

Meses 8 a 12: 3.648 linhas cada, soma 0, nenhuma linha diferente de zero.

## Urgência

O cron de mx roda nos dias 20-24 com `update_metadata=True` por padrão. Sem este
PR, o próximo run grava cobertura até 2026-12.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date filtering so records after the current reporting period are excluded, including padded zero values.
  * Removed trailing empty months from the latest year while preserving historical and interior zero values.
  * Improved handling of empty data partitions and reporting of written years.
* **Tests**
  * Added regression coverage for reporting-period cutoffs, blank months, zero-filled years, and trailing-month cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->