### PR TITLE
fix(fr_meteofrance): two download bugs that killed both climatologie flows on prod

### DIFF
--- a/pipelines/datasets/fr_meteofrance/clim_utils.py
+++ b/pipelines/datasets/fr_meteofrance/clim_utils.py
@@ -71,11 +71,29 @@ def fetch(args, attempts: int = 5) -> tuple[str, bool]:
                 urllib.request.urlopen(url, timeout=900) as r,
                 tmp.open("wb") as fh,
             ):
+                expected = r.headers.get("Content-Length")
+                written = 0
                 while chunk := r.read(1 << 20):
                     fh.write(chunk)
+                    written += len(chunk)
+            # A clean mid-transfer close makes read() return b'' and the loop
+            # exit NORMALLY -- no exception, so the retry below never fires and
+            # a short file gets renamed over the real one. That is how a
+            # truncated .csv.gz reached build_poste and blew up as
+            # "EOFError: Compressed file ended before the end-of-stream marker".
+            # Comparing against Content-Length turns a silent truncation back
+            # into a retryable error.
+            if expected is not None and written != int(expected):
+                raise OSError(
+                    f"{dest.name}: truncated, got {written:,} of "
+                    f"{int(expected):,} bytes"
+                )
             tmp.rename(dest)
             return dest.name, True
         except Exception as exc:  # retry every transport error
+            # Never leave a partial file behind: the resume check above treats
+            # any non-empty file as complete.
+            tmp.unlink(missing_ok=True)
             if attempt == attempts:
                 raise RuntimeError(
                     f"{dest.name}: giving up after {attempts} tries"

--- a/pipelines/datasets/fr_meteofrance/utils.py
+++ b/pipelines/datasets/fr_meteofrance/utils.py
@@ -85,11 +85,28 @@ def _synop_schema():
 
 # ── download ─────────────────────────────────────────────────────────────────
 def _get(url: str, dest: Path, timeout: int = 600) -> Path:
+    """Download `url` to `dest`, writing the response body byte for byte.
+
+    `decode_content=False` is load-bearing, not a micro-optimisation. Three of
+    the 1,576 climatological sheets -- FICHECLIM_10372001, _13108004 and
+    _81192005 -- are stored on the OVH bucket with `Content-Encoding: gzip`
+    object metadata while their bodies are plain text. `requests.iter_content`
+    honours that header and dies decompressing text:
+
+        ContentDecodingError: Received response with content-encoding: gzip,
+        but failed to decode it. Error -3 ... incorrect header check
+
+    Setting `Accept-Encoding: identity` does NOT help -- the header comes from
+    S3 object metadata and is sent regardless. Reading the raw stream ignores
+    it. That is also correct for the real `.csv.gz` archives, which the bucket
+    serves with no `Content-Encoding` at all, so their gzip bytes must reach
+    disk untouched.
+    """
     dest.parent.mkdir(parents=True, exist_ok=True)
     with requests.get(url, stream=True, timeout=timeout) as r:
         r.raise_for_status()
         with dest.open("wb") as fh:
-            for chunk in r.iter_content(chunk_size=1 << 20):
+            for chunk in r.raw.stream(1 << 20, decode_content=False):
                 fh.write(chunk)
     return dest
 


### PR DESCRIPTION
Two independent download bugs, both found only by running the flows against
prod. Each one killed a flow on its first ever prod run.

## 1. `Content-Encoding: gzip` on plain-text sheets (`utils.py`)

`fr_meteofrance_climatologie` died in `download_fiches`, three retries, same
place:

```
ContentDecodingError: Received response with content-encoding: gzip,
but failed to decode it. Error -3 ... incorrect header check
```

Three of the 1,576 climatological sheets — `FICHECLIM_10372001`, `_13108004`
and `_81192005` — are stored on the OVH bucket with `Content-Encoding: gzip`
object metadata while their bodies are plain text. `requests.iter_content`
honours the header and dies decompressing text. I probed all 1,576: it is
exactly those three, hence a deterministic rather than flaky failure.

`Accept-Encoding: identity` does **not** help — verified; the header is S3
object metadata and is sent regardless. `_get` now reads `r.raw` with
`decode_content=False`, which also keeps the real `.csv.gz` archives intact
(the bucket serves those with no `Content-Encoding`).

## 2. Truncated downloads renamed over good files (`clim_utils.py`)

`fr_meteofrance_climatologie_base` died in `build_poste`:

```
EOFError: Compressed file ended before the end-of-stream marker was reached
```

A `.csv.gz` arrived short and the download **reported success**. A clean
mid-transfer close makes `urlopen`'s `read()` return `b''`, so the write loop
exits normally — no exception, the retry loop never fires, and the truncated
`.part` is renamed over the real name. The resume check (`exists and size > 0`)
then treats it as complete, making the corruption sticky.

This is the more dangerous of the two: it is silent corruption. Had the
truncation landed in a file the cleaner does not parse strictly, it would have
produced a quietly incomplete table rather than a crash.

`fetch()` now compares bytes written against `Content-Length`, raises when
short so the existing retry engages, and unlinks the `.part` on every failed
attempt.

## Verification

| check | result |
|---|---|
| the 3 mislabelled sheets | parse as `FICHE CLIMATOLOGIQUE` |
| a normal sheet (`07005001`) | unchanged, 5,149 bytes |
| `liste_fiches_clim.geojson` | 1,576 features |
| `synop_2026.csv.gz` (22.4 MB) | decompresses, 65-column header |
| server advertising 100 kB, sending 100 B | detected, retried to exhaustion, no final **and** no `.part` left |
| `MENSQ_75_avant-1949.csv.gz` | 332,471 bytes, matches the API filesize, decompresses to 162 columns |

`ruff` clean, `pyrefly` 0 diagnostics.

## Note for the reviewer

This PR touches `utils.py` and `clim_utils.py`, not `flows.py`, so
`deploy_flows.py` finds no flows and deploys nothing — the staging deploy job
will report `pass` having deployed zero flows. It therefore **cannot** be
validated by a dev run on this branch. It needs merging, after which re-running
`fr_meteofrance_climatologie` and `fr_meteofrance_climatologie_base` on the
prod pool exercises both fixes.

Neither flow has yet completed against prod, so `quotidienne` and `mensuelle`
have never had their Row Access Policies applied. The schedules should stay
paused until they do. `fr_meteofrance_synop` is unaffected and already
validated end to end on prod.
