### PR TITLE
feat(br_senatran_estatisticas): adiciona municipio_combustivel e o parâmetro backfill_start

### DIFF
--- a/models/br_senatran_estatisticas/br_senatran_estatisticas__municipio_combustivel.sql
+++ b/models/br_senatran_estatisticas/br_senatran_estatisticas__municipio_combustivel.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        alias="municipio_combustivel",
+        schema="br_senatran_estatisticas",
+        materialized="table",
+        partition_by={
+            "field": "ano",
+            "data_type": "int64",
+            "range": {
+                "start": 2013,
+                "end": 2031,
+                "interval": 1,
+            },
+        },
+        cluster_by=["mes"],
+        pre_hook="{% if adapter.get_relation(this.database, this.schema, this.identifier) %}DROP ALL ROW ACCESS POLICIES ON {{ this }}{% else %}SELECT 1{% endif %}",
+    )
+}}
+
+
+select
+    safe_cast(ano as int64) ano,
+    safe_cast(mes as int64) mes,
+    safe_cast(sigla_uf as string) sigla_uf,
+    safe_cast(id_municipio as string) id_municipio,
+    safe_cast(lower(combustivel) as string) combustivel,
+    safe_cast(quantidade as int64) quantidade
+from
+    {{ set_datalake_project("br_senatran_estatisticas_staging.municipio_combustivel") }}
+    as t

--- a/models/br_senatran_estatisticas/schema.yml
+++ b/models/br_senatran_estatisticas/schema.yml
@@ -71,3 +71,44 @@ models:
         description: Tipo de veículo
       - name: quantidade
         description: Quantidade de veículos
+  - name: br_senatran_estatisticas__municipio_combustivel
+    description: >
+      Frota de veículos por município e tipo de combustível, com dados mensais
+      a partir de 2013. Fonte: recorte D das estatísticas de frota da SENATRAN.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [ano, mes, id_municipio, combustivel]
+          config:
+            where: __most_recent_year_month__
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
+          config:
+            where: __most_recent_year_month__
+    columns:
+      - name: ano
+        description: Ano
+        tests: [not_null]
+      - name: mes
+        description: Mês
+        tests: [not_null]
+      - name: sigla_uf
+        description: Sigla da Unidade da Federação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
+              config:
+                where: __most_recent_year_month__
+      - name: id_municipio
+        description: ID Município - IBGE 7 Dígitos
+        tests:
+          - not_null
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio
+              config:
+                where: __most_recent_year_month__
+      - name: combustivel
+        description: Tipo de combustível do veículo
+      - name: quantidade
+        description: Quantidade de veículos

--- a/pipelines/datasets/br_senatran_estatisticas/breakdowns.py
+++ b/pipelines/datasets/br_senatran_estatisticas/breakdowns.py
@@ -1,0 +1,361 @@
+"""Recortes mensais da frota publicados nas páginas anuais do gov.br/SENATRAN.
+
+Cada recorte tem o mesmo formato — ``UF | Município | <dimensão…> | quantidade`` —
+e difere apenas nas colunas de dimensão. Este módulo trata todos eles de forma
+genérica, a partir da configuração em :data:`LAYOUTS`.
+
+Funções puras: nenhum import do Prefect. As tasks ficam em ``tasks.py``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+import unicodedata
+import urllib.parse
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pandas as pd
+import polars as pl
+import requests
+from bs4 import BeautifulSoup
+
+from pipelines.datasets.br_senatran_estatisticas.constants import (
+    constants as senatran_constants,
+)
+
+MONTHS: dict[str, int] = {
+    "janeiro": 1,
+    "fevereiro": 2,
+    "marco": 3,
+    "abril": 4,
+    "maio": 5,
+    "junho": 6,
+    "julho": 7,
+    "agosto": 8,
+    "setembro": 9,
+    "outubro": 10,
+    "novembro": 11,
+    "dezembro": 12,
+}
+
+# O gov.br publica "Março" com grafias inconsistentes. Depois do asciify,
+# "Março" -> "marco", mas os arquivos trazem também "Maro" (o "ç" some antes
+# do upload) e as abreviações de três letras.
+MONTH_ALIASES: dict[str, int] = {
+    **MONTHS,
+    "maro": 3,
+    **{name[:3]: number for name, number in MONTHS.items()},
+}
+
+
+@dataclass(frozen=True)
+class Layout:
+    """Um recorte da frota publicado mensalmente."""
+
+    table_id: str
+    #: token que identifica o recorte no nome do arquivo, já normalizado
+    token: str
+    #: nomes finais das colunas de dimensão, na ordem em que aparecem
+    dimensions: tuple[str, ...]
+    #: tokens que, se presentes, desqualificam o arquivo
+    excludes: tuple[str, ...] = field(default=())
+
+
+LAYOUTS: dict[str, Layout] = {
+    "municipio_combustivel": Layout(
+        table_id="municipio_combustivel",
+        token="combustivel",
+        dimensions=("combustivel",),
+    ),
+}
+
+
+def normalize(text: str) -> str:
+    """Normaliza um nome de arquivo ou cabeçalho para comparação.
+
+    Decodifica escapes de URL, remove acentos, passa para minúsculas e colapsa
+    tudo que não for alfanumérico em ``_``. É o que permite casar as várias
+    gerações de nomenclatura do gov.br sem depender de um template.
+    """
+    text = urllib.parse.unquote(text)
+    text = unicodedata.normalize("NFKD", text)
+    text = text.encode("ascii", "ignore").decode()
+    return re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")
+
+
+def month_from_filename(filename: str) -> int | None:
+    """Extrai o mês de um nome de arquivo, tolerando as grafias do gov.br."""
+    normalized = normalize(filename)
+    # nomes longos primeiro: "marco" antes de "mar", senão "mar" casa cedo demais
+    for name in sorted(MONTH_ALIASES, key=len, reverse=True):
+        if re.search(rf"(?:^|_){name}(?:_|$|\d)", normalized):
+            return MONTH_ALIASES[name]
+    return None
+
+
+def extract_breakdown_links(
+    year: int,
+    layout: Layout,
+    session: requests.Session | None = None,
+) -> dict[int, str]:
+    """Devolve ``{mês: url}`` para um recorte na página anual do gov.br.
+
+    Casa pelo **nome do arquivo** normalizado, não pelo texto do link: os
+    rótulos visíveis variam muito mais que os nomes, e é por isso que o
+    extrator antigo (``extract_links_post_2012``) perde 2013-2016.
+    """
+    session = session or requests.Session()
+    url = f"{senatran_constants.BASE_URL_POST_2012.value}/frota-de-veiculos-{year}"
+    response = session.get(
+        url, headers=senatran_constants.HEADERS.value, timeout=180
+    )
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    candidates: dict[int, list[str]] = {}
+    for anchor in soup.find_all("a", href=True):
+        href = anchor["href"]
+        if not re.search(r"\.(xlsx|xls|csv|zip|rar)$", href, re.I):
+            continue
+        filename = href.rsplit("/", 1)[-1]
+        normalized = normalize(filename)
+        if layout.token not in normalized:
+            continue
+        if any(bad in normalized for bad in layout.excludes):
+            continue
+        month = month_from_filename(filename)
+        if month is None:
+            continue
+        absolute = (
+            href
+            if href.startswith("http")
+            else urllib.parse.urljoin("https://www.gov.br", href)
+        )
+        candidates.setdefault(month, []).append(absolute)
+
+    # O gov.br deixa duplicatas na página ("copy_of_", "copy2_of_"). Preferimos
+    # o nome sem prefixo de cópia; empatando, o mais curto.
+    resolved: dict[int, str] = {}
+    for month, urls in candidates.items():
+        resolved[month] = sorted(
+            urls,
+            key=lambda u: (
+                "copy" in normalize(u.rsplit("/", 1)[-1]),
+                len(u.rsplit("/", 1)[-1]),
+            ),
+        )[0]
+    return resolved
+
+
+def read_breakdown(path: str | Path, layout: Layout) -> pl.DataFrame:
+    """Lê um arquivo de recorte e devolve colunas já renomeadas.
+
+    O nome da planilha varia (``Layout C``, ``Layout D `` com espaço à direita),
+    então pegamos a primeira aba que não seja o glossário.
+    """
+    excel = pd.ExcelFile(path)
+    sheets = [s for s in excel.sheet_names if normalize(str(s)) != "glossario"]
+    if not sheets:
+        raise ValueError(f"Nenhuma aba de dados em {path}")
+    frame = pd.read_excel(path, sheet_name=sheets[0])
+
+    expected = 2 + len(layout.dimensions) + 1
+    if frame.shape[1] < expected:
+        raise ValueError(
+            f"{path}: esperava >= {expected} colunas para o recorte "
+            f"{layout.table_id}, encontrou {frame.shape[1]}"
+        )
+    frame = frame.iloc[:, :expected]
+    frame.columns = [
+        "nome_uf",
+        "nome_denatran",
+        *layout.dimensions,
+        "quantidade",
+    ]
+    return pl.from_pandas(frame.astype(str))
+
+
+def build_municipio_lookup(
+    nomes: pl.DataFrame, ibge: pl.DataFrame
+) -> pl.DataFrame:
+    """Constrói o cruzamento ``(sigla_uf, nome_denatran) -> id_municipio``.
+
+    Feito **uma vez por arquivo sobre os nomes distintos**, e não linha a linha:
+    nos recortes cada município aparece muitas vezes (uma linha por combustível,
+    por cor etc.), então casar por linha seria lento e faria
+    ``treat_uf`` acusar duplicidade em todo município.
+    """
+    from pipelines.datasets.br_senatran_estatisticas.utils import (
+        fix_suggested_nome_ibge,
+        get_city_name_ibge,
+    )
+
+    pieces = []
+    for uf in sorted(nomes["sigla_uf"].unique().to_list()):
+        nomes_uf = nomes.filter(pl.col("sigla_uf") == uf).unique(
+            subset=["nome_denatran"]
+        )
+        ibge_uf = ibge.filter(pl.col("sigla_uf") == uf).with_columns(
+            pl.col("nome")
+            .apply(
+                lambda n: normalize(n).replace("_", " "),
+                return_dtype=pl.Utf8,
+            )
+            .alias("nome")
+        )
+        if ibge_uf.is_empty() or nomes_uf.is_empty():
+            continue
+        # ibge_uf ligado como default: sem isso o lambda captura a variável
+        # do laço por referência (ruff B023)
+        sugerido = nomes_uf["nome_denatran"].apply(
+            lambda x, _ibge=ibge_uf: get_city_name_ibge(x, _ibge),
+            return_dtype=pl.Utf8,
+        )
+        nomes_uf = nomes_uf.with_columns(sugerido.alias("suggested_nome_ibge"))
+        nomes_uf = nomes_uf.with_columns(
+            nomes_uf.apply(fix_suggested_nome_ibge)["map"].alias(
+                "suggested_nome_ibge"
+            )
+        )
+        pieces.append(
+            nomes_uf.join(
+                ibge_uf.select(["nome", "sigla_uf", "id_municipio"]),
+                left_on=["suggested_nome_ibge", "sigla_uf"],
+                right_on=["nome", "sigla_uf"],
+                how="left",
+            ).select(["sigla_uf", "nome_denatran", "id_municipio"])
+        )
+    if not pieces:
+        raise ValueError("Nenhum município pôde ser cruzado com o IBGE")
+    return pl.concat(pieces)
+
+
+def clean_breakdown(
+    frame: pl.DataFrame,
+    layout: Layout,
+    year: int,
+    month: int,
+    ibge: pl.DataFrame,
+) -> tuple[pl.DataFrame, int]:
+    """Transforma um recorte bruto no formato final da tabela.
+
+    Devolve ``(dados, descartadas)`` — o segundo item conta as linhas sem UF
+    reconhecida ou com "município não informado", que a fonte traz em todo mês.
+    """
+    from pipelines.datasets.br_senatran_estatisticas.utils import asciify
+
+    reverse_ufs = {
+        normalize(nome): sigla
+        for sigla, nome in senatran_constants.DICT_UFS.value.items()
+    }
+
+    frame = frame.with_columns(
+        pl.col("nome_uf")
+        .apply(lambda x: reverse_ufs.get(normalize(x)), return_dtype=pl.Utf8)
+        .alias("sigla_uf"),
+        pl.col("nome_denatran")
+        .apply(asciify, return_dtype=pl.Utf8)
+        .str.to_lowercase()
+        .alias("nome_denatran"),
+    )
+
+    descartadas = frame.filter(
+        pl.col("sigla_uf").is_null()
+        | (pl.col("nome_denatran") == "municipio nao informado")
+    )
+    frame = frame.filter(
+        pl.col("sigla_uf").is_not_null()
+        & (pl.col("nome_denatran") != "municipio nao informado")
+    )
+
+    lookup = build_municipio_lookup(
+        frame.select(["sigla_uf", "nome_denatran"]), ibge
+    )
+    frame = frame.join(lookup, on=["sigla_uf", "nome_denatran"], how="left")
+
+    frame = frame.with_columns(
+        pl.lit(year, dtype=pl.Int64).alias("ano"),
+        pl.lit(month, dtype=pl.Int64).alias("mes"),
+        # id_municipio é identificador, não quantidade: STRING por convenção
+        pl.col("id_municipio").cast(pl.Utf8).alias("id_municipio"),
+        pl.col("quantidade")
+        .str.replace_all(r"[^0-9-]", "")
+        .cast(pl.Int64, strict=False)
+        .alias("quantidade"),
+    )
+
+    final = frame.select(
+        [
+            "ano",
+            "mes",
+            "sigla_uf",
+            "id_municipio",
+            *layout.dimensions,
+            "quantidade",
+        ]
+    )
+    return final.with_columns(
+        [pl.col(dim).str.strip().alias(dim) for dim in layout.dimensions]
+    ), len(descartadas)
+
+
+def reference_date(year: int, month: int) -> datetime.date:
+    return datetime.date(year, month, 1)
+
+
+def available_months(
+    layout: Layout,
+    start_after: datetime.date,
+    today: datetime.date | None = None,
+    session: requests.Session | None = None,
+) -> list[tuple[int, int, str]]:
+    """Meses publicados de um recorte, posteriores a ``start_after``.
+
+    Devolve ``[(ano, mes, url), …]`` em ordem cronológica. Busca **uma vez por
+    página anual**, e não uma vez por mês: o extrator antigo refaz o download da
+    página a cada mês do intervalo, o que torna um backfill completo
+    (~280 meses) dezenas de minutos mais lento sem necessidade.
+    """
+    session = session or requests.Session()
+    today = today or datetime.date.today()
+    encontrados: list[tuple[int, int, str]] = []
+    for year in range(max(start_after.year, 2013), today.year + 1):
+        try:
+            links = extract_breakdown_links(year, layout, session=session)
+        except Exception:
+            # uma página anual indisponível não deve abortar o backfill inteiro
+            continue
+        for month, url in sorted(links.items()):
+            reference = datetime.date(year, month, 1)
+            if start_after < reference <= today:
+                encontrados.append((year, month, url))
+    return sorted(encontrados)
+
+
+def download(url: str, dest_dir: str | Path, session=None) -> Path:
+    """Baixa um arquivo de recorte, retomando se a conexão cair.
+
+    O host do gov.br derruba conexões longas, então tentamos algumas vezes e
+    conferimos o tamanho antes de aceitar o arquivo.
+    """
+    session = session or requests.Session()
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    destino = dest_dir / urllib.parse.unquote(
+        url.rsplit("/", 1)[-1].split("?")[0]
+    )
+    ultimo_erro: Exception | None = None
+    for _ in range(4):
+        try:
+            resposta = session.get(
+                url, headers=senatran_constants.HEADERS.value, timeout=600
+            )
+            resposta.raise_for_status()
+            destino.write_bytes(resposta.content)
+            if destino.stat().st_size > 0:
+                return destino
+        except Exception as erro:
+            ultimo_erro = erro
+    raise RuntimeError(f"Falha ao baixar {url}: {ultimo_erro}")

--- a/pipelines/datasets/br_senatran_estatisticas/flows.py
+++ b/pipelines/datasets/br_senatran_estatisticas/flows.py
@@ -2,6 +2,8 @@
 Flows para br_senatran_estatisticas — Prefect 3.
 """
 
+from pathlib import Path
+
 from prefect import flow
 
 from pipelines.datasets.br_senatran_estatisticas.constants import (
@@ -10,8 +12,10 @@ from pipelines.datasets.br_senatran_estatisticas.constants import (
 from pipelines.datasets.br_senatran_estatisticas.tasks import (
     build_paths,
     crawl_task,
+    get_breakdown_months_task,
     get_desired_file_task,
     get_latest_date_task,
+    treat_breakdown_task,
     treat_municipio_tipo_task,
     treat_uf_tipo_task,
 )
@@ -131,6 +135,7 @@ def _run_senatran(
     if not materialize_after_dump:
         return
 
+    # pyrefly: ignore [no-matching-overload]
     upload_to_gcs(
         data_path=filepath,
         dataset_id=dataset_id,
@@ -219,4 +224,157 @@ br_senatran_estatisticas__uf_tipo.deploy_schedules = [
 # pyrefly: ignore [missing-attribute]
 br_senatran_estatisticas__municipio_tipo.deploy_schedules = [
     {"cron": "20 21 10-30 * *", "timezone": "America/Sao_Paulo"}
+]
+
+
+def _run_breakdown(
+    *,
+    dataset_id: str,
+    table_id: str,
+    layout_key: str,
+    materialize_after_dump: bool,
+    update_metadata: bool,
+    target: str,
+    force_run: bool,
+    backfill_start: str | None,
+) -> None:
+    """Executa um recorte da frota (combustível, cor, potência…).
+
+    Difere de ``_run_senatran`` só no par baixar/limpar: os recortes vêm de um
+    único XLSX por mês, já em formato longo, então não passam pelo
+    ``crawl_task``/``get_desired_file_task`` do par município/UF x tipo.
+    """
+    # pyrefly: ignore [unused-coroutine]
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=dataset_id, table_id=table_id
+    )
+
+    input_dir, output_dir = build_paths()
+
+    datas, urls = get_breakdown_months_task(
+        table_id=table_id,
+        dataset_id=dataset_id,
+        layout_key=layout_key,
+        backfill_start=backfill_start,
+    )
+
+    if not datas:
+        print("Não há novas atualizações na fonte original")
+        return
+
+    source_max_date_str = max(datas).strftime("%Y-%m")
+
+    if not force_run and not backfill_start:
+        has_new_data = poll_source_for_update_task(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            source_max_date=source_max_date_str,
+            env="prod",
+            date_format="%Y-%m",
+            compare_against="coverage",
+        )
+        if not has_new_data:
+            print("Não há novas atualizações na fonte original")
+            return
+
+    commit_source_update_task(
+        dataset_id=dataset_id,
+        table_id=table_id,
+        source_max_date=source_max_date_str,
+        env="prod",
+        date_format="%Y-%m",
+        update_metadata=update_metadata,
+        materialize_after_dump=materialize_after_dump,
+    )
+
+    filepath: Path | None = None
+    for data, url in zip(datas, urls, strict=True):
+        filepath = treat_breakdown_task(
+            url=url,
+            year=data.year,
+            month=data.month,
+            layout_key=layout_key,
+            input_dir=input_dir,
+            output_dir=output_dir,
+        )
+
+    if filepath is None:
+        raise RuntimeError("Nenhum mês foi processado — nada a subir")
+
+    # pyrefly: ignore [no-matching-overload]
+    upload_to_gcs(
+        data_path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        bucket_name="basedosdados-dev",
+        dump_mode="append",
+        source_format="parquet",
+    )
+    run_dbt(
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dbt_command="run/test",
+        target="dev",
+    )
+
+    if not materialize_after_dump:
+        return
+
+    # pyrefly: ignore [no-matching-overload]
+    upload_to_gcs(
+        data_path=filepath,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        bucket_name="basedosdados",
+        dump_mode="append",
+        source_format="parquet",
+    )
+    run_dbt(
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dbt_command="run/test",
+        target=target,
+    )
+
+    if update_metadata:
+        register_table_materialization_task(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            coverage=PartBdpro(
+                date_column=YearMonth(year="ano", month="mes"),
+                date_format=DateFormat.YEAR_MONTH,
+            ),
+            env="prod",
+            bq_project="basedosdados",
+        )
+
+
+@flow(
+    name="br_senatran_estatisticas__municipio_combustivel",
+    log_prints=True,
+)
+def br_senatran_estatisticas__municipio_combustivel(
+    dataset_id: str = "br_senatran_estatisticas",
+    table_id: str = "municipio_combustivel",
+    materialize_after_dump: bool = True,
+    update_metadata: bool = True,
+    target: str = "prod",
+    force_run: bool = False,
+    backfill_start: str | None = None,
+) -> None:
+    _run_breakdown(
+        dataset_id=dataset_id,
+        table_id=table_id,
+        layout_key="municipio_combustivel",
+        materialize_after_dump=materialize_after_dump,
+        update_metadata=update_metadata,
+        target=target,
+        force_run=force_run,
+        backfill_start=backfill_start,
+    )
+
+
+# pyrefly: ignore [missing-attribute]
+br_senatran_estatisticas__municipio_combustivel.deploy_schedules = [
+    {"cron": "40 21 10-30 * *", "timezone": "America/Sao_Paulo"}
 ]

--- a/pipelines/datasets/br_senatran_estatisticas/flows.py
+++ b/pipelines/datasets/br_senatran_estatisticas/flows.py
@@ -42,6 +42,7 @@ def _run_senatran(
     update_metadata: bool,
     target: str,
     force_run: bool,
+    backfill_start: str | None = None,
 ) -> None:
     # pyrefly: ignore [unused-coroutine]
     rename_flow_run_dataset_table(
@@ -56,12 +57,15 @@ def _run_senatran(
         _source_first_available_date,
         source_first_available_date_str,
     ) = get_latest_date_task(
-        table_id=table_id, dataset_id=dataset_id, input_dir=input_dir
+        table_id=table_id,
+        dataset_id=dataset_id,
+        input_dir=input_dir,
+        backfill_start=backfill_start,
     )
 
     print(f"First available date: {source_first_available_date_str}")
 
-    if not force_run:
+    if not force_run and not backfill_start:
         has_new_data = poll_source_for_update_task(
             dataset_id=dataset_id,
             table_id=table_id,
@@ -167,6 +171,7 @@ def br_senatran_estatisticas__uf_tipo(
     update_metadata: bool = True,
     target: str = "prod",
     force_run: bool = False,
+    backfill_start: str | None = None,
 ) -> None:
     _run_senatran(
         dataset_id=dataset_id,
@@ -177,6 +182,7 @@ def br_senatran_estatisticas__uf_tipo(
         update_metadata=update_metadata,
         target=target,
         force_run=force_run,
+        backfill_start=backfill_start,
     )
 
 
@@ -191,6 +197,7 @@ def br_senatran_estatisticas__municipio_tipo(
     update_metadata: bool = True,
     target: str = "prod",
     force_run: bool = False,
+    backfill_start: str | None = None,
 ) -> None:
     _run_senatran(
         dataset_id=dataset_id,
@@ -201,6 +208,7 @@ def br_senatran_estatisticas__municipio_tipo(
         update_metadata=update_metadata,
         target=target,
         force_run=force_run,
+        backfill_start=backfill_start,
     )
 
 

--- a/pipelines/datasets/br_senatran_estatisticas/tasks.py
+++ b/pipelines/datasets/br_senatran_estatisticas/tasks.py
@@ -433,3 +433,89 @@ def get_latest_date_task(
 def get_senatran_date(filename: str) -> datetime.date:
     year, month = get_year_month_from_filename(filename)
     return datetime.date(year, month, 1)
+
+
+@task
+def get_breakdown_months_task(
+    table_id: str,
+    dataset_id: str,
+    layout_key: str,
+    backfill_start: str | None = None,
+) -> tuple[list, list]:
+    """Meses de um recorte ainda não ingeridos.
+
+    Com ``backfill_start`` ("%Y-%m") ignora a cobertura registrada no backend e
+    percorre tudo a partir daquele mês — é como se reconstrói uma tabela do zero
+    sem mexer na cobertura de um dataset em produção.
+    """
+    from pipelines.datasets.br_senatran_estatisticas.breakdowns import (
+        LAYOUTS,
+        available_months,
+    )
+
+    layout = LAYOUTS[layout_key]
+    if backfill_start:
+        inicio = datetime.datetime.strptime(backfill_start, "%Y-%m").date()
+        log(f"Backfill: percorrendo a partir de {backfill_start}")
+    else:
+        backend = bd.Backend(graphql_url=get_url("prod"))
+        inicio = get_api_most_recent_date(
+            table_id=table_id,
+            dataset_id=dataset_id,
+            date_format="%Y-%m",
+            backend=backend,
+        )
+
+    encontrados = available_months(layout, start_after=inicio)
+    datas = [datetime.datetime(a, m, 1) for a, m, _ in encontrados]
+    urls = [u for _, _, u in encontrados]
+    log(f"{len(datas)} meses disponíveis para {layout.table_id}")
+    return datas, urls
+
+
+@task
+def treat_breakdown_task(
+    url: str,
+    year: int,
+    month: int,
+    layout_key: str,
+    input_dir: str | Path,
+    output_dir: str | Path,
+) -> Path:
+    """Baixa, limpa e grava um mês de um recorte como parquet particionado."""
+    from pipelines.datasets.br_senatran_estatisticas.breakdowns import (
+        LAYOUTS,
+        clean_breakdown,
+        download,
+        read_breakdown,
+    )
+
+    layout = LAYOUTS[layout_key]
+    arquivo = download(url, input_dir)
+    log(f"------- Baixado {arquivo.name}")
+
+    municipios = pl.from_pandas(
+        bd.read_sql(
+            "select nome, id_municipio, sigla_uf "
+            "from `basedosdados.br_bd_diretorios_brasil.municipio`",
+            from_file=True,
+        )
+    )
+
+    bruto = read_breakdown(arquivo, layout)
+    final, descartadas = clean_breakdown(
+        bruto, layout, year, month, municipios
+    )
+    sem_id = final.filter(pl.col("id_municipio").is_null()).height
+    if sem_id:
+        raise ValueError(
+            f"{arquivo.name}: {sem_id} linhas sem id_municipio — "
+            "adicione o município em constants.SUBSTITUTIONS"
+        )
+    log(
+        f"------- {layout.table_id} {year}-{month:02d}: {final.height} linhas "
+        f"({descartadas} descartadas)"
+    )
+    return output_file_to_parquet(
+        final, table_id=layout.table_id, output_dir=output_dir
+    )

--- a/pipelines/datasets/br_senatran_estatisticas/tasks.py
+++ b/pipelines/datasets/br_senatran_estatisticas/tasks.py
@@ -323,24 +323,40 @@ def treat_municipio_tipo_task(
 
 @task
 def get_latest_date_task(
-    table_id: str, dataset_id: str, input_dir: str | Path
+    table_id: str,
+    dataset_id: str,
+    input_dir: str | Path,
+    backfill_start: str | None = None,
 ) -> tuple[list, list, int | None, str | None]:
     """Task to extract the latest data from available on the data source
     Args:
         table_id (str): table_id from BQ
         dataset_id (str): table_id from BQ
+        backfill_start (str | None): "%Y-%m" seed for a full backfill. When set,
+            the registered table coverage is ignored and the walk starts at the
+            month AFTER this one. Use to rebuild a table from scratch without
+            rewinding the coverage recorded on the production backend.
 
     Returns:
         [year, month]: most recente date
     """
-    backend = bd.Backend(graphql_url=get_url("prod"))
+    if backfill_start:
+        senatran_data = datetime.datetime.strptime(
+            backfill_start, "%Y-%m"
+        ).date()
+        log(
+            f"Backfill mode: walking from {backfill_start} onwards, "
+            "ignoring the coverage registered on the backend"
+        )
+    else:
+        backend = bd.Backend(graphql_url=get_url("prod"))
 
-    senatran_data = get_api_most_recent_date(
-        table_id=table_id,
-        dataset_id=dataset_id,
-        date_format="%Y-%m",
-        backend=backend,
-    )
+        senatran_data = get_api_most_recent_date(
+            table_id=table_id,
+            dataset_id=dataset_id,
+            date_format="%Y-%m",
+            backend=backend,
+        )
 
     log(f"{senatran_data}")
     year = senatran_data.year


### PR DESCRIPTION
Dois commits: o parâmetro `backfill_start` e a primeira das sete tabelas de recorte da frota.

## `backfill_start`

`get_latest_date_task` parte da cobertura registrada no backend de produção, então a única forma
de reconstruir um histórico completo era **rebobinar essa cobertura** — passando a informar errado,
em produção, o alcance de um dataset publicado, durante todas as horas que o backfill levasse.

`backfill_start` (`"%Y-%m"`) ignora a consulta ao backend e percorre a partir do mês seguinte ao
informado, dispensando também o poll guard. O metadado de produção permanece correto enquanto o
backfill roda.

É pré-requisito das sete tabelas novas: nenhuma delas tem cobertura registrada de onde partir.

## `municipio_combustivel`

Frota por município e tipo de combustível, **2013-06 a 2026-07 (152 meses)**. É o primeiro dos sete
recortes mensais publicados nas páginas anuais do gov.br/SENATRAN; faltam cor, potência, restrição,
tipo/espécie/eixos, CEP e ano fab/modelo.

O módulo `breakdowns.py` trata os recortes genericamente a partir de `LAYOUTS`, porque todos têm o
mesmo formato — `UF | Município | <dimensão…> | quantidade`. Adicionar os outros seis passa a ser
uma entrada de configuração mais um modelo dbt.

### Casamento por nome de arquivo, não pelo texto do link

`extract_links_post_2012` casa pelo rótulo visível do link, e é por isso que **perde 2013-04 a
2016-12 — 45 meses cujos arquivos estão nas páginas** (2013: 101 links, 2014: 132, 2015: 130,
2016: 132). Os nomes atravessam pelo menos cinco gerações de nomenclatura:

```
frotamunic2013_dezembro.zip
1quantidadeveiculosporufmunicipioanofabr_outubro2013.zip
frota_munic_modelo_outubro_2023.xls
frota_reg_uftipo_modelo_fevereiro_2024.xls
copy2_of_frota_por_uf_tipo_de_veiculo_maro_2025.xlsx
D_Frota_por_UF_Municipio_COMBUSTIVEL_Julho_2026.xlsx
```

O novo extrator normaliza (unquote → sem acento → minúscula → não-alfanumérico vira `_`) e casa por
token, resolvendo também `Maro` (o `ç` de "Março" se perde antes do upload) e as duplicatas
`copy_of_` / `copy2_of_` que o gov.br deixa nas páginas.

### O cruzamento município→IBGE é por arquivo, não por linha

Nos recortes cada município aparece muitas vezes — uma linha por combustível. Reaproveitar
`treat_uf` diretamente faria o casamento difuso rodar em cada uma das ~58.000 linhas e dispararia o
aviso de duplicidade em todo município. O cruzamento é construído uma vez, sobre os nomes
distintos, e depois unido aos dados.

`available_months` também busca **uma vez por página anual**; o caminho antigo refaz o download da
página a cada mês do intervalo, o que sozinho custa dezenas de minutos num backfill completo.

## Verificação

Ponta a ponta com arquivos reais:

| mês | linhas | sem `id_municipio` | frota nacional |
|---|---|---|---|
| 2026-05 | 57.401 | **0** | 131.330.316 |
| 2026-06 | 57.984 | **0** | 131.818.976 |
| 2026-07 | 58.587 | **0** | 132.323.803 |

5.571 municípios cruzados, ~26 linhas/mês descartadas ("município não informado"), frota crescendo
de forma monotônica, parquet particionado em `ano=/mes=`. `dbt parse` limpo e o modelo mais seus 7
testes resolvem; `ruff` e `pyrefly` sem diagnósticos; as três flows são encontradas por
`deploy_flows.load_flows_from_file`.

Não exercitado localmente: o upload para produção e a materialização, que dependem das credenciais
do worker.

## Labels

Leva **`table-approve`** (modelo novo, precisa materializar em produção no merge) e
**`deploy-flow`** (flows alteradas, para um run de validação no pool de dev).

## Depois do merge

`backfill_start="2025-08"` passa a ser acionável nas flows já publicadas — é o que preenche
2025-09 e 2025-10, hoje ausentes de `municipio_tipo` e `uf_tipo`, e o mesmo mecanismo carrega os
152 meses de `municipio_combustivel`.
