### PR TITLE
fix: sync com o backend roda mesmo se um flow falhar ao registrar

### DIFF
--- a/.github/workflows/cd-prefect3.yaml
+++ b/.github/workflows/cd-prefect3.yaml
@@ -25,6 +25,7 @@ jobs:
             --branch ${{ github.ref_name }} \
             --all
       - name: Sync deployments with backend
+        if: always()
         env:
           PREFECT3_AUTH_TOKEN: ${{ secrets.PREFECT3_AUTH_TOKEN }}
         run: |-

--- a/.github/workflows/cd-prefect3.yaml
+++ b/.github/workflows/cd-prefect3.yaml
@@ -29,7 +29,8 @@ jobs:
         env:
           PREFECT3_AUTH_TOKEN: ${{ secrets.PREFECT3_AUTH_TOKEN }}
         run: |-
-          curl -sf -X POST https://backend.basedosdados.org/admin-tools/sync-deployments/ \
+          curl -sf --connect-timeout 10 --max-time 60 \
+            -X POST https://backend.basedosdados.org/admin-tools/sync-deployments/ \
             -H "Authorization: Bearer $PREFECT3_AUTH_TOKEN" \
             -H "Content-Type: application/json" \
             || echo "⚠️ Backend sync failed — activate flows manually via Django admin"

--- a/models/world_wil_wid/code/upload.py
+++ b/models/world_wil_wid/code/upload.py
@@ -54,31 +54,18 @@ def _patched_bucket(
     self: gcs.Client,
     bucket_name: str,
     user_project: str | None = None,
-    generation: int | None = None,
 ) -> "gcs.Bucket":
     """Force ``user_project`` so the requester-pays bucket bills our project.
-
-    Accepts ``generation`` so a caller that passes one keeps working, but only
-    forwards it when it is set: older google-cloud-storage releases have no
-    such parameter and reject it outright.
 
     Args:
         self: The storage client the method is bound to.
         bucket_name: Name of the bucket to instantiate.
         user_project: Ignored; overridden with the billing project.
-        generation: Optional bucket generation, forwarded only when provided.
 
     Returns:
         The instantiated ``Bucket`` billed to ``BILLING_PROJECT``.
     """
-    if generation is None:
-        return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
-    return _orig_bucket(
-        self,
-        bucket_name,
-        user_project=BILLING_PROJECT,
-        generation=generation,
-    )
+    return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
 
 
 gcs.Client.bucket = _patched_bucket

--- a/pipelines/datasets/world_wil_wid/utils.py
+++ b/pipelines/datasets/world_wil_wid/utils.py
@@ -355,7 +355,9 @@ def _derive_code_parts(
     Returns:
         ``(series_type, concept)``.
     """
+    # pyrefly: ignore [missing-attribute]
     series_type = pc.utf8_slice_codeunits(variable, 0, 1)
+    # pyrefly: ignore [missing-attribute]
     concept = pc.utf8_slice_codeunits(variable, 1, 6)
     return series_type, concept
 


### PR DESCRIPTION
# Sync com o backend roda mesmo se um flow falhar ao registrar

# Contexto

Em `.github/workflows/cd-prefect3.yaml`, o step "Sync deployments with backend" só rodava se o step anterior ("Deploy all flows to basedosdados") tivesse sucesso — comportamento padrão do GitHub Actions sem `if:` explícito.

`deploy_flows.py --all` registra o catálogo inteiro a cada push em `main` e continua registrando os demais flows mesmo quando um falha, mas o job termina com exit code 1 se qualquer flow der erro — pulando o sync mesmo quando a maioria registrou certo.

Incidente real: em 2026-08-21 e 2026-08-22, `br_sfb_sicar_flow` falhou ao registrar (#1893). Os outros 178 flows registraram normalmente, mas o "Sync deployments with backend" ficou pulado — deixando ~150 flows marcados como ativos no backend com o deployment pausado no Prefect, sem alerta visível fora do log da action. Corrigido manualmente rodando o sync depois.

# O que muda

```diff
 - name: Sync deployments with backend
+  if: always()
   env:
     PREFECT3_AUTH_TOKEN: ${{ secrets.PREFECT3_AUTH_TOKEN }}
   run: |-
     curl -sf -X POST https://backend.basedosdados.org/admin-tools/sync-deployments/ \
       -H "Authorization: Bearer $PREFECT3_AUTH_TOKEN" \
       -H "Content-Type: application/json" \
       || echo "⚠️ Backend sync failed — activate flows manually via Django admin"
```

Uma falha isolada num flow não vai mais impedir a reativação de todos os outros que já registraram com sucesso no mesmo push.

# Correção extra: destrava o Pyrefly no CI

O CI deste PR falhava no "Pyrefly type check" por dois erros que já estavam em `main` (de outro PR mesclado, `world_wil_wid`, não relacionados a esse fix):

- `models/world_wil_wid/code/upload.py`: `_patched_bucket` aceitava um `generation` especulativo que ninguém nunca passa (nem o próprio arquivo, nem `bd.Storage`) e que a versão instalada de `google-cloud-storage` (2.10.0) nem aceita — removido, era código morto e já estava quebrado.
- `pipelines/datasets/world_wil_wid/utils.py`: `pc.utf8_slice_codeunits` existe de verdade no `pyarrow` instalado (22.0.0) e roda normalmente — só o stub de tipos do Pyrefly não conhece essa função. Mesmo falso positivo já suprimido em `us_sec_edgar/utils.py`; aplicado o mesmo `# pyrefly: ignore [missing-attribute]`.

# Acompanhamento

Detalhes completos, o incidente real e o fluxograma de como o deploy funciona hoje em #1892.