### PR TITLE
docs(us_fec_campaign_finance): past cycles are not frozen, and the flow misses their edits

### DIFF
--- a/pipelines/datasets/us_fec_campaign_finance/flows.py
+++ b/pipelines/datasets/us_fec_campaign_finance/flows.py
@@ -2,14 +2,29 @@
 Flows for us_fec_campaign_finance — Prefect 3.
 
 FEC bulk campaign-finance data. The FEC republishes the **current** election cycle
-daily and freezes past cycles, so a scheduled run re-pulls only the current cycle and
-overwrites that one partition. Every frozen cycle stays in the staging bucket
-untouched, and the dbt models — plain `materialized="table"` — rebuild the full
-1980-present table from all of them.
+daily, so a scheduled run re-pulls only that cycle and overwrites its one partition.
+Every other cycle stays in the staging bucket untouched, and the dbt models — plain
+`materialized="table"` — rebuild the full 1980-present table from all of them.
 
-That is why the upload uses ``dump_mode="append"``. "overwrite" would delete the whole
-staging table and, via ``tb.delete(mode="all")``, the prod table with it — throwing
-away 45 years of frozen cycles to refresh one. "append" with a deterministic blob path
+**Past cycles are NOT frozen, and this flow does not pick up their changes.** Amendments
+keep landing in a closed cycle for years; the bulk files are re-published when they do.
+Checking ``Last-Modified`` on the individual-contributions zips (2026-08-20)::
+
+    1980, 1996 -> 2017-08-31    2020 -> 2024-12-29
+    2008       -> 2021-11-01    2024 -> 2026-03-08
+    2016       -> 2022-10-16    2022 -> 2026-08-16   (four days earlier)
+
+Only the oldest cycles look settled. Since ``refresh_cycle`` downloads just the current
+cycle, an amendment filed today against 2022 never reaches these tables — the data is
+correct as of each cycle's last ingest, not as of today. Note the full table rebuild does
+**not** mitigate this: staging for past cycles never changes, so every rebuilt past
+partition is recomputed byte-identical. Fixing it means widening the refresh window to
+the current cycle plus one or two prior, which pairs naturally with an incremental
+(``insert_overwrite`` on ``year``) materialization.
+
+The upload uses ``dump_mode="append"``. "overwrite" would delete the whole staging table
+and, via ``tb.delete(mode="all")``, the prod table with it — throwing away 45 years of
+history to refresh one cycle. "append" with a deterministic blob path
 (``staging/<ds>/<table>/year=<CYCLE>/data.parquet``) replaces exactly the current
 cycle's partition, which is the intended semantics.
 
@@ -18,8 +33,11 @@ window: the most recent 6 months are pro-only, everything older is free. The
 registration tables (candidate, committee, candidate_committee_link) have no date
 column and stay fully free.
 
-Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``us_fec_campaign_finance_flow``;
-the dev pool ignores the schedule, the prod pool activates it.
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers ``us_fec_campaign_finance_flow``.
+The dev pool strips the schedule entirely. The prod pool keeps it but deploys
+``paused=True``, and the backend sync leaves an unknown deployment paused — arming is a
+manual step in Django admin (``/admin/admin_data_tools/disabledflowschedule/``), not a
+consequence of merging.
 """
 
 import shutil


### PR DESCRIPTION
## Descrição do PR

O docstring do módulo `flows.py` afirmava duas coisas que não são verdade. Ambas descrevem comportamento que **já está em produção com o schedule armado**, então valem correção.

**1. "The FEC freezes past cycles" — não congela.** Emendas continuam entrando num ciclo já encerrado por anos, e os arquivos em massa são republicados quando isso acontece. `Last-Modified` dos zips de contribuições individuais, verificado em 2026-08-20:

| ciclo | last-modified | ciclo | last-modified |
|---|---|---|---|
| 1980, 1996 | 2017-08-31 | 2020 | 2024-12-29 |
| 2008 | 2021-11-01 | 2024 | 2026-03-08 |
| 2016 | 2022-10-16 | **2022** | **2026-08-16** |

O arquivo de 2022 mudou **quatro dias** antes dessa verificação. Só os ciclos mais antigos parecem assentados.

Isso importa porque `refresh_cycle` baixa **apenas o ciclo corrente**: uma emenda protocolada hoje contra 2022 nunca chega a estas tabelas. O docstring agora declara essa limitação em vez de sugerir que o dado está atual para todo ciclo — os dados estão corretos até o último ingest de cada ciclo, não até hoje.

Registra também que **a reconstrução completa da tabela não mitiga isso**: o staging dos ciclos passados nunca muda, então cada partição antiga é recomputada byte a byte idêntica. E aponta a correção real — ampliar a janela de refresh para o ciclo corrente mais um ou dois anteriores, o que combina com materialização incremental (`insert_overwrite` em `year`).

**2. "the prod pool activates it" — não ativa.** O pool de produção faz deploy com `paused=True`, e o sync do backend deixa um deployment desconhecido pausado. Armar é passo manual no Django admin (`/admin/admin_data_tools/disabledflowschedule/`). Mesclar não liga o schedule. Esta parte foi justamente o passo executado à mão agora.

## Detalhes Técnicos

**Principais alterações:** somente o docstring do módulo.

**Mudanças nos dados e no schema:** nenhuma.

**Impacto no desempenho:** nenhum.

## Teste e Validações

- [x] Testado localmente
- [ ] Testado na Cloud

Alteração sem efeito em comportamento, confirmado:

```
flow: us_fec_campaign_finance
schedule: [{'cron': '0 5 * * 0', 'timezone': 'America/Sao_Paulo'}]
coverage tables: 7

pyrefly check pipelines/datasets/us_fec_campaign_finance/
INFO 0 diagnostics (5 suppressed)

pytest pipelines/datasets/us_fec_campaign_finance/tests/ -q
9 passed

ruff check / ruff format: Passed
```

## Contexto

O pipeline está **funcionando e armado**. A execução de produção `skilled-meerkat` concluiu em 66 min: 28/28 `dbt run`/`test` (7 em dev + 7 em prod, run e test), cobertura registrada e as Row Access Policies aplicadas — 4x `BDpro filter was included` + 4x `All users filter was included`, uma por tabela `part_bdpro`. A janela BD Pro está no ar (livre até 2026-01-31, pro 2026-02-01..2026-07-31; disbursement 2026-02-12 / 2026-02-13..2026-08-12).

## Riscos e Mitigações

- Riscos conhecidos: nenhum — documentação.
- Planos de rollback: reverter o commit.
