### PR TITLE
fix(br_camara_dados_abertos): valor_retido é anulável na fonte

### DIFF
--- a/models/br_camara_dados_abertos/schema.yml
+++ b/models/br_camara_dados_abertos/schema.yml
@@ -1195,8 +1195,11 @@ models:
       - name: valor_documento
         description: Valor de face do documento comprobatório da despesa
       - name: valor_retido
-        description: Valor retido
-        tests: [not_null]
+        description: >
+          Valor retido. A fonte publica este campo vazio quando não há glosa
+          registrada, o que é distinto de uma glosa igual a zero — por isso a
+          coluna é anulável e não tem teste `not_null`. Em 2026-08-25 eram 1.375
+          de 307.943 linhas (0,45%) nos arquivos Ano-2025 e Ano-2026
       - name: valor_liquido
         description: Valor da despesa efetivamente debitado da Cota Parlamentar
         tests: [not_null]


### PR DESCRIPTION
O teste `not_null` em `despesa.valor_retido` passou a falhar em 2026-08-25 (run `01a0384c-fda8-7867-8b5d-af7a00d626e9`) com "Got 1375 results, configured to fail if != 0". O `dbt run` passou; só o teste falhou.

**Causa confirmada baixando a fonte, não inferida.** A Câmara publica `vlrGlosa` vazio quando não há glosa registrada: 930 linhas em `Ano-2025.csv` e 445 em `Ano-2026.csv` — exatamente as 1.375 do teste. `safe_cast('' as float64)` mapeia corretamente para NULL.

Vazio não é zero: preencher com 0 afirmaria um fato que a fonte não traz. O teste é que codificava uma premissa que a fonte deixou de satisfazer, então ele sai e o motivo fica na descrição da coluna. `valor_liquido` continua com `not_null` — verificado, zero vazios nos dois arquivos.

**Não exercitado.** `test-dev-model` filtra `models/**/*.sql` e esta mudança é só `schema.yml`, então o job não roda nada e mesmo assim reporta pass. O dbt local não tem credenciais (`/credentials-dev/dev.json`). A verificação real é a próxima execução agendada após o merge — e o deployment `br_camara_dados_abertos__despesa` está **pausado**, então precisa ser rearmado.