### PR TITLE
fix(utils): tabela externa da staging usa o cliente certo e segue o bucket da propria perna

### DIFF
--- a/pipelines/datasets/br_sfb_sicar/README.md
+++ b/pipelines/datasets/br_sfb_sicar/README.md
@@ -118,12 +118,10 @@ sem nenhum modelo lendo essa coluna — e derruba depois do download inteiro.
 
 ## Pendências
 
-- **O PATCH do schema da staging falha com 403.** `_sync_staging_schema`
-  (`pipelines/utils/tasks.py`) abre `bigquery.Client(project=...)` sem credencial e cai no
-  ADC do pod, que só lê; o `get_table` passa e o `update_table` estoura com
-  `bigquery.tables.update denied`. O cliente autenticado está em
-  `tb.client["bigquery_staging"]`, no objeto que a função já recebe. Vale para este e para
-  qualquer outro conjunto; o conserto sai em PR à parte.
+- ~~**O PATCH do schema da staging falha com 403.**~~ Corrigido:
+  `_sync_staging_schema` (`pipelines/utils/tasks.py`) usava
+  `bigquery.Client(project=...)` sem credencial e caía no ADC do pod, que só lê. Agora usa
+  `tb.client["bigquery_staging"]`, o cliente autenticado que já vem no objeto recebido.
 - **Não há staging em dev.** Nem o dataset `br_sfb_sicar_staging` em `basedosdados-dev`,
   nem o prefixo `gs://basedosdados-dev/staging/br_sfb_sicar/`. O próximo run no pool de dev
   os cria pelo ramo `tb.create` do `upload_to_gcs`.

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -76,7 +76,6 @@ def _sync_staging_schema(
     tb: bd.Table,
     data_path: str | Path,
     source_format: str,
-    billing_project_id: str,
 ) -> None:
     """Adiciona ao schema da staging as colunas que a fonte passou a trazer.
 
@@ -103,14 +102,17 @@ def _sync_staging_schema(
         tb: tabela `basedosdados` já instanciada, apontando para a staging.
         data_path: arquivo ou diretório com os dados que serão carregados.
         source_format: `"csv"` ou `"parquet"`.
-        billing_project_id: projeto GCP usado para faturar a chamada.
     """
     header_path = dump_header(data_path=data_path, source_format=source_format)
     incoming = tb._load_staging_schema_from_data(
         data_sample_path=header_path, source_format=source_format
     )
 
-    client = bigquery.Client(project=billing_project_id)
+    # O cliente tem que ser o da própria lib: `bigquery.Client()` sem
+    # credencial cai no ADC do pod, que não é o principal com acesso à
+    # staging — o `get_table` estoura 403 em dataset novo e o
+    # `update_table` estoura 403 sempre.
+    client = tb.client["bigquery_staging"]
     table = client.get_table(tb.table_full_name["staging"])
 
     current = {_bq_safe_column_name(field.name) for field in table.schema}
@@ -190,7 +192,6 @@ def _upload_to_gcs(
                 tb=tb,
                 data_path=data_path,
                 source_format=source_format,
-                billing_project_id=billing_project_id,
             )
 
     elif dump_mode == "overwrite":

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -72,6 +72,85 @@ def _bq_safe_column_name(name: str) -> str:
     return re.sub(r"[^0-9a-zA-Z_]", "_", name)
 
 
+# Projeto BigQuery da staging que corresponde a cada bucket, na mesma
+# convenção do macro `set_datalake_project`: o alvo `dev` do dbt lê
+# `basedosdados-dev` e o alvo `prod` lê `basedosdados-staging`.
+_STAGING_PROJECT_BY_BUCKET = {
+    "basedosdados-dev": "basedosdados-dev",
+    "basedosdados": "basedosdados-staging",
+}
+
+
+def _leg_owns_staging_table(tb: bd.Table, bucket_name: str) -> bool:
+    """Diz se esta perna do flow é a dona da definição da tabela externa.
+
+    O projeto BigQuery da staging vem do `config.toml` do pod, não do
+    `bucket_name`, e é o mesmo nas duas pernas: `basedosdados-dev` no worker
+    de dev, `basedosdados-staging` no de prod. Só uma das pernas casa com o
+    projeto em que está escrevendo — a outra mexe numa tabela que nunca vai
+    ler, e é essa que não pode alterar a definição.
+
+    Args:
+        tb: tabela `basedosdados` já instanciada, apontando para a staging.
+        bucket_name: bucket para onde esta perna vai escrever.
+
+    Returns:
+        `True` quando o projeto da staging é o par do bucket.
+    """
+    esperado = _STAGING_PROJECT_BY_BUCKET.get(bucket_name)
+    return esperado is not None and (
+        tb.client["bigquery_staging"].project == esperado
+    )
+
+
+def _sync_staging_uris(tb: bd.Table, bucket_name: str) -> None:
+    """Aponta a tabela externa da staging para o bucket em que esta perna escreve.
+
+    Como a perna de dev roda primeiro, no worker de prod a tabela externa de
+    `basedosdados-staging` nasce apontando para `gs://basedosdados-dev/...`:
+    é a perna de dev que cai no ramo `tb.create`, e a de prod encontra
+    `table_exists` verdadeiro e segue sem olhar as URIs. O dbt de prod passa
+    então a materializar a partir do bucket de dev — números certos, origem
+    errada.
+
+    Só a definição é alterada. Nada é escrito nem apagado no GCS: recriar a
+    tabela chamaria `Storage.delete_table` e levaria o histórico junto.
+
+    Args:
+        tb: tabela `basedosdados` já instanciada, apontando para a staging.
+        bucket_name: bucket para onde esta perna vai escrever.
+    """
+    if not _leg_owns_staging_table(tb, bucket_name):
+        return
+
+    esperado = tb.uri.format(dataset=tb.dataset_id, table=tb.table_id)
+    prefixo = esperado.removesuffix("*")
+
+    client = tb.client["bigquery_staging"]
+    table = client.get_table(tb.table_full_name["staging"])
+    config = table.external_data_configuration
+
+    if config is None or list(config.source_uris) == [esperado]:
+        return
+
+    anterior = list(config.source_uris)
+    config.source_uris = [esperado]
+
+    # O getter devolve uma cópia — sem reatribuir, a mudança se perde.
+    hive = config.hive_partitioning
+    if hive is not None:
+        hive.source_uri_prefix = prefixo
+        config.hive_partitioning = hive
+
+    table.external_data_configuration = config
+    client.update_table(table, ["external_data_configuration"])
+
+    print(
+        f"Tabela externa {tb.table_full_name['staging']} reapontada para "
+        f"{anterior} -> {[esperado]}"
+    )
+
+
 def _sync_staging_schema(
     tb: bd.Table,
     data_path: str | Path,
@@ -193,6 +272,7 @@ def _upload_to_gcs(
                 data_path=data_path,
                 source_format=source_format,
             )
+            _sync_staging_uris(tb=tb, bucket_name=bucket_name)
 
     elif dump_mode == "overwrite":
         if tb.table_exists(mode="staging"):

--- a/pipelines/utils/tests/test_sync_staging_uris.py
+++ b/pipelines/utils/tests/test_sync_staging_uris.py
@@ -1,0 +1,131 @@
+"""Testes de `_leg_owns_staging_table` e `_sync_staging_uris`.
+
+O projeto BigQuery da staging vem do `config.toml` do pod e é o mesmo nas duas
+pernas do flow; só a perna cujo bucket casa com esse projeto pode alterar a
+definição da tabela externa.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from google.cloud import bigquery
+
+from pipelines.utils.tasks import _leg_owns_staging_table, _sync_staging_uris
+
+DATASET = "br_senatran_estatisticas"
+TABLE = "municipio_combustivel"
+
+
+def _fake_table(staging_project: str, bucket_name: str) -> MagicMock:
+    """Um `bd.Table` mínimo: só o que as duas funções leem."""
+    tb = MagicMock()
+    tb.dataset_id = DATASET
+    tb.table_id = TABLE
+    tb.uri = f"gs://{bucket_name}" + "/staging/{dataset}/{table}/*"
+    tb.table_full_name = {
+        "staging": f"{staging_project}.{DATASET}_staging.{TABLE}"
+    }
+    tb.client = {"bigquery_staging": MagicMock(project=staging_project)}
+    return tb
+
+
+def _external_config(bucket_name: str) -> bigquery.ExternalConfig:
+    config = bigquery.ExternalConfig("PARQUET")
+    prefix = f"gs://{bucket_name}/staging/{DATASET}/{TABLE}/"
+    config.source_uris = [prefix + "*"]
+    hive = bigquery.external_config.HivePartitioningOptions.from_api_repr(
+        {
+            "mode": "STRINGS",
+            "sourceUriPrefix": prefix,
+            "fields": ["ano", "mes"],
+        }
+    )
+    config.hive_partitioning = hive
+    return config
+
+
+# ── quem é dono da definição ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("staging_project", "bucket_name", "esperado"),
+    [
+        # worker de dev: só a perna de dev casa
+        ("basedosdados-dev", "basedosdados-dev", True),
+        ("basedosdados-dev", "basedosdados", False),
+        # worker de prod: só a perna de prod casa
+        ("basedosdados-staging", "basedosdados", True),
+        ("basedosdados-staging", "basedosdados-dev", False),
+        # bucket desconhecido nunca é dono
+        ("basedosdados-dev", "outro-bucket", False),
+    ],
+)
+def test_leg_owns_staging_table(staging_project, bucket_name, esperado):
+    tb = _fake_table(staging_project, bucket_name)
+    assert _leg_owns_staging_table(tb, bucket_name) is esperado
+
+
+# ── o reaponte em si ──────────────────────────────────────────────────────
+
+
+def test_reaponta_quando_a_tabela_aponta_para_o_bucket_errado():
+    """O caso real: perna de prod achando a URI de dev que a perna de dev deixou."""
+    tb = _fake_table("basedosdados-staging", "basedosdados")
+    client = tb.client["bigquery_staging"]
+    table = MagicMock()
+    table.external_data_configuration = _external_config("basedosdados-dev")
+    client.get_table.return_value = table
+
+    _sync_staging_uris(tb=tb, bucket_name="basedosdados")
+
+    client.update_table.assert_called_once()
+    atualizada, campos = client.update_table.call_args[0]
+    assert campos == ["external_data_configuration"]
+
+    config = atualizada.external_data_configuration
+    prefixo = f"gs://basedosdados/staging/{DATASET}/{TABLE}/"
+    assert config.source_uris == [prefixo + "*"]
+    assert config.hive_partitioning.source_uri_prefix == prefixo
+    # as colunas de partição têm que sobreviver ao reaponte
+    assert config.hive_partitioning.to_api_repr()["fields"] == ["ano", "mes"]
+    assert config.hive_partitioning.mode == "STRINGS"
+
+
+def test_nao_faz_nada_quando_ja_esta_certo():
+    tb = _fake_table("basedosdados-staging", "basedosdados")
+    client = tb.client["bigquery_staging"]
+    table = MagicMock()
+    table.external_data_configuration = _external_config("basedosdados")
+    client.get_table.return_value = table
+
+    _sync_staging_uris(tb=tb, bucket_name="basedosdados")
+
+    client.update_table.assert_not_called()
+
+
+def test_perna_de_dev_no_worker_de_prod_nao_toca_na_tabela():
+    """A regressão que o guard existe para evitar.
+
+    Sem ele, a perna de dev reapontaria a tabela de `basedosdados-staging`
+    para o bucket de dev — e um table-approve seguinte materializaria prod a
+    partir dele.
+    """
+    tb = _fake_table("basedosdados-staging", "basedosdados-dev")
+    client = tb.client["bigquery_staging"]
+
+    _sync_staging_uris(tb=tb, bucket_name="basedosdados-dev")
+
+    client.get_table.assert_not_called()
+    client.update_table.assert_not_called()
+
+
+def test_tabela_nao_externa_e_ignorada():
+    tb = _fake_table("basedosdados-dev", "basedosdados-dev")
+    client = tb.client["bigquery_staging"]
+    table = MagicMock()
+    table.external_data_configuration = None
+    client.get_table.return_value = table
+
+    _sync_staging_uris(tb=tb, bucket_name="basedosdados-dev")
+
+    client.update_table.assert_not_called()


### PR DESCRIPTION
Dois defeitos em `_upload_to_gcs`, ambos vistos em producao no backfill de `br_senatran_estatisticas.municipio_combustivel`. Separados de #1939 a pedido.

**1. `_sync_staging_schema` abria `bigquery.Client()` sem credencial** e caia no ADC do pod, que nao e o principal com acesso a staging. `get_table` estoura 403 em dataset novo e `update_table` estoura 403 sempre. O cliente autenticado ja vem no proprio `bd.Table` recebido pela funcao. Derrubou dois backfills de 47 minutos; estava documentado como pendencia no README do br_sfb_sicar, agora riscada.

**2. A tabela externa da staging nascia apontando para o bucket errado.** O projeto BigQuery da staging vem do `config.toml` do pod, nao do `bucket_name`, e e o mesmo nas duas pernas do flow. No worker de prod a perna de dev roda primeiro e cai no ramo `tb.create`, entao a tabela de `basedosdados-staging` fica com a URI de `gs://basedosdados-dev`; a perna de prod encontra `table_exists` verdadeiro e segue sem olhar. O dbt de prod passa a materializar a partir do bucket de dev — numeros certos, origem errada. Vale para toda tabela cuja primeira carga sai do pool de prod.

O reaponte corrige so a definicao, pela API: recriar a tabela chamaria `Storage.delete_table` e levaria o historico do GCS junto. E guardado por `_leg_owns_staging_table`, que so deixa agir a perna cujo bucket casa com o projeto da staging (mesma convencao do macro `set_datalake_project`) — sem esse guard a perna de dev no worker de prod reapontaria a tabela de prod para o bucket de dev.

9 testes cobrindo a matriz de decisao das duas pernas nos dois pools.