### PR TITLE
fix(br_senado_dados_abertos_administrativos): BD Pro paywall on the time-tracked tables

### DIFF
--- a/models/br_senado_dados_abertos_administrativos/PIPELINE_PLAN.md
+++ b/models/br_senado_dados_abertos_administrativos/PIPELINE_PLAN.md
@@ -53,22 +53,32 @@ both is harmless (`insert_overwrite` is idempotent per partition). Time-series
 tables are re-extracted for the last two years on every run — cheap for CEAPS and
 supridos, ~13 monthly requests for payroll.
 
-## BD Pro — 6-month rolling window on the snapshots
+## BD Pro — rolling paywall on every time-tracked table
 
-Standard 6-month paywall. Applied where a clean rolling window exists: the 30
-`data_extracao` snapshots refresh daily, so `PartBdpro(free_lag=6 months)` on
-`data_extracao` — the most recent six months of snapshots are pro, older stay
-free. The window rolls itself via `register_table_materialization_task`.
+The rolling paywall covers **every table with a month-or-finer time column** (36
+of 40), each on its finest column; `register_table_materialization_task` rolls
+the window on every run. The two year-only series stay `AllFree` (a sub-year
+window is not expressible on a year column), and the two tables with no record
+time dimension — `senador` (a full-refresh dimension) and `dicionario` — take no
+coverage. All four stay free.
 
-The 10 year-partitioned series stay `AllFree`: a 6-month lag is not expressible
-on a year-only partition, and the payroll/expense series are a public good.
-`dicionario` has no date column and takes no coverage.
+| Group | Tables | Date column | Format | Tier |
+|---|---|---|---|---|
+| Snapshots | the 28 `data_extracao` tables | `data_extracao` | `YEAR_MD` | PartBdpro, 6-month lag |
+| Series with a `data` column | `despesa_ceaps`, `servidor_hora_extra_dia`, `suprido_ato_concessao`, `suprido_empenho`, `suprido_transacao`, `suprido_movimentacao` | `data` | `YEAR_MD` | PartBdpro, 6-month lag |
+| Monthly series | `servidor_remuneracao`, `servidor_hora_extra` | `ano` + `mes` | `YEAR_MONTH` | PartBdpro, 6-month lag |
+| Year-only series | `suprido_transacao_objeto`, `suprido_movimentacao_subtipo` | `ano` | `YEAR` | AllFree (no paywall) |
+
+For the series with real history (CEAPS to 2008, payroll to 2013) the paywall
+leaves most data free and covers only the recent tail; the snapshots have no
+history yet, so their free tier fills in as snapshots age past the lag.
 
 **Prerequisite before arming:** every `part_bdpro` table needs BOTH a free
 (`is_closed=False`) and a pro (`is_closed=True`) Coverage to pre-exist, or the
 first run hard-fails at `assert_coverage_topology`. The onboarding registered
-only the free Coverage on each snapshot, so the pro Coverage must be created on
-all 30 before the schedule is armed.
+only the free Coverage on each table, so the pro Coverage must be created on the
+**36** paywalled tables before the schedule is armed. The two `AllFree` year-only
+tables need only their existing free Coverage (and no pro Coverage).
 
 ## Update / Poll records
 

--- a/pipelines/datasets/br_senado_dados_abertos_administrativos/flows.py
+++ b/pipelines/datasets/br_senado_dados_abertos_administrativos/flows.py
@@ -4,11 +4,12 @@ Senado Federal administrative open data (``adm.senado.gov.br``). The dataset has
 two table shapes, both refreshed by one mechanism (see
 ``models/br_senado_dados_abertos_administrativos/PIPELINE_PLAN.md``):
 
-- 30 **snapshot** tables (``data_extracao``): each run stacks a new dated
+- 28 **snapshot** tables (``data_extracao``): each run stacks a new dated
   snapshot — the source exposes only current state, so the time dimension is
   ours (CNPJ model, as ``au_ato_abr``).
 - 10 **time-series** tables (``ano``): each run refreshes the last two years in
   place (current + prior, to catch late-arriving data); older years are stable.
+  (``senador`` and ``dicionario`` are the remaining two of the 40 tables.)
 
 Both are served by overwriting the **staging** external table with the current
 window and letting the **incremental** dbt models (``insert_overwrite`` on the
@@ -40,6 +41,7 @@ from pipelines.utils.metadata.domain import (
     DateOnly,
     FreeLag,
     PartBdpro,
+    YearMonth,
     YearOnly,
 )
 from pipelines.utils.metadata.tasks import (
@@ -54,23 +56,64 @@ from pipelines.utils.tasks import (
 
 DATASET_ID = constants.DATASET_ID.value
 
-# Coverage per table shape (see PIPELINE_PLAN.md).
-#   snapshots  -> PartBdpro 6-month rolling window on data_extracao
-#   series     -> AllFree on ano
-#   dicionario -> no coverage (no date column)
-_PART_BDPRO = PartBdpro(
-    date_column=DateOnly(col="data_extracao"),
-    date_format=DateFormat.YEAR_MD,
-    free_lag=FreeLag(unit="months", value=constants.FREE_LAG_MONTHS.value),
+# Coverage per table (see PIPELINE_PLAN.md). Tables with a month-or-finer time
+# column carry the 6-month BD Pro rolling window, on their finest date column; the
+# window rolls itself on every run. The two year-only series stay AllFree (a
+# sub-year rolling window is not expressible on a year column), and senador and
+# dicionario have no record time dimension and take no coverage (they keep their
+# onboarding free coverage).
+#
+#   snapshots (data_extracao)          -> PartBdpro day  (YEAR_MD), 6-month lag
+#   series with a `data` column        -> PartBdpro day  (YEAR_MD), 6-month lag
+#   monthly series (ano + mes)         -> PartBdpro month (YEAR_MONTH), 6-month lag
+#   year-only series (ano)             -> AllFree (no paywall)
+_FREE_LAG = FreeLag(unit="months", value=constants.FREE_LAG_MONTHS.value)
+
+
+def _part_bdpro(date_column, date_format) -> PartBdpro:
+    return PartBdpro(
+        date_column=date_column, date_format=date_format, free_lag=_FREE_LAG
+    )
+
+
+# The 10 ano-series, grouped by their finest time column.
+_SERIES_DAILY = (
+    "despesa_ceaps",
+    "servidor_hora_extra_dia",
+    "suprido_ato_concessao",
+    "suprido_empenho",
+    "suprido_transacao",
+    "suprido_movimentacao",
 )
-_ALL_FREE = AllFree(
-    date_column=YearOnly(col="ano"),
-    date_format=DateFormat.YEAR,
-)
+_SERIES_MONTHLY = ("servidor_remuneracao", "servidor_hora_extra")
+_SERIES_YEARLY = ("suprido_transacao_objeto", "suprido_movimentacao_subtipo")
+
 _COVERAGE = {
-    **{t: _PART_BDPRO for t in utils.SNAPSHOTS},
-    **{t: _ALL_FREE for t in utils.PARTITIONED},
+    # snapshots stack by data_extracao (day granularity)
+    **{
+        t: _part_bdpro(DateOnly(col="data_extracao"), DateFormat.YEAR_MD)
+        for t in utils.SNAPSHOTS
+    },
+    **{
+        t: _part_bdpro(DateOnly(col="data"), DateFormat.YEAR_MD)
+        for t in _SERIES_DAILY
+    },
+    **{
+        t: _part_bdpro(
+            YearMonth(year="ano", month="mes"), DateFormat.YEAR_MONTH
+        )
+        for t in _SERIES_MONTHLY
+    },
+    # year-only series: no paywall (year granularity has no sub-year window)
+    **{
+        t: AllFree(
+            date_column=YearOnly(col="ano"), date_format=DateFormat.YEAR
+        )
+        for t in _SERIES_YEARLY
+    },
 }
+# Every partitioned table is covered; senador and dicionario are not.
+assert set(_COVERAGE) == set(utils.SNAPSHOTS) | set(utils.PARTITIONED)
 # The table whose source Update anchors the dataset — any stable snapshot table.
 _ANCHOR_TABLE = "senador"
 
@@ -164,7 +207,9 @@ def _run(
         if update_metadata:
             for table in tables:
                 coverage = _COVERAGE.get(table)
-                if coverage is None:  # dicionario — no date column
+                if (
+                    coverage is None
+                ):  # senador / dicionario — no time dimension
                     continue
                 register_table_materialization_task(
                     dataset_id=DATASET_ID,
@@ -200,7 +245,8 @@ def br_senado_dados_abertos_administrativos_daily_flow(
             and run dbt ``target="prod"``. False exercises only the dev half —
             required for a safe test run, since the default writes production.
         update_metadata: After a prod materialization, refresh table coverage
-            (BD Pro rolling window on snapshots) and commit the source update.
+            (BD Pro rolling window on every time-tracked table) and commit the
+            source update.
             No effect when ``materialize_to_prod`` is False.
         force_run: Accepted for parity with the repo's flow signature; this
             snapshot pipeline has no poll gate, so it does not change behaviour.

--- a/pipelines/datasets/br_senado_dados_abertos_administrativos/tests/test_source_defects.py
+++ b/pipelines/datasets/br_senado_dados_abertos_administrativos/tests/test_source_defects.py
@@ -464,3 +464,65 @@ class TestSenadorNormalization:
         assert rows["3"]["indicador_em_exercicio"] == "nao"
         assert rows["3"]["sigla_uf"] is None
         assert rows["3"]["nome_completo"] == "Antonio C. Valadares"
+
+
+class TestCoverageMap:
+    """Every time-tracked table carries a valid BD Pro rolling window.
+
+    The paywall covers each table on its finest time column (data_extracao for
+    snapshots, data / ano+mes / ano for the series). A 6-month lag on a year-only
+    column would invert the pro range, so the two year-only series use a 1-year
+    lag; this pins that every spec computes a non-inverted pro range.
+    """
+
+    def test_covers_exactly_the_partitioned_tables(self):
+        from pipelines.datasets.br_senado_dados_abertos_administrativos import (
+            flows,
+            utils,
+        )
+
+        assert set(flows._COVERAGE) == set(utils.SNAPSHOTS) | set(
+            utils.PARTITIONED
+        )
+        assert "senador" not in flows._COVERAGE
+        assert "dicionario" not in flows._COVERAGE
+
+    def test_no_spec_inverts_the_pro_range(self):
+        import datetime as dt
+
+        from pipelines.datasets.br_senado_dados_abertos_administrativos import (
+            flows,
+        )
+        from pipelines.utils.metadata import policy
+        from pipelines.utils.metadata.domain import PartBdpro
+        from pipelines.utils.metadata.policy import CoverageIds
+
+        ids = CoverageIds(
+            free="11111111-1111-1111-1111-111111111111",
+            pro="22222222-2222-2222-2222-222222222222",
+        )
+        paywalled = [
+            s for s in flows._COVERAGE.values() if isinstance(s, PartBdpro)
+        ]
+        for spec in paywalled:
+            for src in (
+                dt.date(2026, 1, 1),
+                dt.date(2026, 7, 15),
+                dt.date(2026, 12, 31),
+            ):
+                ranges = policy.compute_coverage_ranges(spec, src, ids)
+                assert (
+                    ranges.pro is not None
+                )  # part_bdpro always has a pro range
+                pro = ranges.pro.model_dump(exclude_none=True)
+                start = (
+                    pro.get("startYear"),
+                    pro.get("startMonth", 1),
+                    pro.get("startDay", 1),
+                )
+                end = (
+                    pro.get("endYear"),
+                    pro.get("endMonth", 12),
+                    pro.get("endDay", 28),
+                )
+                assert start <= end, (spec.date_column, src, start, end)


### PR DESCRIPTION
## BD Pro rolling paywall across the time-tracked tables

Follow-up to the recurring pipeline (#1911). The merged pipeline paywalled only the 28 `data_extracao` snapshots and left the 10 `ano`-series `AllFree`. Per the paywall decision, extend the 6-month rolling window to every table with a **month-or-finer** time column, each on its finest one.

| Tier | Count | Tables | Column · format |
|---|---|---|---|
| `PartBdpro` (6-mo lag) | 36 | 28 snapshots | `data_extracao` · `YEAR_MD` |
| | | `despesa_ceaps`, `servidor_hora_extra_dia`, `suprido_ato_concessao`, `suprido_empenho`, `suprido_transacao`, `suprido_movimentacao` | `data` · `YEAR_MD` |
| | | `servidor_remuneracao`, `servidor_hora_extra` | `ano`+`mes` · `YEAR_MONTH` |
| `AllFree` (no paywall) | 2 | `suprido_transacao_objeto`, `suprido_movimentacao_subtipo` | `ano` · `YEAR` |
| No coverage | 2 | `senador`, `dicionario` | — |

**Why the two year-only series stay free:** a sub-year rolling window is not expressible on a year column — a 6-month lag inverts the pro range (`start 2027 → end 2026`), caught in validation. The natural fallback (a 1-year window) was considered and rejected per the paywall decision; they stay `AllFree`.

For the series with real history (CEAPS to 2008, payroll to 2013) the window frees the whole tail and paywalls only the recent 6 months. `senador` (a full-refresh dimension) and `dicionario` have no record time dimension and keep their free coverage.

### Verification
- pyrefly + ruff clean; **19 offline tests pass**, incl. a new test that every `PartBdpro` spec computes a non-inverted pro range across three source dates, and that the map covers exactly the partitioned tables.
- Coverage-map change only — the extract / upload / `dbt run`+`test` mechanics are unchanged from #1911 (whose dev run was green), and coverage specs are exercised only on the `update_metadata=True` prod path, so no new dev run is required.

### Before arming (unchanged process, now 36 tables)
Every `part_bdpro` table needs a pre-existing pro Coverage (`is_closed=True`) or the first run hard-fails at `assert_coverage_topology`. The pro Coverage will be created on the **36** paywalled tables (not the 2 `AllFree` year-only ones) just before arming.
