### PR TITLE
fix(us_ed_college_scorecard): correct stale dicionario row count in validation report

### DIFF
--- a/models/us_ed_college_scorecard/code/validation_report.json
+++ b/models/us_ed_college_scorecard/code/validation_report.json
@@ -68,7 +68,7 @@
     "key_unique": true,
     "missing_columns": [],
     "partitions": 1,
-    "rows": 308,
+    "rows": 247,
     "rows_match_clean": true,
     "sparse_columns": []
   },


### PR DESCRIPTION
Corrects one stale number in the College Scorecard validation report. No data
changes, no model changes — a single JSON field.

## What was wrong

`validation_report.json` recorded `dicionario.rows = 308`. The table actually has
**247** rows in dev and in production.

The report was last written at `d602e594`, one commit before `794d87f`
("derive dictionary coverage from the dictionary itself") regenerated the dictionary
from the source labels. The row count was never refreshed afterwards, so the
committed report describes a superseded build.

## Why it matters

Verifying the prod promotion of #1953, ten of eleven tables matched their expected
counts exactly and `dicionario` appeared to be **61 rows short** — indistinguishable
at a glance from silent data loss. It cost a real detour to establish that production
was correct and the report was not. The next person to compare the two would hit the
same false alarm.

## Evidence that 247 is correct

Four independent sources agree, and every other figure in the report already matches:

| Source | `dicionario` rows |
|---|---|
| `clean_stats.json` (written after the regeneration) | 247 |
| output parquet footer | 247 |
| `basedosdados-dev.us_ed_college_scorecard.dicionario` | 247 |
| `basedosdados.us_ed_college_scorecard.dicionario` | 247 |

`rows_match_clean` stays `true` — it was true before against the old clean output and
is true now against the current one.

## Note for whoever touches this next

The report could not simply be regenerated: `validate_output.py` now fails on its own
output tree, because `year` is both a file column and a hive partition key —

```
pyarrow.lib.ArrowTypeError: Unable to merge: Field year has incompatible types:
string vs dictionary<values=int32, indices=int32, ordered=0>
```

Reading the parquet files directly, without hive partitioning, is the workaround. That
is worth fixing if the script is reused, but it blocks nothing today, so it is left
out of this PR rather than bundled into an unrelated one-line correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the validation report to reflect the corrected `dicionario` row count of 247 entries.
  - The report’s existing JSON structure remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->