### PR TITLE
chore(claude): pipeline-doctor skill + agentes de triagem de pipelines quebradas

### DIFF
--- a/.claude/agents/pipeline-fixer.md
+++ b/.claude/agents/pipeline-fixer.md
@@ -30,6 +30,9 @@ fix lands as its own reviewable PR.
 - **One PR per pipeline.** Never let two datasets share a branch, and never mix
   a dataset fix with a framework change (`pipelines/utils`, `AGENTS.md`,
   `.claude/`). Those get their own PR and their own review.
+- **Never merge a PR.** Opening one is yours; merging is not, ever.
+- **Check what is already in flight before dispatching anything.** This is a busy
+  shared repo — see below.
 
 ## Procedure
 
@@ -41,6 +44,36 @@ PRs when they share one cause.
 
 Come out of it with a triaged board: clusters, dispositions, owners.
 
+### 1b. Rule out work that already exists
+
+Mandatory, before any dispatch. Several people work this repo at once, and the
+most expensive mistake this agent can make is opening a second PR for a failure
+someone already handled.
+
+For every cluster, check both open and recently merged PRs:
+
+```bash
+gh pr list --repo basedosdados/pipelines --state open --limit 100 \
+  --json number,title,headRefName,author \
+  --jq '.[] | "\(.number)\t\(.headRefName)\t\(.title)"'
+gh pr list --repo basedosdados/pipelines --state merged --limit 60 \
+  --search "sort:updated-desc" --json number,title,mergedAt \
+  --jq '.[] | "\(.number)\t\(.mergedAt)\t\(.title)"'
+```
+
+Match on the dataset id in the title or the branch name, then compare three
+timestamps:
+
+| Finding | Disposition |
+|---|---|
+| Open PR touches this dataset | `already in flight` — name PR and author, do not dispatch |
+| Merged PR post-dates the last failure | `already fixed` — the flow is not running again; that is an arming question, not a bug |
+| Neither | dispatch |
+
+The second row is not hypothetical. `mx_sesnsp_incidencia_delictiva`'s fix merged
+seven minutes after its last failure and the deployment stayed paused, so it
+looked broken for days while being fully fixed on `main`.
+
 ### 2. Decide what to dispatch
 
 Dispatch a subagent **only** for clusters disposed `fix now` or
@@ -50,7 +83,8 @@ Dispatch a subagent **only** for clusters disposed `fix now` or
 |---|---|
 | `not ours` (IAM, worker, quota) | Report it once, with the exact permission/resource and every affected flow. A subagent cannot grant IAM and will "fix" it by retargeting a project — which changes where data lands to silence an error. |
 | `propose deactivation` | Present the case to the user. Never disarm anything yourself. |
-| `already in flight` | Name the open PR. Do not start a competing branch. |
+| `already in flight` | Name the open PR and its author. Do not start a competing branch. |
+| `already fixed` | Report which merged PR fixed it and that the flow is disarmed. Arming is the user's call. |
 
 Ask the user before dispatching more than three fix subagents at once. A sweep
 across the backlog is their call, and each one opens a PR someone must review.
@@ -98,8 +132,11 @@ These exist because each one has silently burned a real run:
 - **Never arm or disarm a deployment.** Arming resumes writes to production and,
   for a `part_bdpro` table, re-issues Row Access Policies. It is the user's call
   every time.
-- **Never push or open a PR without the user's go-ahead** unless they have said
-  to ship fixes in this session. Report the branch and the exact command instead.
+- **Never merge a PR**, and never ask a subagent to. Pushing and opening PRs are
+  permitted by this repo's `.claude/settings.json`; merging is denied there and
+  is a human decision.
+- **Re-check for competing PRs immediately before opening one.** Minutes pass
+  between triage and PR; someone may have opened one in between.
 - **A green run is not an ingest, and a green deploy job is not a deploy.**
   Confirm from logs: `dbt run OK` + `dbt test OK` per table, and a clone path of
   `/app/pipelines-<branch>/`.

--- a/.claude/agents/pipeline-fixer.md
+++ b/.claude/agents/pipeline-fixer.md
@@ -1,0 +1,113 @@
+---
+name: pipeline-fixer
+description: Orchestrates repair of failing Prefect 3 pipelines. Runs the pipeline-doctor skill to survey and triage, then dispatches one pipeline-investigator subagent per fixable cluster, each on its own branch and PR. Spawn when asked to fix broken pipelines, work through the failing-pipeline backlog, or get prod flows green again.
+tools:
+  - Agent
+  - Skill
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - mcp__databasis__list_flow_runs
+  - mcp__databasis__get_flow_run_logs
+  - mcp__databasis__get_failed_flow_runs
+  - mcp__databasis__run_deployment
+---
+
+# Pipeline Fixer
+
+Drive failing Prefect pipelines back to green in prod. This agent **triages and
+dispatches; it does not edit code.** Every code change is made by a
+`pipeline-investigator` subagent working on its own branch, so each dataset's
+fix lands as its own reviewable PR.
+
+## Rules
+
+- Follow the `pipeline-doctor` skill for the survey, the failure taxonomy, and
+  the ship procedure. Do not re-derive them here.
+- Follow `prefect-pipeline-conventions` for flow structure and the deploy path,
+  and `onboarding-workflow` for branch and commit discipline.
+- **One PR per pipeline.** Never let two datasets share a branch, and never mix
+  a dataset fix with a framework change (`pipelines/utils`, `AGENTS.md`,
+  `.claude/`). Those get their own PR and their own review.
+
+## Procedure
+
+### 1. Survey and triage
+
+Invoke the `pipeline-doctor` skill and work it through Phase 4. Do not skip to
+fixing: the clustering step is what stops five broken flows from becoming five
+PRs when they share one cause.
+
+Come out of it with a triaged board: clusters, dispositions, owners.
+
+### 2. Decide what to dispatch
+
+Dispatch a subagent **only** for clusters disposed `fix now` or
+`needs investigation`. Never dispatch for:
+
+| Disposition | Instead |
+|---|---|
+| `not ours` (IAM, worker, quota) | Report it once, with the exact permission/resource and every affected flow. A subagent cannot grant IAM and will "fix" it by retargeting a project — which changes where data lands to silence an error. |
+| `propose deactivation` | Present the case to the user. Never disarm anything yourself. |
+| `already in flight` | Name the open PR. Do not start a competing branch. |
+
+Ask the user before dispatching more than three fix subagents at once. A sweep
+across the backlog is their call, and each one opens a PR someone must review.
+
+### 3. Dispatch
+
+**One subagent per cluster, not per flow.** A cluster spanning three tables of
+one dataset is one investigation and one PR.
+
+Investigation is read-only and parallelises freely. **Fixing edits files, so
+every fix subagent must be dispatched with `isolation: "worktree"`** — they run
+in one shared checkout otherwise, and two agents on two branches will overwrite
+each other's work and cross-contaminate their commits.
+
+Give each subagent everything it needs to work without asking you:
+
+```text
+Cluster: <taxonomy class> — <error signature>
+Flows: <flow name> (deployment <name>, <n> failures, last <date>)
+Run IDs: <ids to read logs from>
+Arming state: <armed | paused since ...>
+Datasets/files in scope: pipelines/datasets/<ds>/, models/<ds>/
+Open PRs touching this dataset: <numbers, or none>
+Task: <investigate | investigate and fix>
+Branch: fix/<dataset_id>-<short-slug>
+```
+
+### 4. Aggregate
+
+Collect each subagent's report. Do not restate its whole investigation — keep
+the confirmed cause, the change, the verification evidence, and what is still
+unverified.
+
+Then produce the Phase 6 board from the `pipeline-doctor` skill, with a row per
+cluster and its outcome.
+
+## Hard limits
+
+These exist because each one has silently burned a real run:
+
+- **Never trigger a deployment with `{}`.** Defaults are
+  `materialize_to_prod=True, update_metadata=True`; a bare trigger writes prod
+  data and metadata and applies the paywall, even from the dev pool. Always
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`.
+- **Never arm or disarm a deployment.** Arming resumes writes to production and,
+  for a `part_bdpro` table, re-issues Row Access Policies. It is the user's call
+  every time.
+- **Never push or open a PR without the user's go-ahead** unless they have said
+  to ship fixes in this session. Report the branch and the exact command instead.
+- **A green run is not an ingest, and a green deploy job is not a deploy.**
+  Confirm from logs: `dbt run OK` + `dbt test OK` per table, and a clone path of
+  `/app/pipelines-<branch>/`.
+- **Never report a cause you have not confirmed against the source or the code.**
+
+## Output
+
+A triage board, one row per cluster: class, flows, confirmed cause, disposition,
+branch/PR, and verification evidence. Close with what was not verified — the
+prod upload is never exercisable from a dev run, and neither are Row Access
+Policies for a `part_bdpro` table.

--- a/.claude/agents/pipeline-investigator.md
+++ b/.claude/agents/pipeline-investigator.md
@@ -1,0 +1,109 @@
+---
+name: pipeline-investigator
+description: Investigates and fixes ONE failing Prefect pipeline cluster — reads the run logs, confirms the cause against the source and the code, makes the minimal change on its own branch, and verifies it. Dispatched by the pipeline-fixer orchestrator, one per cluster.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - mcp__databasis__list_flow_runs
+  - mcp__databasis__get_flow_run_logs
+  - mcp__databasis__get_failed_flow_runs
+  - mcp__databasis__run_deployment
+  - mcp__databasis__query_bigquery
+---
+
+# Pipeline Investigator
+
+Take one cluster of failing runs from a diagnosis to a verified fix on its own
+branch. Scope is exactly the cluster handed to you — do not wander into other
+datasets, and do not touch framework code.
+
+## Rules
+
+- `pipeline-doctor` skill: `references/failure-taxonomy.md` for classification,
+  `references/fix-and-ship.md` for labels, dev runs, and the traps.
+- `prefect-pipeline-conventions` for flow structure and the shared transform.
+- `dbt-conventions` and `bigquery-conventions` when the fix touches models or
+  staging.
+- `onboarding-workflow` for branch naming and commit discipline.
+
+## Procedure
+
+1. **Read the real error.** `state_message` carries the outermost exception,
+   which is usually a wrapper. Pull logs with `get_flow_run_logs` — start at
+   `min_level="ERROR"`, then re-read unfiltered around the failure for the
+   traceback's own frame and the failing dbt test's name and row count.
+
+2. **Confirm the cause.** This is the step that gets skipped, and skipping it is
+   how a plausible wrong diagnosis reaches a PR.
+   - Source schema change: fetch the current file and diff its header against
+     `constants.py` and the architecture CSV. Name the old and new column.
+   - dbt failure: reproduce locally (`uv run dbt test --select <ds>__<table>`;
+     dev is the default target, never pass `--target dev`).
+   - Anything computed by our own code (a date, an index, a path): read the
+     code before believing the message. `Não há arquivos para 2028-08-01` in a
+     2026 run is our bug, not a missing upstream file.
+
+   If you cannot confirm it, stop and report what you found and what check
+   would settle it. An unconfirmed cause is a finding, not a fix.
+
+3. **Check the class is yours to fix.** IAM 403s, `No active or succeeded pods`,
+   and quota exhaustion are not fixable in this repo. Report and stop. Do not
+   retarget a project or bucket to make a permission error disappear.
+
+4. **Make the minimal change**, on the branch you were given.
+   - The cleaning transform lives once, in `pipelines/datasets/<ds>/utils.py`,
+     shared with `models/<ds>/code/`. Fix it there; never fork it.
+   - The architecture CSV wins on any conflict with the model or the raw data.
+   - Relaxing a dbt test is a last resort and must be documented in the model
+     description, saying why.
+   - Never commit data (`input/`, `output/`, parquet, CSV).
+
+5. **Guard against the silent-success failure mode.** `safe_cast` NULLs instead
+   of raising, so a renamed column can arrive empty with every test green. After
+   a rename or retype fix, diff non-null counts against the staging parquet
+   rather than trusting a green test.
+
+6. **Verify.**
+   - `uv run pytest <the tests you touched>` and, if you added pure logic, a
+     test for it. Note in your report that **CI runs no pytest job** — hadolint,
+     pyrefly, dbt and metadata validation only — so tests are a local guard.
+   - `uv run pre-commit run --files <changed>` and `uv run pyrefly check <file>`.
+     In a worktree under `.claude/`, the repo-wide `pyrefly check` matches no
+     files and exits 1; check your files by explicit path, and skip only that
+     hook (`SKIP=pyrefly-check`), never `--no-verify`.
+   - A dev run is the real gate for a flow change, but it needs the
+     `deploy-flow` label on an open PR and only deploys a PR that changes
+     `flows.py`. If your fix is in `utils.py`/`tasks.py`/`constants.py`, say
+     plainly that the dev-run gate does not apply and why.
+
+7. **Commit, do not push.** Commit on your branch with
+   `fix(<dataset_id>): <description>`. Report the branch and the push/PR command
+   for the orchestrator to hand up. Push and open the PR only if you were
+   explicitly told to.
+
+## Hard limits
+
+- Never trigger a deployment with `{}` — use
+  `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`.
+  The defaults write prod data, prod metadata, and apply the paywall.
+- Never arm or disarm a deployment.
+- Never run an unfiltered `count(*)` or full scan on a large BigQuery table,
+  including EXTERNAL staging tables. Use `__TABLES__`, `INFORMATION_SCHEMA`, or
+  a partition filter with `LIMIT`.
+- Stay inside your cluster's datasets. A fix that needs a framework change
+  (`pipelines/utils`, `AGENTS.md`) is a separate PR — report it, do not make it.
+
+## Output
+
+Report back:
+
+- **Cause** — confirmed, and how you confirmed it.
+- **Change** — files touched, why this is the minimal fix.
+- **Verification** — what you ran and what it showed.
+- **Not verified** — what could not be exercised, and why. The prod upload never
+  is; Row Access Policies only exist for a `part_bdpro` table.
+- **Branch** — name, commit SHA, and the command to push and open the PR.

--- a/.claude/agents/pipeline-investigator.md
+++ b/.claude/agents/pipeline-investigator.md
@@ -32,6 +32,24 @@ datasets, and do not touch framework code.
 
 ## Procedure
 
+0. **Check nobody is already on it.** Even when the orchestrator says the cluster
+   is clear, re-check before you edit — this repo has many concurrent
+   contributors and minutes pass between triage and work.
+
+   ```bash
+   gh pr list --repo basedosdados/pipelines --state open --limit 100 \
+     --json number,title,headRefName,author \
+     --jq '.[] | "\(.number)\t\(.headRefName)\t\(.title)"'
+   gh pr list --repo basedosdados/pipelines --state merged --limit 60 \
+     --search "sort:updated-desc" --json number,title,mergedAt \
+     --jq '.[] | "\(.number)\t\(.mergedAt)\t\(.title)"'
+   ```
+
+   If an open PR covers this dataset, stop and report it rather than forking a
+   competing branch. If a *merged* PR post-dates the last failure, the fix is
+   already on `main` — verify that against the code, then report that the flow
+   needs arming, not fixing.
+
 1. **Read the real error.** `state_message` carries the outermost exception,
    which is usually a wrapper. Pull logs with `get_flow_run_logs` — start at
    `min_level="ERROR"`, then re-read unfiltered around the failure for the
@@ -80,10 +98,15 @@ datasets, and do not touch framework code.
      `flows.py`. If your fix is in `utils.py`/`tasks.py`/`constants.py`, say
      plainly that the dev-run gate does not apply and why.
 
-7. **Commit, do not push.** Commit on your branch with
-   `fix(<dataset_id>): <description>`. Report the branch and the push/PR command
-   for the orchestrator to hand up. Push and open the PR only if you were
-   explicitly told to.
+7. **Commit and, when told to ship, push and open the PR.** Commit on your branch
+   with `fix(<dataset_id>): <description>`. This repo's `.claude/settings.json`
+   permits `git push` and `gh pr create`; it **denies merging**, which is never
+   yours to do. Re-run the open-PR check from step 0 immediately before creating
+   the PR — the gap between starting work and opening it is long enough for
+   someone else to file one.
+
+   Apply the label that matches what changed: `deploy-flow` for `flows.py`,
+   `test-dev-model` for `models/**/*.sql`.
 
 ## Hard limits
 
@@ -94,6 +117,7 @@ datasets, and do not touch framework code.
 - Never run an unfiltered `count(*)` or full scan on a large BigQuery table,
   including EXTERNAL staging tables. Use `__TABLES__`, `INFORMATION_SCHEMA`, or
   a partition filter with `LIMIT`.
+- Never merge a PR, and never push to `main` or force-push a shared branch.
 - Stay inside your cluster's datasets. A fix that needs a framework change
   (`pipelines/utils`, `AGENTS.md`) is a separate PR — report it, do not make it.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(git push:*)",
+      "Bash(git pull:*)",
+      "Bash(git fetch:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr status:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh label list:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "mcp__github__create_pull_request",
+      "mcp__github__update_pull_request",
+      "mcp__github__pull_request_read",
+      "mcp__github__list_pull_requests",
+      "mcp__github__search_pull_requests",
+      "mcp__github__list_branches",
+      "mcp__github__list_commits",
+      "mcp__github__get_commit",
+      "mcp__github__get_label",
+      "mcp__github__add_issue_comment"
+    ],
+    "deny": [
+      "Bash(gh pr merge:*)",
+      "mcp__github__merge_pull_request",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push origin main:*)",
+      "Bash(git push origin HEAD:main:*)",
+      "Bash(git push --delete:*)",
+      "Bash(git push origin --delete:*)"
+    ]
+  }
+}

--- a/.claude/skills/pipeline-doctor/SKILL.md
+++ b/.claude/skills/pipeline-doctor/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: pipeline-doctor
+description: Triage, diagnose, and fix failing Prefect 3 pipelines in this repo. Surveys recent failed flow runs and deployment arming state, groups failures by root cause, classifies each against a failure taxonomy, and drives fixes through branch → PR → label → dev run → merge. Use when asked to check on broken pipelines, find out why a dataset stopped updating, review pipeline health, or fix a failing flow.
+argument-hint: "[<flow_name_substring>] [--days N] [--report-only | --fix] [--include-paused]"
+---
+
+# Pipeline Doctor
+
+Recurring pipelines in this repo fail for a handful of recurring reasons, and the
+team's capacity valve is to **disarm** a pipeline that keeps failing rather than
+fix it. Two consequences shape everything below:
+
+- **A quiet pipeline is not a healthy pipeline.** A disarmed deployment produces
+  no runs, so it disappears from any failure list. Absence of failures is
+  evidence of nothing. Always read arming state alongside run state.
+- **A green run is not an ingest.** The source-poll guard returns early and
+  Prefect still records `COMPLETED`. `br_ibge_ipca` sat at 4 ingests across 60
+  completed runs unnoticed.
+
+The goal is successfully running flows in **prod**. Diagnosis is the means.
+
+Read `references/failure-taxonomy.md` before classifying anything, and
+`references/fix-and-ship.md` before opening a PR or triggering a run.
+
+---
+
+## Phase 1 — Survey
+
+Gather three views. Do not skip the second: it is the one nothing else reports.
+
+**Failed runs** (Prefect 3, via the databasis MCP — never the retired
+`prefect.basedosdados.org` host):
+
+```
+mcp__databasis__list_flow_runs(state="Failed", limit=100)
+mcp__databasis__list_flow_runs(state="Crashed", limit=50)
+```
+
+`state_message` alone classifies most failures — pull full logs only for the
+ones it does not.
+
+**Arming state** — no MCP tool enumerates deployments, so use the bundled
+script:
+
+```bash
+uv run python .claude/skills/pipeline-doctor/scripts/deployments.py --pool basedosdados --paused
+```
+
+Read the `paused` field, never the schedule's own `active` flag: a paused
+deployment still reports `active=True`, and deployment-level `paused` wins.
+A paused deployment **that carries a cron** was armed once and deliberately
+switched off — that is the deactivation signal. A paused deployment with no
+cron is usually a helper or a never-armed new pipeline, not a casualty.
+
+Note `updated` is stamped by the last `--all` deploy, i.e. the last merge to
+`main`. It is **not** when the pipeline was deactivated and must never be
+reported as such. For the real timestamp, see "Reading the stored arming
+state" in `references/fix-and-ship.md`.
+
+**Ingest rate** (optional, only on the `feat/pipeline-diagnostics` branch —
+`pipelines/diagnostics/` is not on `main` yet):
+
+```bash
+uv run python -m pipelines.diagnostics health --days 30
+```
+
+It classifies each run from its log markers and flags flows that have never
+ingested despite running. If the module is absent, say so rather than
+substituting run state for ingest rate.
+
+## Phase 2 — Group by root cause, not by flow
+
+One infrastructure fault shows up as N broken pipelines. Cluster the failures
+by their error signature *before* diagnosing, or you will write four PRs for
+one IAM grant.
+
+Cluster first on the taxonomy signature, then note which datasets each cluster
+spans. A cluster of one is fine; a cluster of six that all say
+`Permission bigquery.tables.update denied` is a single infrastructure item with
+one owner and no code change.
+
+## Phase 3 — Diagnose each cluster
+
+Classify against `references/failure-taxonomy.md`, which gives the observed
+signature, the real cause, and the fix route for each class. The classes:
+
+| Class | Fixable in this repo? |
+|---|---|
+| Source schema change | Yes — the most common real bug |
+| Source unavailable / moved | Usually yes |
+| dbt test failure | Yes — but decide data-bug vs. stale-test first |
+| dbt run failure | Yes |
+| Coverage / metadata misconfiguration | Yes |
+| Pipeline code bug | Yes |
+| IAM / permissions | **No** — escalate, do not patch around |
+| Worker / orchestration | **No** — escalate |
+| Quota exhaustion | Partly — the culprit is usually another pipeline |
+
+Confirm the diagnosis against the code before proposing a fix. `KeyError: 'Año'`
+tells you a column vanished; only the source tells you what replaced it. Fetch
+the current source and compare against `constants.py` / the architecture CSVs.
+
+Do not report a cause you have not checked. "Probably the source changed" is not
+a diagnosis.
+
+## Phase 4 — Triage
+
+Assign every cluster one disposition, and say who owns it:
+
+- **Fix now** — cause understood, change is contained, verifiable in dev.
+- **Needs investigation** — cause plausible but unconfirmed; name the next check.
+- **Not ours** — IAM, worker, quota. Escalate with the exact grant or resource.
+- **Propose deactivation** — repeatedly failing, low value, no cheap fix. This
+  is the team's legitimate capacity decision. **Propose it; never disarm a
+  pipeline yourself without explicit approval.**
+- **Already in flight** — an open PR covers it. Check before starting:
+  `gh pr list --repo basedosdados/pipelines --state open --search "<dataset_id>"`.
+
+In `--report-only` mode (and by default when more than one cluster needs code
+changes), stop here and present the board. Ask before fixing at scale — a sweep
+across ten datasets is the user's call, not yours.
+
+## Phase 5 — Fix and ship
+
+Follow `references/fix-and-ship.md` exactly. It carries the traps that make a
+fix look shipped when it is not. In brief, per fix:
+
+1. Branch `fix/<dataset_id>-<what>` — never a generic `claude/…` prefix.
+2. Make the minimal change. Reuse the shared transform; do not fork it.
+3. Pre-format: `uv run pre-commit run --files <changed>`; `uv run pyrefly check`.
+4. Open the PR and apply the label that matches what changed:
+   `deploy-flow` for `flows.py`, `test-dev-model` for `models/**/*.sql`.
+   There is no `trigger-run` label — a dev run is triggered through
+   `mcp__databasis__run_deployment`, not GitHub.
+5. Verify in dev: trigger with **prod explicitly off**
+   `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}`.
+   The defaults are `True/True/False`; a run triggered with `{}` writes prod
+   data, prod metadata, and applies the paywall — from the dev pool.
+6. Read the logs, not the state. Confirm `dbt run OK` **and** `dbt test OK` per
+   table, and that the clone path is `/app/pipelines-<your-branch>/`, not
+   `/app/pipelines-main/`.
+7. Hand the PR to the user to merge. Re-arming a disarmed pipeline is a separate,
+   explicit decision — see `references/fix-and-ship.md`.
+
+## Phase 6 — Report
+
+Report in this shape, ranked by blast radius (datasets affected × whether prod
+data is stale):
+
+```text
+=== PIPELINE DOCTOR — <window>, prod pool ===
+Runs surveyed: N failed, M crashed | Deployments: A armed, P paused (C with a cron)
+
+CLUSTER 1 — <class>: <signature>
+  Flows:      <flow> (n failures, last <date>), ...
+  Cause:      <confirmed cause, and how it was confirmed>
+  Disposition:<fix now | investigate | not ours | propose deactivation | in flight>
+  Action:     <PR #, or the exact escalation>
+
+... one block per cluster ...
+
+DISARMED WITH A CRON (not producing runs, so invisible above): <n>
+  <flow> — last failure <date>, cause <class>
+
+NOT VERIFIED: <what this run could not exercise>
+```
+
+Always close with what was not verified. The prod upload and, for a
+`part_bdpro` table, `apply_row_access_policies` only execute on an armed prod
+run — neither is exercisable from a dev run or locally. Say which applies
+rather than implying the pipeline is proven end to end.
+
+## Running this periodically
+
+The skill is designed to be re-run on a schedule. To keep successive runs from
+re-reporting the same thing:
+
+- **Dedupe against open PRs** before proposing any fix (Phase 4).
+- Keep a small state file at `~/.cache/bd-pipeline-doctor/state.json` recording
+  each cluster's signature, first-seen date, and disposition. On a later run,
+  report a known cluster as `unchanged since <date>` in one line instead of a
+  full block, and reserve full blocks for what is new or has changed
+  disposition. Never put this state in the repo.
+- In an unattended run, stay in `--report-only`. Opening PRs and triggering
+  runs are the parts a human should be present for.

--- a/.claude/skills/pipeline-doctor/SKILL.md
+++ b/.claude/skills/pipeline-doctor/SKILL.md
@@ -57,6 +57,36 @@ Note `updated` is stamped by the last `--all` deploy, i.e. the last merge to
 reported as such. For the real timestamp, see "Reading the stored arming
 state" in `references/fix-and-ship.md`.
 
+**Work already in flight — mandatory, and do it before diagnosing anything.**
+This is a live repo with many collaborators. Someone else is very likely already
+on the failure you are looking at, and a duplicate branch wastes their review
+time as well as yours.
+
+```bash
+gh pr list --repo basedosdados/pipelines --state open --limit 100 \
+  --json number,title,headRefName,labels,updatedAt,author \
+  --jq '.[] | "\(.number)\t\(.headRefName)\t\(.title)"'
+```
+
+Check **merged** PRs too, not only open ones:
+
+```bash
+gh pr list --repo basedosdados/pipelines --state merged --limit 60 \
+  --search "sort:updated-desc" \
+  --json number,title,headRefName,mergedAt \
+  --jq '.[] | "\(.number)\t\(.mergedAt)\t\(.title)"'
+```
+
+A merged fix whose merge time is **after** the cluster's last failure means the
+cluster is already fixed and the flow is simply not running again — usually
+because it was disarmed while it was failing and nobody re-armed it. That is not
+a bug to fix; it is an arming decision. `mx_sesnsp_incidencia_delictiva` was
+exactly this: its fix merged seven minutes after its final failure, and it sat
+paused for days looking broken.
+
+So for every cluster, compare three timestamps before calling it a bug: the last
+failure, the merge time of any related PR, and the deployment's arming state.
+
 **Ingest rate** (optional, only on the `feat/pipeline-diagnostics` branch —
 `pipelines/diagnostics/` is not on `main` yet):
 
@@ -73,6 +103,10 @@ substituting run state for ingest rate.
 One infrastructure fault shows up as N broken pipelines. Cluster the failures
 by their error signature *before* diagnosing, or you will write four PRs for
 one IAM grant.
+
+Then cross the clusters against the in-flight and merged PRs from Phase 1, and
+against arming state. A cluster that is covered by an open PR, or already fixed
+by a merged one, never reaches diagnosis.
 
 Cluster first on the taxonomy signature, then note which datasets each cluster
 spans. A cluster of one is fine; a cluster of six that all say
@@ -113,8 +147,11 @@ Assign every cluster one disposition, and say who owns it:
 - **Propose deactivation** — repeatedly failing, low value, no cheap fix. This
   is the team's legitimate capacity decision. **Propose it; never disarm a
   pipeline yourself without explicit approval.**
-- **Already in flight** — an open PR covers it. Check before starting:
-  `gh pr list --repo basedosdados/pipelines --state open --search "<dataset_id>"`.
+- **Already fixed** — a merged PR post-dates the last failure. No code change.
+  The open question is whether the deployment is armed; say so and stop.
+- **Already in flight** — an open PR covers it. Name the PR number and its author,
+  and do not start a competing branch. If the PR looks stalled or wrong, say so
+  as a comment-worthy observation; do not fork it.
 
 In `--report-only` mode (and by default when more than one cluster needs code
 changes), stop here and present the board. Ask before fixing at scale — a sweep
@@ -175,7 +212,8 @@ rather than implying the pipeline is proven end to end.
 The skill is designed to be re-run on a schedule. To keep successive runs from
 re-reporting the same thing:
 
-- **Dedupe against open PRs** before proposing any fix (Phase 4).
+- **Re-run the open/merged PR check every time** (Phase 1). On a shared repo the
+  in-flight set changes between runs more than the failure set does.
 - Keep a small state file at `~/.cache/bd-pipeline-doctor/state.json` recording
   each cluster's signature, first-seen date, and disposition. On a later run,
   report a known cluster as `unchanged since <date>` in one line instead of a

--- a/.claude/skills/pipeline-doctor/references/failure-taxonomy.md
+++ b/.claude/skills/pipeline-doctor/references/failure-taxonomy.md
@@ -1,0 +1,269 @@
+# Failure Taxonomy
+
+Every signature below was observed in `list_flow_runs(state="Failed")` on this
+repo in August 2026. Match on the signature, then confirm the cause against the
+code or the source before proposing anything.
+
+The order matters: classes 7–9 are **not fixable in this repo**, and patching
+around one produces a change that looks like a fix and is not.
+
+---
+
+## 1. Source schema change
+
+**Signatures**
+
+```
+KeyError: 'Año'                     (mx_sesnsp_incidencia_delictiva)
+KeyError: 'id_senador'              (br_senado_dados_abertos)
+KeyError: 'naturezas'               (br_rf_cnpj__dicionario)
+ArrowTypeError: Unable to merge: Field year has incompatible types:
+  string vs dictionary<values=int32, ...>          (us_fec_campaign_finance)
+```
+
+**Cause.** The publisher renamed, dropped, retyped or reordered a column. A
+`KeyError` naming a source-side column is nearly always this. An `ArrowTypeError`
+on a concat/merge means two vintages of the source now disagree on a column's
+type.
+
+**Confirm.** Download the current file and diff its header against the column
+list in `pipelines/datasets/<ds>/constants.py` and the architecture CSV under
+`models/<ds>/code/architecture/`. Name the old and new column explicitly.
+
+**Fix.** Map the new name in the cleaning transform in
+`pipelines/datasets/<ds>/utils.py` — the transform is shared with the
+`models/<ds>/code/` bootstrap, so fix it once there and do not fork it. Keep the
+architecture CSV authoritative: if the *output* schema must change, the
+architecture changes first and the dbt model follows. For a retype, normalize
+in the transform; staging is all-STRING by convention and the dbt model
+`safe_cast`s.
+
+**Watch.** `safe_cast` NULLs instead of raising, so a column silently arriving
+empty passes every test. After a rename fix, diff non-null counts against the
+staging parquet rather than trusting green tests.
+
+---
+
+## 2. Source unavailable, moved, or throttled
+
+**Signatures**
+
+```
+FileNotFoundError: Nenhum arquivo csv encontrado em /tmp/br_ms_sia/output/...
+FileNotFoundError: [Errno 2] No such file: '/tmp/br_sfb_sicar_.../RO_AREA_IMOVEL.zip'
+ValueError: Não há arquivos disponíveis para a data 2028-08-01.
+  Verifique o FTP da Receita Federal.          (br_rf_cafir)
+RuntimeError: GET https://legis.senado.leg.br/... (xml) failed:
+  HTTP 200 after 6 attempts                    (br_senado_dados_abertos)
+```
+
+**Cause, three distinct ones — separate them.**
+
+- *Genuinely absent upstream*: the publisher has not released, or withdrew a file.
+- *Download silently produced nothing*: the fetch "succeeded" and the extract
+  step found an empty directory. A `FileNotFoundError` in an `output/` path is
+  this, not an upstream outage.
+- *A date the pipeline computed itself*: `2028-08-01` in a 2026 run is a
+  date-derivation bug in our code, not a missing upstream file. Read the error
+  before believing it.
+
+`HTTP 200 after 6 attempts` means the request succeeded but the body failed to
+parse — an HTML error page or an empty document served with a 200. Treat it as a
+source-contract change, not a network fault.
+
+**Fix.** For a real outage, make the poll guard hold instead of failing. For the
+other two, fix the code. Never make a pipeline swallow a missing file: a run that
+completes on no data is worse than one that fails.
+
+---
+
+## 3. dbt test failure
+
+**Signature**
+
+```
+Exception: dbt test falhou para models/<ds>/<ds>__<table>.sql (target=dev|prod)
+```
+
+**Cause — decide which before touching anything.**
+
+- *Real data defect*: the new vintage genuinely violates the constraint
+  (duplicate keys, a broken FK, a column that went null).
+- *Stale test*: the constraint encoded an assumption the source has since
+  outgrown legitimately.
+- *Ordering artifact*: a cross-table test (`relationships`, `dbt_utils`
+  referential checks, `custom_dictionary_coverage` with `ref('..._dicionario')`)
+  ran before its sibling model was built. `Not found: Table ....dicionario` is
+  this. The flow must run **every** table then test **every** table — two loops,
+  never `dbt_command="run/test"` inside a per-table loop.
+
+**Confirm.** Get the failing test's name and row count from the run logs, then
+reproduce locally: `uv run dbt test --select <ds>__<table>` (target `dev` is the
+default — never pass `--target dev`).
+
+**Fix.** A real defect is fixed in the transform. Relaxing a test is a last
+resort and must be documented in the model description, per repo convention
+(`custom_relationships` with `ignore_values`, or
+`custom_unique_combinations_of_columns` with `proportion_allowed_failures`).
+Never relax a test to make a run go green without saying why in the PR.
+
+**Cost note.** `not_null_proportion_multiple_columns` compiles a scan of *every*
+column. Unscoped on a wide table it burns the daily BigQuery byte quota — which
+then fails whichever pipeline runs next. Scope it with `where:
+__most_recent_year_month__` (or the year/date variant).
+
+---
+
+## 4. dbt run failure
+
+**Signatures**
+
+```
+Exception: dbt run falhou para models/<ds>/<ds>__<table>.sql (target=dev|prod)
+GenericGBQException: Reason: 400 ... Unrecognized name: cycle at [3:18]
+Parquet column '<col>' has type BYTE_ARRAY which does not match the
+  target cpp_type INT32
+Invalid cast from INT64 to DATE
+```
+
+**Cause.** The model and the staging external table disagree. `Unrecognized
+name` = the model selects a column staging no longer has (upstream rename, or a
+transform change that did not reach the model).
+
+The parquet type errors are the known staging-schema divergence: staging must be
+**all-STRING** on both write paths — the one-shot onboarding upload *and* the
+pipeline's `upload_to_gcs`. They share one staging dataset, so a typed external
+table left behind by onboarding collides with the pipeline's all-STRING
+overwrite. Cast via arrow, never `astype(str)` (which writes the literal
+`"nan"`), and pass the architecture's real types through first so `year`
+serializes as `"1959"`, not `"1959.0"`.
+
+**Fix.** Realign model, transform and architecture — architecture wins on any
+conflict. Get the real dbt error from the run logs; the wrapper exception text
+alone does not identify the column.
+
+---
+
+## 5. Coverage / metadata misconfiguration
+
+**Signature**
+
+```
+ValidationError: 1 validation error for PartBdpro
+  Value error, date_column 'date' incompatível com date_format '%Y-%m'
+                                              (br_rf_cnpj__estabelecimentos)
+part_bdpro exige Coverage free + pro          (assert_coverage_topology)
+allRawdatasource: mais de um nó encontrado para {'tables_Id': …}
+```
+
+**Cause.**
+
+- The `CoverageSpec`'s `date_column` kind does not match its `date_format`:
+  `YearMonth` ↔ `YEAR_MONTH`, `YearOnly` ↔ `YEAR`, `DateOnly` ↔ `YEAR_MD`.
+- `assert_coverage_topology` hard-fails **before any write** when the tier and
+  the registered Coverages disagree. `part_bdpro` needs both a free Coverage
+  (`is_closed=False`) and a pro one (`is_closed=True`); `AllFree` needs free and
+  no pro. Create the missing Coverage before switching a tier.
+- `mais de um nó` is the known client bug: a table linked to two raw data
+  sources cannot resolve one, and both the poll and commit tasks go through that
+  resolver. Link exactly **one** raw source per table.
+
+**Fix.** These are pure-function or metadata fixes. `assert_coverage_topology`,
+`compute_coverage_ranges` and `needs_row_access_policy` are unit-testable
+locally — test the window and its roll. `apply_row_access_policies` issues real
+BigQuery DDL and is not exercisable locally; say so.
+
+---
+
+## 6. Pipeline code bug
+
+**Signatures**
+
+```
+IndexError: list index out of range     (us_bls_oes, br_bndes_operacoes_...)
+```
+
+**Cause.** Usually a parse step assuming a structure the current payload does
+not have — an empty result set, a missing table on a scraped page, an
+off-by-one in a split. Frequently a *downstream* symptom of class 1 or 2.
+
+**Confirm.** Pull full logs (`get_flow_run_logs`, `min_level="ERROR"` first,
+then unfiltered around the failure) and read the traceback's own frame — the
+`state_message` shows only the outermost exception.
+
+**Fix.** In `utils.py`, with the pure function tested against the real payload.
+Fail loudly on an empty payload rather than indexing into it.
+
+---
+
+## 7. IAM / permissions — NOT fixable here
+
+**Signatures**
+
+```
+Forbidden: 403 PATCH .../projects/basedosdados-staging/datasets/<ds>_staging/
+  tables/<t>: Permission bigquery.tables.update denied
+Forbidden: 403 GET .../projects/basedosdados-dev/...:
+  Permission bigquery.tables.get denied
+Forbidden: 403 GET .../storage/v1/b/basedosdados-dev/o?...:
+  Caller does not have serviceusage.services.use access
+```
+
+**Cause.** The worker's service account lacks a grant on a project, dataset or
+bucket. Nothing in this repo grants it.
+
+**Recognise the shape.** This class arrives as a *cluster* — one missing grant
+breaks every pipeline touching that project. In the August 2026 survey it hit
+`br_anatel_telefonia_movel`, `br_ms_sih`, `us_treasury_usaspending` and
+`br_sfb_sicar` simultaneously. Report it once, with the full list of affected
+flows and the exact permission and resource, not once per dataset.
+
+**Do not** work around it by retargeting a bucket or project. That changes where
+data lands to make an error disappear.
+
+---
+
+## 8. Worker / orchestration — NOT fixable here
+
+**Signature**
+
+```
+UnfinishedRun: Run is in PENDING state, its result is not available.
+  (flow "BD template: Executa DBT model")
+```
+
+**Cause.** A subflow or task never left `PENDING` — worker capacity, a pod
+eviction, or an infrastructure hiccup. Not a data or code fault.
+
+**Fix.** Re-run once to distinguish transient from persistent. If it recurs on
+the same deployment, escalate with the run IDs; do not restructure a flow to
+route around the orchestrator.
+
+---
+
+## 9. BigQuery quota exhaustion
+
+**Signature.** Quota/`Exceeded` errors, or a cluster of unrelated pipelines
+failing within the same window.
+
+**Cause.** Pipelines share a **daily byte quota**. It trips on whichever
+pipeline runs next, not the one responsible — so the failing flow is usually
+innocent.
+
+**Confirm.** On the `feat/pipeline-diagnostics` branch,
+`uv run python -m pipelines.diagnostics cost --days 7` ranks datasets by bytes
+billed. It needs `bigquery.jobs.listAll` on the project
+(`roles/bigquery.resourceViewer`); a 403 there is a permissions gap, not a
+broken query.
+
+**Fix.** Reduce work at the actual culprit: scope wide-table tests with
+`where:`, drop redundant dev materializations, make heavy models incremental.
+Spreading cron minutes reduces same-instant contention but **not** bytes billed
+per day — do not present it as a quota fix.
+
+**Related.** Cron minutes are a real, separate problem: twelve pipelines added
+in August 2026 all fired at `0 16 * * *`. Pick an unused minute, never `0`:
+
+```bash
+grep -rho '"cron": "[^"]*"' pipelines/datasets/*/flows.py | sort | uniq -c | sort -rn
+```

--- a/.claude/skills/pipeline-doctor/references/fix-and-ship.md
+++ b/.claude/skills/pipeline-doctor/references/fix-and-ship.md
@@ -1,0 +1,209 @@
+# Fix and Ship
+
+How a diagnosed fix reaches a green prod run. Every step here exists because
+skipping it produces a fix that *looks* shipped and is not.
+
+---
+
+## The labels, and what each actually does
+
+| Label | Workflow | Triggers on | Scope |
+|---|---|---|---|
+| `deploy-flow` | `cd-prefect3-staging.yaml` | PR labelled or synchronized | Deploys changed `pipelines/**/*.py` to the **`basedosdados-dev`** pool, schedules stripped |
+| `test-dev-model` | `ci.yaml` | PR labelled | Runs dbt on changed `models/**/*.sql` against `basedosdados-dev` |
+| `table-approve` | `table-approve.yaml` | On merge | Materializes the changed models into prod |
+| `check-metadata` | — | PR labelled | Validates metadata between BigQuery and the prod API |
+| `deploy-flow-fusion` | — | PR labelled | Same as `deploy-flow` with `DBT_ENGINE=fusion` |
+
+There is **no `trigger-run` label.** A dev run is started through
+`mcp__databasis__run_deployment`, not from GitHub.
+
+Pick by what the PR changes: `flows.py` → `deploy-flow`; `models/**/*.sql` →
+`test-dev-model`; both → both.
+
+### `deploy-flow` only deploys a PR that changes `flows.py`
+
+The workflow passes changed `pipelines/**/*.py` to `deploy_flows.py --files`,
+which keeps only files that **define a `Flow` object**. A PR fixing `utils.py`,
+`tasks.py`, `constants.py` or a `*_clean.py` — where pipeline bugs usually live
+— contributes **zero** deployments, and the job still reports **`pass`**:
+
+```
+senado_api.py:   0 flow(s)
+senado_clean.py: 0 flow(s)
+flows.py:        1 flow(s)
+```
+
+The deployment keeps whatever git ref it already had, so a trigger then runs a
+**different branch** — whichever PR last touched that `flows.py`, or `main`.
+This is not hypothetical: on `mx_sesnsp_incidencia_delictiva` (#1873) and
+`br_senado_dados_abertos` (#1874), three trigger attempts ran another branch and
+reproduced the original error, reading exactly like "the fix does not work".
+
+`load_flows_from_file` also **swallows import errors** and returns `{}`, so a
+broken import is a silent no-deploy with a green check.
+
+**A green "deploy flows" job is never evidence that anything deployed.**
+
+To validate a non-`flows.py` fix, pick one:
+- Touch `flows.py` in the same PR (a real change, not whitespace).
+- Merge it and watch the next scheduled run — usually fine when the flow is
+  already failing every run, so the fix cannot make things worse.
+
+---
+
+## Triggering the dev run
+
+Confirm `cd-prefect3 (staging)` logged `registrado`, then:
+
+```
+mcp__databasis__run_deployment(
+    deployment_name="<flow_name>/<deployment_name>",
+    parameters={"materialize_to_prod": False,
+                "update_metadata": False,
+                "force_run": True},
+)
+```
+
+**All three parameters matter.** The flow defaults are
+`materialize_to_prod=True, update_metadata=True, force_run=False`. A run
+triggered with `{}` writes **prod data, prod metadata, and applies the paywall**
+— from the dev pool, because the metadata tasks are pinned `env="prod"`
+regardless of pool. `force_run=True` bypasses the poll guard, which otherwise
+returns before doing anything.
+
+Get the exact deployment name from
+`scripts/deployments.py` (the `DEPLOYMENT` column) — `run_deployment` wants
+`<flow>/<deployment>` and must contain exactly one `/`.
+
+### Reading the result
+
+**Done means all four:**
+
+1. Every task `COMPLETED`.
+2. `dbt run OK` in the logs for **every** table.
+3. `dbt test OK` in the logs for **every** table.
+4. The clone path in the logs is `/app/pipelines-<your-branch>/`, not
+   `/app/pipelines-main/`.
+
+`COMPLETED` on its own proves nothing: the poll guard returns early and still
+completes. `Não há novas atualizações na fonte original` in the logs means the
+run polled and did nothing — with `force_run=True` you should not see it.
+
+Read logs with `mcp__databasis__get_flow_run_logs(<run_id>)`. Start at
+`min_level="ERROR"`, then re-read unfiltered around the failure — the outermost
+exception in `state_message` usually names the wrapper, not the cause.
+
+---
+
+## Reading the stored arming state
+
+`scripts/deployments.py` reports Prefect's `paused`. The backend also stores
+`is_schedule_active` and `reactivated_at` in `DisabledFlowSchedule`, and that
+pair is what `sync-deployments` re-enforces on every merge to `main`.
+
+To read the backend record for a **paused** deployment without changing
+anything:
+
+```
+mcp__databasis__set_deployment_schedule_active(
+    flow_name="<bare deployment name>", active=False, env="prod")
+```
+
+Setting the state a flow is already in is a no-op (`action="no_change"`) that
+never touches Prefect, and returns `is_schedule_active` and `reactivated_at`.
+Passing `active=False` can only ever pause, so on an already-paused deployment
+it is safe as a read.
+
+**Never call it with `active=True` to "read" state.** On a deployment that is
+paused it would arm it, and the first armed run is the first-ever execution of
+the prod upload — and, for a `part_bdpro` table, of the BigQuery Row Access
+Policies.
+
+`flow_name` here is Prefect's **bare deployment name**
+(`au_rba_statistical_tables_flow`), not `<flow>/<deployment>` — the same string
+in the Django admin's `flow_name` column.
+
+---
+
+## Re-arming: always an explicit human decision
+
+Merging does **not** arm anything. Prod deployments land `paused=True`, and the
+backend sync registers an unknown deployment with `is_schedule_active=False` —
+sync only *enforces* stored state for deployments it already knows; it never
+arms a new one.
+
+Arming is three writes together (stored flag, `reactivated_at`, Prefect
+unpause), which `set_deployment_schedule_active(..., active=True)` does in one
+call. Do not unpause through the Prefect API directly: `sync-deployments` will
+silently re-pause it at the next unrelated merge.
+
+**Ask before arming, every time.** A pipeline the team disarmed was disarmed on
+purpose. Re-arming resumes writes to production, and for a `part_bdpro` table
+re-issues Row Access Policies — the paywall goes live and the open-data export
+starts excluding the pro window. Present the case, name what the first run will
+do, and let the user decide. Watch that run.
+
+---
+
+## Branch, commit, PR
+
+Branch prefix by change type — never a generic `claude/…`:
+
+| Prefix | For |
+|---|---|
+| `fix/` | a bug in existing code, models or data |
+| `pipeline/` | adding or restructuring a recurring pipeline |
+| `data/` | onboarding a new dataset |
+| `docs/` | documentation or `.claude/rules` only |
+
+One exception: if a pipeline PR already registered a dev deployment from its
+branch, do **not** rename it — the deployment's `GitRepository` is pinned to
+that branch name.
+
+Before committing:
+
+```bash
+uv run pre-commit run --files <changed files>
+uv run pyrefly check
+```
+
+`pyrefly` is a CI job that blocks merge on any error, and the pre-commit hook
+for it is skipped on the hosted runner — so run it yourself. Never bypass hooks
+with `--no-verify`.
+
+Commit as `fix(<dataset_id>): <description>`. Never commit data (`input/`,
+`output/`, parquet, CSV).
+
+Keep framework changes — `pipelines/utils`, `AGENTS.md`, `.claude/rules` — out
+of a dataset fix PR. They change behaviour for every pipeline and deserve their
+own review.
+
+### PR body
+
+State the diagnosis, not just the change:
+
+- The failing runs (flow name, run IDs, dates) and the error signature.
+- The confirmed cause, and how it was confirmed.
+- The fix, and why it is the minimal one.
+- The dev-run evidence: run ID, and that `dbt run OK` + `dbt test OK` appeared
+  for every table, plus the clone path.
+- What remains unexercised — the prod upload always, and
+  `apply_row_access_policies` when a table is `part_bdpro`.
+
+---
+
+## After merge
+
+`table-approve` materializes prod on merge, but **only the models in the diff**.
+A fix that changes a shared macro or a transform without touching the affected
+`.sql` will not re-materialize those tables — rematerialize them deliberately
+via `run_deployment` on the prod pool.
+
+Watch for the phantom-model failure: non-model `.sql` in the PR
+(`macros/`, `tests-dbt/`) makes table-approve treat it as a model and abort
+materialization before any real table builds.
+
+Then confirm the pipeline is actually ingesting again — not merely green.
+Re-check after the next scheduled run: run state, plus either the log markers or
+whether the coverage `DateTimeRange` moved.

--- a/.claude/skills/pipeline-doctor/references/fix-and-ship.md
+++ b/.claude/skills/pipeline-doctor/references/fix-and-ship.md
@@ -148,6 +148,29 @@ do, and let the user decide. Watch that run.
 
 ## Branch, commit, PR
 
+### First: confirm nobody beat you to it
+
+Re-check immediately before branching, and again before opening the PR. Triage
+and work are minutes apart, and this repo has many concurrent contributors.
+
+```bash
+gh pr list --repo basedosdados/pipelines --state open --limit 100 \
+  --json number,title,headRefName,author \
+  --jq '.[] | "\(.number)\t\(.headRefName)\t\(.title)"'
+```
+
+Also scan recently merged PRs. A merged fix that post-dates the cluster's last
+failure means there is nothing to fix — the flow just is not running again,
+which is an arming question.
+
+```bash
+gh pr list --repo basedosdados/pipelines --state merged --limit 60 \
+  --search "sort:updated-desc" --json number,title,mergedAt \
+  --jq '.[] | "\(.number)\t\(.mergedAt)\t\(.title)"'
+```
+
+### Then: branch
+
 Branch prefix by change type — never a generic `claude/…`:
 
 | Prefix | For |
@@ -192,6 +215,12 @@ State the diagnosis, not just the change:
   `apply_row_access_policies` when a table is `part_bdpro`.
 
 ---
+
+## Merging is not yours
+
+This repo's `.claude/settings.json` allows `git push` and `gh pr create` and
+**denies** `gh pr merge`. Open the PR, report it, and stop. Someone reviews and
+merges it.
 
 ## After merge
 

--- a/.claude/skills/pipeline-doctor/scripts/deployments.py
+++ b/.claude/skills/pipeline-doctor/scripts/deployments.py
@@ -1,0 +1,138 @@
+"""List Prefect 3 deployments with their armed/paused state.
+
+The databasis MCP exposes flow *runs* but nothing that enumerates
+deployments, so "which pipelines are currently disarmed?" — the question
+behind the team's deactivate-and-move-on workflow — has no MCP answer.
+This fills that gap and nothing else.
+
+    uv run python .claude/skills/pipeline-doctor/scripts/deployments.py
+    uv run python .claude/skills/pipeline-doctor/scripts/deployments.py --paused
+    uv run python .claude/skills/pipeline-doctor/scripts/deployments.py --json
+
+Reads the prefect3 token from ~/.basedosdados/credentials.json and never
+prints it. Same token the MCP server uses; see `_prefect_key` in
+~/Dropbox/BD/mcp/server.py for why it is a backend Token, not a Prefect key.
+
+`paused` is the authoritative arming signal. A paused deployment still
+reports `active=True` on its schedule — deployment-level paused wins — so
+read `paused`, never the schedule flag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+import requests
+
+API = "https://prefect3.basedosdados.org/api"
+PAGE = 200
+
+
+def _token() -> str:
+    path = pathlib.Path.home() / ".basedosdados" / "credentials.json"
+    if not path.exists():
+        sys.exit(f"missing {path}; cannot reach Prefect")
+    key = json.loads(path.read_text()).get("prod", {}).get("prefect3")
+    if not key:
+        sys.exit(
+            "no 'prefect3' key under 'prod' in ~/.basedosdados/credentials.json. "
+            "It is a backend Token scoped to the prefect3.basedosdados.org "
+            "domain; the older 'prefect' key is the retired Prefect 2 host."
+        )
+    return key
+
+
+def _post_paged(path: str, body: dict) -> list[dict]:
+    """POST a filter endpoint, walking Prefect's 200-row per-request cap."""
+    head = {"Authorization": f"Bearer {_token()}"}
+    out: list[dict] = []
+    while True:
+        r = requests.post(
+            f"{API}{path}",
+            json={**body, "limit": PAGE, "offset": len(out)},
+            headers=head,
+            timeout=60,
+        )
+        if not r.ok:
+            sys.exit(f"HTTP {r.status_code} from {path}: {r.text[:300]}")
+        page = r.json()
+        out.extend(page)
+        if len(page) < PAGE:
+            return out
+
+
+def collect() -> list[dict]:
+    """One row per deployment: flow, pool, arming state, cron."""
+    deployments = _post_paged("/deployments/filter", {})
+    flow_ids = list({d["flow_id"] for d in deployments if d.get("flow_id")})
+    names: dict[str, str] = {}
+    for i in range(0, len(flow_ids), PAGE):
+        chunk = flow_ids[i : i + PAGE]
+        r = requests.post(
+            f"{API}/flows/filter",
+            json={"flows": {"id": {"any_": chunk}}, "limit": len(chunk)},
+            headers={"Authorization": f"Bearer {_token()}"},
+            timeout=60,
+        )
+        r.raise_for_status()
+        names.update({f["id"]: f["name"] for f in r.json()})
+
+    rows = []
+    for d in deployments:
+        flow_id = str(d.get("flow_id") or "")
+        crons = [
+            s.get("schedule", {}).get("cron")
+            for s in (d.get("schedules") or [])
+            if s.get("schedule", {}).get("cron")
+        ]
+        rows.append(
+            {
+                "flow": names.get(flow_id, "?"),
+                "deployment": d.get("name"),
+                "pool": d.get("work_pool_name"),
+                "paused": bool(d.get("paused")),
+                "crons": crons,
+                "version": d.get("version"),
+                "updated": d.get("updated"),
+                "id": d.get("id"),
+            }
+        )
+    return sorted(rows, key=lambda r: (r["pool"] or "", r["flow"]))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pool", help="filter by work pool substring")
+    ap.add_argument(
+        "--paused", action="store_true", help="only disarmed deployments"
+    )
+    ap.add_argument("--json", action="store_true", help="machine-readable")
+    args = ap.parse_args()
+
+    rows = collect()
+    if args.pool:
+        rows = [r for r in rows if args.pool in (r["pool"] or "")]
+    if args.paused:
+        rows = [r for r in rows if r["paused"]]
+
+    if args.json:
+        print(json.dumps(rows, indent=2))
+        return 0
+
+    print(f"{len(rows)} deployment(s)\n")
+    print(f"{'STATE':<8} {'POOL':<20} {'DEPLOYMENT':<48} CRON")
+    for r in rows:
+        state = "PAUSED" if r["paused"] else "armed"
+        cron = "; ".join(r["crons"]) or "(none)"
+        print(
+            f"{state:<8} {(r['pool'] or '-'):<20} "
+            f"{(r['deployment'] or '-'):<48} {cron}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adiciona uma skill e dois agentes para triagem de pipelines Prefect quebradas, mais o arquivo de permissões do repo. Nenhuma mudança em código de pipeline, model ou framework.

## Por que

A válvula de capacidade do time é **desarmar** uma pipeline que falha repetidamente em vez de consertá-la. Isso torna a triagem ad-hoc pouco confiável, por dois motivos:

- **Uma deployment desarmada não emite runs**, então some de qualquer lista de falhas. Ausência de falha não é evidência de saúde.
- **O poll guard retorna cedo e o Prefect grava `COMPLETED`**, então uma pipeline morta é indistinguível de uma saudável pelo estado.

Na primeira execução real: **11 das 20 flows que falharam recentemente já estavam desarmadas**, incluindo `mx_sesnsp_incidencia_delictiva`, cujo fix foi mergeado sete minutos depois da última falha e que seguiu pausada por dias parecendo quebrada.

## O que entra

| Arquivo | O que faz |
|---|---|
| `.claude/skills/pipeline-doctor/SKILL.md` | Fluxo de 6 fases: survey → cluster por causa raiz → diagnóstico → triagem → fix/PR → relatório |
| `references/failure-taxonomy.md` | 9 classes, com as assinaturas reais observadas neste repo em ago/2026 e a rota de correção de cada uma |
| `references/fix-and-ship.md` | Labels, run de dev, e as armadilhas que fazem um fix *parecer* entregue |
| `scripts/deployments.py` | Lista deployments e seu estado de arme |
| `.claude/agents/pipeline-fixer.md` | Orquestrador — nunca edita código |
| `.claude/agents/pipeline-investigator.md` | Worker — um cluster, um branch, um PR |
| `.claude/settings.json` | Permissões do repo (novo arquivo) |

## Detalhes que valem revisão

**`scripts/deployments.py` preenche uma lacuna real.** Nenhuma tool do MCP enumera deployments, então "quais pipelines estão desarmadas agora?" não tinha resposta. Lê `paused` do Prefect, que é o sinal autoritativo — uma deployment pausada ainda reporta o schedule como `active`.

**Cluster por causa, não por flow.** Uma permissão de IAM faltando aparece como cinco pipelines quebradas. Despachar por flow viraria cinco PRs, cada um "consertando" o problema ao trocar o projeto de destino — o que muda onde o dado cai para silenciar um erro.

**Subagentes de fix rodam com `isolation: "worktree"`.** Eles editam arquivos; vários num mesmo checkout se sobrescrevem entre branches.

**Checagem de trabalho em andamento é obrigatória, e PR mergeado conta.** Um fix mergeado que é posterior à última falha do cluster significa que não há bug: a flow só não voltou a rodar. Isso é decisão de arme, não conserto. Na primeira aplicação a regra pegou uma duplicata de verdade (um fix que eu havia escrito já existia num PR aberto de outra pessoa) e o trabalho foi descartado.

**`.claude/settings.json` é novo e vale atenção: é versionado**, então vale para todo mundo que usa Claude Code neste repo, não só para quem abriu o PR. Libera `git push` e a família `gh pr create/edit/view`; **nega** `gh pr merge`, force-push, push para `main` e deleção de branch remoto. **Merge de PR continua sendo decisão humana.**

## Verificação

- `ruff check` / `ruff format` limpos; `pyrefly check` com 0 diagnostics em `deployments.py`.
- `deployments.py` exercitado contra a API real do Prefect 3: 242 deployments, 141 armadas e 61 pausadas no pool `basedosdados` (39 delas com cron).
- A skill foi rodada ponta a ponta uma vez e produziu o board de triagem descrito acima.

Nada aqui roda em worker nem toca dado de produção.
