### PR TITLE
fix(au_aec_elections): complete observation levels, column order and backend resilience

### DIFF
--- a/models/au_aec_elections/code/bootstrap_dataset.py
+++ b/models/au_aec_elections/code/bootstrap_dataset.py
@@ -1,0 +1,252 @@
+"""Create the au_aec_elections organization, dataset and raw data sources.
+
+Run once per backend before ``register_metadata.py``, which registers the tables into
+an already-existing dataset.
+
+    uv run --with fastmcp python models/au_aec_elections/code/bootstrap_dataset.py --env prod
+
+**Slugs differ between backends and must be resolved per environment.** Staging names
+Australian agencies `au_abs` / `au_ato` / `au_rba` and tags in Portuguese; prod drops
+the country prefix (`abs`, `ato`, `rba`) and uses English tags. The organization
+records are genuinely distinct — different UUIDs, not one record with two slugs — so
+nothing here may be copied across by id.
+
+The dataset is created as `under_review`, which hides it from the production
+frontend until it is deliberately published.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+MCP_DIR = Path.home() / "Dropbox" / "BD" / "mcp"
+sys.path.insert(0, str(MCP_DIR))
+
+import server  # noqa: E402  — the databasis MCP module
+
+# Organization slug per backend, following each one's own convention.
+ORG_SLUG = {"prod": "aec", "staging": "au_aec", "dev": "au_aec"}
+
+# Tag slug per backend. Same subject matter, different vocabulary.
+TAG_SLUGS = {
+    "prod": [
+        "elections",
+        "vote",
+        "candidacy",
+        "political_party",
+        "donation",
+        "campaign-finance",
+        "electoral-system",
+        "transparency",
+        "parliament",
+        "referendum",
+    ],
+    "staging": [
+        "eleicao",
+        "voto",
+        "candidatura",
+        "partido",
+        "doacao",
+        "campaign-finance",
+        "sistema_eleitoral",
+        "transparencia",
+        "parlamento",
+        "referendum",
+    ],
+}
+
+# Tags that may not exist yet on a given backend. Slug is English and kebab-case;
+# names are lowercase in all three languages.
+CREATABLE_TAGS = {
+    "referendum": ("referendo", "referendum", "referendo"),
+}
+
+DATASET = {
+    "slug": "elections",
+    "name_pt": "Eleições Federais e Transparência do Financiamento Político",
+    "name_en": "Federal Elections and Political Finance Disclosures",
+    "name_es": "Elecciones Federales y Transparencia del Financiamiento Político",
+    "description_pt": (
+        "Resultados das eleições federais australianas apurados pela Comissão "
+        "Eleitoral Australiana (AEC), para a Câmara dos Representantes e o Senado, no "
+        "nível da divisão eleitoral e do local de votação individual. Cobre as oito "
+        "eleições gerais de 2004 a 2025, 24 eleições suplementares, a eleição de "
+        "Senado da Austrália Ocidental de 2014 e o referendo de 2023. Inclui também "
+        "as declarações de financiamento político do Transparency Register da AEC — "
+        "doações, recebimentos, despesas eleitorais e totais das declarações anuais — "
+        "dos exercícios financeiros de 1998-99 a 2024-25."
+    ),
+    "description_en": (
+        "Australian federal election results counted by the Australian Electoral "
+        "Commission (AEC), for the House of Representatives and the Senate, at both "
+        "electoral division and individual polling place level. Covers the eight "
+        "general elections from 2004 to 2025, 24 by-elections, the 2014 Western "
+        "Australia Senate election and the 2023 referendum. Also includes the "
+        "political finance disclosures from the AEC Transparency Register — "
+        "donations, receipts, electoral expenditure and annual return totals — for "
+        "financial years 1998-99 to 2024-25."
+    ),
+    "description_es": (
+        "Resultados de las elecciones federales australianas escrutados por la "
+        "Comisión Electoral Australiana (AEC), para la Cámara de Representantes y el "
+        "Senado, a nivel de división electoral y de local de votación individual. "
+        "Cubre las ocho elecciones generales de 2004 a 2025, 24 elecciones parciales, "
+        "la elección de Senado de Australia Occidental de 2014 y el referendo de "
+        "2023. Incluye además las declaraciones de financiamiento político del "
+        "Transparency Register de la AEC — donaciones, ingresos, gastos electorales y "
+        "totales de las declaraciones anuales — de los ejercicios financieros 1998-99 "
+        "a 2024-25."
+    ),
+}
+
+ORGANIZATION = {
+    "name_pt": "Comissão Eleitoral Australiana (AEC)",
+    "name_en": "Australian Electoral Commission (AEC)",
+    "name_es": "Comisión Electoral Australiana (AEC)",
+    "description_pt": (
+        "Agência federal independente responsável por conduzir as eleições federais e "
+        "os referendos da Austrália, manter o cadastro eleitoral e administrar o "
+        "regime de transparência do financiamento político."
+    ),
+    "description_en": (
+        "Independent federal agency responsible for conducting Australia's federal "
+        "elections and referendums, maintaining the electoral roll, and administering "
+        "the political finance disclosure regime."
+    ),
+    "description_es": (
+        "Agencia federal independiente responsable de conducir las elecciones "
+        "federales y los referendos de Australia, mantener el padrón electoral y "
+        "administrar el régimen de transparencia del financiamiento político."
+    ),
+    "website": "https://www.aec.gov.au",
+}
+
+RAW_SOURCES = [
+    {
+        "name_pt": "Arquivo de Resultados Eleitorais da AEC (Tally Room)",
+        "name_en": "AEC Tally Room election results archive",
+        "name_es": "Archivo de Resultados Electorales de la AEC (Tally Room)",
+        "description_pt": (
+            "Arquivo público da AEC com os resultados finais de cada evento eleitoral "
+            "federal, publicados em CSV por evento, nos níveis nacional, estadual, de "
+            "divisão e de local de votação."
+        ),
+        "description_en": (
+            "Public AEC archive of the final results of every federal electoral "
+            "event, published as per-event CSV at national, state, division and "
+            "polling place level."
+        ),
+        "description_es": (
+            "Archivo público de la AEC con los resultados finales de cada evento "
+            "electoral federal, publicados en CSV por evento, a nivel nacional, "
+            "estatal, de división y de local de votación."
+        ),
+        "url": "https://results.aec.gov.au/",
+    },
+    {
+        "name_pt": "Transparency Register da AEC",
+        "name_en": "AEC Transparency Register",
+        "name_es": "Transparency Register de la AEC",
+        "description_pt": (
+            "Registro público da AEC com as declarações de financiamento político: "
+            "declarações anuais de partidos, entidades associadas, terceiros e "
+            "doadores, e declarações referentes a eleições e referendos. Oferece "
+            "exportação em massa de todas as declarações em CSV."
+        ),
+        "description_en": (
+            "Public AEC register of political finance disclosures: annual returns "
+            "from parties, associated entities, third parties and donors, and returns "
+            "relating to elections and referendums. Offers a bulk export of all "
+            "disclosures as CSV."
+        ),
+        "description_es": (
+            "Registro público de la AEC con las declaraciones de financiamiento "
+            "político: declaraciones anuales de partidos, entidades asociadas, "
+            "terceros y donantes, y declaraciones referidas a elecciones y "
+            "referendos. Ofrece exportación masiva de todas las declaraciones en CSV."
+        ),
+        "url": "https://transparency.aec.gov.au/",
+    },
+]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--env", default="staging")
+    args = ap.parse_args()
+    env = args.env
+
+    ids = server.discover_ids(
+        env=env,
+        keys=["status", "theme", "license", "availability", "language", "tag"],
+    )
+    under_review = ids["status"]["under_review"]
+    published = ids["status"]["published"]
+
+    org_slug = ORG_SLUG[env]
+    org = server.create_update_organization(
+        slug=org_slug,
+        area_id=server.lookup_id(env=env, slug="au", category="area")["id"],
+        env=env,
+        **ORGANIZATION,
+    )
+    print(f"organization {org_slug}: {org['id']}")
+
+    tag_ids = []
+    for slug in TAG_SLUGS[env]:
+        tag_id = ids["tag"].get(slug)
+        if not tag_id:
+            if slug not in CREATABLE_TAGS:
+                raise SystemExit(
+                    f"tag {slug!r} missing on {env} and not creatable"
+                )
+            pt, en, es = CREATABLE_TAGS[slug]
+            tag_id = server.create_update_tag(
+                slug=slug, name_pt=pt, name_en=en, name_es=es, env=env
+            )["id"]
+            print(f"  created tag {slug}: {tag_id}")
+        tag_ids.append(tag_id)
+    print(f"tags: {len(tag_ids)}")
+
+    existing = server.get_dataset(DATASET["slug"], env=env)
+    dataset = server.create_update_dataset(
+        id=existing["id"] if existing.get("found") else None,
+        organization_ids=[org["id"]],
+        theme_ids=[ids["theme"]["politics"], ids["theme"]["government"]],
+        tag_ids=tag_ids,
+        # under_review keeps the dataset off the production frontend until the prod
+        # tables are verified and it is deliberately published.
+        status_id=under_review,
+        env=env,
+        **DATASET,
+    )
+    print(f"dataset {dataset['slug']}: {dataset['id']} (under_review)")
+
+    existing_sources = {
+        s["url"]: s["id"]
+        for s in server.get_raw_data_sources(DATASET["slug"], env=env)
+    }
+    for src in RAW_SOURCES:
+        res = server.create_update_raw_data_source(
+            id=existing_sources.get(src["url"]),
+            dataset_id=dataset["id"],
+            license_id=ids["license"]["cc_by"],
+            availability_id=ids["availability"]["online"],
+            language_ids=[ids["language"]["en"]],
+            status_id=published,
+            has_structured_data=True,
+            is_free=True,
+            contains_api=False,
+            requires_registration=False,
+            env=env,
+            **src,
+        )
+        print(f"raw source {src['url']}: {res['id']}")
+
+    print(f"\ndataset-id {dataset['id']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/au_aec_elections/code/register_metadata.py
+++ b/models/au_aec_elections/code/register_metadata.py
@@ -40,95 +40,151 @@ DATASET_SLUG = (
     "elections"  # backend slug; the organization carries the au_aec prefix
 )
 
-AREA_AU = "8ad56723-923d-4e85-a725-9c84aca7fb7c"
-STATUS_PUBLISHED = "e16221de-ac30-4926-83d3-de219998dab3"
+AREA_AU_SLUG = "au"
+ENTITY_SLUGS = [
+    "year",
+    "state",
+    "district",
+    "electoral_booth",
+    "election",
+    "person",
+    "party",
+]
 
-ENTITY = {
-    "year": "e1bf146e-b6bb-4b65-bee7-c800876e80a5",
-    "election": "1cf89a2d-6fd0-44af-a115-dc10dc5f0cb5",
-    "district": "031c0045-f144-4aea-b294-dcf91d0ac9c8",
-    "electoral_booth": "74ad2b0b-bba1-43b1-ac10-8cea360f6515",
-    "party": "fcee5475-ec7c-46c9-8000-b223e892932c",
-    "person": "b4e76213-888b-40ea-b877-d82ce76d71a2",
-    "state": "839765a7-9c7a-44bd-bb88-357cedba03f6",
-}
+# Reference ids happen to be identical across staging and prod today, but resolving
+# them by slug per environment means a divergence surfaces as a lookup failure here
+# rather than as metadata silently attached to the wrong entity.
+AREA_AU = ""
+STATUS_PUBLISHED = ""
+ENTITY: dict[str, str] = {}
+
+
+def resolve_reference_ids(env: str) -> None:
+    global AREA_AU, STATUS_PUBLISHED
+    ids = server.discover_ids(env=env, keys=["entity", "status"])
+    STATUS_PUBLISHED = ids["status"]["published"]
+    for slug in ENTITY_SLUGS:
+        entity_id = ids["entity"].get(slug)
+        if not entity_id:
+            raise SystemExit(f"entity {slug!r} not found on {env}")
+        ENTITY[slug] = entity_id
+    AREA_AU = server.lookup_id(env=env, slug=AREA_AU_SLUG, category="area")[
+        "id"
+    ]
+
 
 # table -> [(entity key, the column that identifies that level)]
-# Every level is linked to its identifying column: an unlinked level renders as
+#
+# List every entity dimension a row is broken down by, including each nested
+# geographic level — the house convention, cf. au_ato_taxation_statistics
+# (`individuals_postcode` = year, state, zip_code, item) and br_tse_eleicoes
+# (`detalhes_votacao_municipio_zona` = year, municipality, electoral_zone, ...).
+# Each level is linked to its identifying column: an unlinked level renders as
 # "Não informado" on the site.
+#
+# Party is deliberately a level only on `party`. Everywhere else the row is a
+# candidate or a place and the party is an attribute of it, not a dimension the
+# table is broken down by.
 OBSERVATION_LEVELS: dict[str, list[tuple[str, str]]] = {
-    "election": [("year", "year"), ("election", "election_id")],
+    "election": [
+        ("year", "year"),
+        ("state", "state_abbreviation"),
+        ("election", "election_id"),
+    ],
     "polling_place": [
         ("year", "year"),
-        ("election", "election_id"),
+        ("state", "state_abbreviation"),
+        ("district", "division_id"),
         ("electoral_booth", "polling_place_id"),
+        ("election", "election_id"),
     ],
     "party": [
         ("year", "year"),
+        ("state", "state_abbreviation"),
         ("election", "election_id"),
         ("party", "party_abbreviation"),
-        ("state", "state_abbreviation"),
     ],
     "house_candidate": [
         ("year", "year"),
+        ("state", "state_abbreviation"),
+        ("district", "division_id"),
         ("election", "election_id"),
         ("person", "candidate_id"),
     ],
     "house_first_preference_division": [
         ("year", "year"),
-        ("election", "election_id"),
+        ("state", "state_abbreviation"),
         ("district", "division_id"),
+        ("election", "election_id"),
         ("person", "candidate_id"),
     ],
     "house_first_preference_polling_place": [
         ("year", "year"),
-        ("election", "election_id"),
+        ("state", "state_abbreviation"),
+        ("district", "division_id"),
         ("electoral_booth", "polling_place_id"),
+        ("election", "election_id"),
         ("person", "candidate_id"),
     ],
     "house_two_candidate_preferred_polling_place": [
         ("year", "year"),
-        ("election", "election_id"),
+        ("state", "state_abbreviation"),
+        ("district", "division_id"),
         ("electoral_booth", "polling_place_id"),
+        ("election", "election_id"),
         ("person", "candidate_id"),
     ],
     "house_two_party_preferred_division": [
         ("year", "year"),
-        ("election", "election_id"),
+        ("state", "state_abbreviation"),
         ("district", "division_id"),
+        ("election", "election_id"),
     ],
     "house_two_party_preferred_polling_place": [
         ("year", "year"),
-        ("election", "election_id"),
+        ("state", "state_abbreviation"),
+        ("district", "division_id"),
         ("electoral_booth", "polling_place_id"),
+        ("election", "election_id"),
     ],
+    # The Senate is elected state-wide, so the state is the grain and there is no
+    # division level.
     "senate_candidate": [
         ("year", "year"),
+        ("state", "state_abbreviation"),
         ("election", "election_id"),
         ("person", "candidate_id"),
     ],
     "senate_first_preference_division": [
         ("year", "year"),
-        ("election", "election_id"),
+        ("state", "state_abbreviation"),
         ("district", "division_id"),
+        ("election", "election_id"),
         ("person", "candidate_id"),
     ],
     "division_summary": [
         ("year", "year"),
-        ("election", "election_id"),
+        ("state", "state_abbreviation"),
         ("district", "division_id"),
+        ("election", "election_id"),
     ],
     "referendum_polling_place": [
         ("year", "year"),
-        ("election", "election_id"),
+        ("state", "state_abbreviation"),
+        ("district", "division_id"),
         ("electoral_booth", "polling_place_id"),
+        ("election", "election_id"),
     ],
-    # The disclosure tables carry no event identifier, only the AEC's event label,
-    # so only the year level can be linked to a column.
+    # The disclosure tables carry no event identifier, only the AEC's event label.
+    # Only the election returns name an electorate.
     "disclosure_donation": [("year", "year")],
     "disclosure_receipt": [("year", "year")],
     "disclosure_return_annual": [("year", "year")],
-    "disclosure_election_return": [("year", "year")],
+    "disclosure_election_return": [
+        ("year", "year"),
+        ("state", "electorate_state"),
+        ("district", "electorate_name"),
+    ],
     "dicionario": [],
 }
 
@@ -265,6 +321,7 @@ def main() -> None:
     args = ap.parse_args()
 
     env = args.env
+    resolve_reference_ids(env)
     account_id = server.get_authenticated_account(env=env)["id"]
     today = date.today().isoformat() + "T00:00:00"
     targets = args.only or constants.TABLES.value
@@ -312,6 +369,7 @@ def main() -> None:
         for ol in node.get("observation_levels", []):
             by_entity.setdefault(ol["entity_id"], []).append(ol["id"])
         keep: set[str] = set()
+        ordered_ols: list[str] = []
         for entity_key, column_name in wanted:
             entity_id = ENTITY[entity_key]
             pool = by_entity.get(entity_id, [])
@@ -320,6 +378,7 @@ def main() -> None:
                 table_id=table_id, entity_id=entity_id, id=ol_id, env=env
             )["id"]
             keep.add(ol_id)
+            ordered_ols.append(ol_id)
             server.update_column(
                 column_id=column_ids[column_name],
                 column_name=column_name,
@@ -334,7 +393,16 @@ def main() -> None:
             for stale in ids:
                 if stale not in keep:
                     delete("DeleteObservationLevel", stale, env)
-        print(f"  observation levels: {len(wanted)}")
+        if ordered_ols:
+            # Creation order is not display order; set it explicitly so the levels
+            # read year -> state -> division -> polling place -> event -> person.
+            server.reorder_observation_levels(
+                table_id=table_id, ol_ids=ordered_ols, env=env
+            )
+        print(
+            f"  observation levels: "
+            f"{', '.join(e for e, _ in wanted) if wanted else '(none)'}"
+        )
 
         if table != "dicionario" and not wanted:
             server.update_column(

--- a/models/au_aec_elections/code/register_metadata.py
+++ b/models/au_aec_elections/code/register_metadata.py
@@ -21,13 +21,60 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from datetime import date
 from pathlib import Path
+
+import requests
 
 MCP_DIR = Path.home() / "Dropbox" / "BD" / "mcp"
 sys.path.insert(0, str(MCP_DIR))
 
 import server  # noqa: E402  — the databasis MCP module
+
+# The prod backend routinely takes 60-95s to answer a single query, and the MCP
+# module hardcodes a 60s timeout with no retry — so a full registration run reliably
+# dies partway through with a ReadTimeout. Give it room and retry with backoff.
+#
+# A retry after a timeout can re-apply a mutation the server already accepted. That is
+# safe here: tables are matched by slug, columns by name, and any duplicated
+# observation level, cloud table or coverage is removed by `drop_duplicates` on the
+# next pass over that table.
+BACKEND_TIMEOUT = 300
+BACKEND_TRIES = 5
+
+_original_post = requests.post
+
+
+def _patient_post(*args: object, **kwargs: object) -> requests.Response:
+    kwargs["timeout"] = BACKEND_TIMEOUT
+    for attempt in range(BACKEND_TRIES):
+        reason = ""
+        try:
+            response = _original_post(*args, **kwargs)
+            # A 502/504 from the gateway is the same overload as a client-side
+            # timeout, just reported from the other end. The MCP module turns any
+            # non-2xx into an exception, so it has to be caught here instead.
+            if response.status_code < 500:
+                return response
+            reason = f"HTTP {response.status_code}"
+        except (
+            requests.exceptions.ReadTimeout,
+            requests.exceptions.ConnectionError,
+        ):
+            if attempt == BACKEND_TRIES - 1:
+                raise
+            reason = "timeout"
+        if attempt == BACKEND_TRIES - 1:
+            return response
+        delay = 15 * 2**attempt
+        print(f"  [backend {reason} — retrying in {delay}s]", flush=True)
+        time.sleep(delay)
+    raise RuntimeError("unreachable")
+
+
+requests.post = _patient_post
+server.requests.post = _patient_post
 
 from pipelines.datasets.au_aec_elections import schema  # noqa: E402
 from pipelines.datasets.au_aec_elections.constants import (  # noqa: E402


### PR DESCRIPTION
Follow-up to #1916, from promoting `au_aec_elections` to production. Three fixes plus
a new bootstrap script. The dataset is now **published in prod** — 18 tables,
1,270,495 rows, verified.

## 1. Observation levels were incomplete

The levels registered at onboarding named only the finest grain and skipped the
geographic levels a row also sits in. `state` was set on `party` alone, and
`district` was missing from every polling-place table **even though `division_id` is
part of their uniqueness key**.

The house convention is to list every dimension a row is broken down by, including
each nested geographic level — cf. `au_ato_taxation_statistics.individuals_postcode`
(year, state, zip_code, item) and `br_tse_eleicoes.detalhes_votacao_municipio_zona`
(municipality *and* electoral_zone).

**40 levels → 67.** Concretely: `state` added to the 12 tables carrying
`state_abbreviation`; `district` added to the 5 polling-place tables and to
`house_candidate`; `state` + `district` added to `disclosure_election_return`, which
names an electorate.

Party stays a level only on `party` — elsewhere the row is a candidate or a place and
the party is an attribute of it, not a dimension of the breakdown. Happy to revisit
that call.

Display order is now set explicitly too, since creation order is not display order.

## 2. Column display order was alphabetical on the site

`bulk_upsert_columns` does not write the display order, so the backend fell back to
alphabetical and `state_abbreviation` appeared near the end of every table — directly
contradicting the architecture. `reorder_columns` now runs on every pass instead of
being a manual step.

BigQuery was never affected: the dbt models select in architecture order, so the
tables themselves were always right. Only the metadata the site renders was wrong.

**Worth knowing for anyone verifying this:** `get_dataset` returns a table's columns
sorted alphabetically regardless of stored order, so it cannot be used to check the
fix. Read the `order` field via `allColumn`. That is what made this easy to miss.

## 3. Registration could not survive the prod backend

Registering 18 tables against prod failed three times, each for a different reason:

- The MCP module hardcodes a **60s timeout with no retry**, while the prod backend
  answers a single query in **54–95s** under load. Raised to 300s with backoff.
- A gateway **504 arrives as a successful HTTP response carrying a 5xx status**, not
  as a `ReadTimeout`, so the first version of the retry did not catch it. Any 5xx is
  now retryable.
- The load was largely **self-inflicted**: table-approve materialises through the same
  backend, so running registration alongside it caused the timeouts. Sequencing the
  two is the real fix; the retries are the safety net.

Retrying a mutation the server already accepted is safe here because the script is
idempotent — tables match by slug, columns by name, and any duplicated observation
level, cloud table or coverage is removed by `drop_duplicates` on the next pass.

The prod run then completed clean, absorbing 4 retries with no errors.

## 4. New: `bootstrap_dataset.py`

Creates the organization, dataset and raw data sources for a backend.

**prod and staging are not mirrors**, which is easy to assume and wrong. Organizations
are distinct rows with different UUIDs *and* different slugs: staging uses
`au_abs`/`au_ato`/`au_rba`, prod uses `abs`/`ato`/`rba`. So the prod organization is
**`aec`**, not `au_aec`. Tags differ too — prod is English (`elections`, `vote`,
`political_party`, …) where staging is Portuguese — and `referendum` did not exist on
prod, so it is created. Entity, area, status, theme and license UUIDs *are* shared.

The script encodes this per backend rather than leaving it as tribal knowledge.
`register_metadata.py` now also resolves area/status/entity ids by slug per
environment instead of hardcoding staging UUIDs, so a future divergence surfaces as a
lookup failure rather than as metadata attached to the wrong entity.

## Verification

Prod, measured rather than assumed (ADC billed through the `basedosdados` project):

- 18/18 tables, **1,270,495 rows**, every count matching dev exactly
- 255 columns, 67 observation levels, 0 misordered tables
- Content checks against known results: 2013 Coalition 53.49% two-party-preferred,
  2022 ALP 52.13%, 2025 ALP 55.22%, 2023 referendum 40.09% Yes, 150 members elected
  in 2025, 150/151/150 divisions

## Known gap, not addressed here

Column `observations` are stored PT-only across the backend — `bulk_upsert_columns`
writes the bare `observations` field, though the backend supports
`observationsPt/En/Es`. This affects **3,022 columns across ~50 datasets**, not just
this one, and is being handled separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting up Australian electoral datasets, elections, referendum tags, and raw data sources across deployment environments.
  * Added richer metadata for state, geographic, and election-return observation levels.

* **Bug Fixes**
  * Improved reliability when registering metadata by adding request timeouts, retries, and environment-specific reference resolution.
  * Existing records can now be updated safely while preserving review and licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->