### PR TITLE
fix(br_bd_execucao_estadual): two defects the first production run exposed

### DIFF
--- a/models/br_bd_execucao_estadual/code/clean_pe.py
+++ b/models/br_bd_execucao_estadual/code/clean_pe.py
@@ -167,7 +167,7 @@ def harmonise(
         con.execute(
             f"COPY (SELECT * FROM read_parquet('{d}/data_*.parquet', "
             f"                                 union_by_name=true) "
-            f"      WHERE ano = {year}) "
+            f"      WHERE ano = '{year}') "
             f"TO '{tmp}' (FORMAT PARQUET, COMPRESSION SNAPPY)"
         )
     for part in parts:
@@ -220,7 +220,11 @@ def clean(
         # authority for which exercise the row was published under; the empenho year is
         # recovered separately in dbt.
         con.execute(
-            f"COPY (SELECT {year} AS ano, * FROM {_relation(path)}) "
+            # Quoted so `ano` is VARCHAR like every other column: `all_varchar` makes
+            # the source columns strings, but a bare {year} literal is an INTEGER, and
+            # that one typed column is enough for BigQuery to reject the whole file
+            # against the all-STRING schema dump_header declares.
+            f"COPY (SELECT '{year}' AS ano, * FROM {_relation(path)}) "
             f"TO '{out}' (FORMAT PARQUET, COMPRESSION SNAPPY)"
         )
         n = con.execute(

--- a/models/br_bd_execucao_estadual/code/download_sp.py
+++ b/models/br_bd_execucao_estadual/code/download_sp.py
@@ -176,7 +176,7 @@ class Sigeo:
             dict(query, **{SP_CTL + "btnPesquisar": "Pesquisar"})
         ).text
         if "gdvDespesas" not in searched:
-            raise RuntimeError(
+            raise NoResultGridError(
                 f"{year}/{orgao}: search returned no result grid"
             )
         self.html = searched
@@ -209,6 +209,21 @@ def _orgao_of(content: bytes) -> str | None:
     return None
 
 
+class NoResultGridError(RuntimeError):
+    """SIGEO answered normally, with no expenditure for that (exercise, órgão).
+
+    Distinct from every other failure mode on purpose. Órgãos are queried as a full
+    year x órgão grid, but a secretariat only answers for the exercises in which it
+    existed -- SECRETARIA DE GESTAO E GOVERNO DIGITAL has nothing in 2010. Treating
+    that as a fetch failure aborts the whole scrape, which is what happened on the
+    first production run: 35 empty pairs out of 544, and the run died having already
+    downloaded 509 good files.
+
+    509 + 35 = 544 is the whole grid, and 509 is exactly what the onboarding scrape
+    produced, so these are the same legitimately-empty pairs, not lost data.
+    """
+
+
 def main(
     first_year: int = SP_FIRST_YEAR,
     last_year: int = SP_LAST_YEAR,
@@ -223,6 +238,7 @@ def main(
     )
 
     failures: list[str] = []
+    empty: list[str] = []
     for year in years:
         for code, label in orgaos:
             dest = SP_INPUT / f"despesa_{year}_{code}.csv"
@@ -242,6 +258,11 @@ def main(
                     # failure from poisoning every subsequent export with stale
                     # viewstate.
                     candidate = Sigeo().query(year, code)
+                except NoResultGridError as exc:
+                    # Expected for a body that did not exist in that exercise.
+                    print(f"  {year} {code} {label}: {exc}")
+                    empty.append(f"{year}/{code}")
+                    break
                 except (requests.RequestException, RuntimeError) as exc:
                     print(f"  {year} {code} {label}: {exc}")
                     break
@@ -256,16 +277,42 @@ def main(
                 )
                 time.sleep(pause)
             if content is None:
-                failures.append(f"{year}/{code}")
+                if f"{year}/{code}" not in empty:
+                    failures.append(f"{year}/{code}")
                 continue
             dest.write_bytes(content)
             print(f"  {year} {code}: {len(content) / 1024:.0f} KB", flush=True)
             time.sleep(pause)
 
+    attempted = len(years) * len(orgaos)
+    if empty:
+        print(
+            f"EMPTY {len(empty)} of {attempted} (exercise, órgão) pairs "
+            f"had no expenditure: {sorted(empty)}"
+        )
+    # An empty is normal; empty EVERYWHERE means SIGEO changed under us and the grid
+    # detection now matches nothing. Only the total case is treated as broken: a large
+    # empty share is legitimate early in an exercise, when most órgãos have not spent
+    # yet, and an incremental run attempts a single year -- refusing on a majority
+    # would fail every January for no reason.
+    if attempted and len(empty) == attempted:
+        print(
+            f"REFUSING: all {attempted} pairs came back empty — that is a broken "
+            "scrape, not a sparse grid"
+        )
+        raise SystemExit(1)
+    if empty and len(empty) > attempted // 2:
+        print(
+            f"  WARNING {len(empty)}/{attempted} pairs empty — high, but accepted; "
+            "expected early in an exercise"
+        )
     if failures:
         print(f"FAILED {len(failures)}: {failures}")
         raise SystemExit(1)
-    print("SP download complete")
+    print(
+        f"SP download complete ({attempted - len(empty)} with data, "
+        f"{len(empty)} legitimately empty)"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two independent defects, each found by an actual production run, each invisible in dev. Both block the dataset reaching prod.

## 1. Pernambuco's `ano` was the only typed column in the dataset

The MG/BA/PE run uploaded all 49 staging mirrors and then failed on the first dbt model:

```
Error while reading table: basedosdados-staging...pe_despesa,
error message: Parquet column 'ano' has type INT32 which does not match the target cpp_type STRING
```

`clean_pe` stamps the exercise onto each row from the filename with `SELECT {year} AS ano`. duckdb types that bare literal INTEGER while `all_varchar` makes every other column VARCHAR, so PE's three mirrors were the only ones whose parquet was not all-STRING. Confirmed by reading the parquet schema of every mirror in the dataset: exactly `pe_despesa`, `pe_despesa_legado`, `pe_pagamento`, `ano` int32, in both header and data files.

**Why dev never caught it.** Dev's external tables were created during onboarding by `upload.py`, which infers the schema from the data, so a typed column was fine. The flow creates them via `dump_header`, which stringifies — the table declares STRING, the file carries INT32, BigQuery refuses the read. Four green dev runs could not have found this, because dev's tables predated the flow.

Verified on a real PE file: bare literal → `ano int32`; quoted → `ano string`, no non-string column left. dbt is unaffected (both PE models already `safe_cast(ano as int64)`).

## 2. São Paulo treated an empty órgão as a fetch failure

The SP run downloaded 509 files and then died:

```
FAILED 35: ['2022/48000', '2021/48000', ..., '2010/54000']
```

All 35 are expected gaps. SIGEO is queried as a full year × órgão grid, but a secretariat only answers for exercises in which it existed — `SECRETARIA DE GESTAO E GOVERNO DIGITAL` has nothing in 2010. **509 + 35 = 544** is the whole grid, and 509 is exactly what the onboarding scrape produced, so these are the same legitimately-empty pairs. No data was lost; the run refused to admit it had finished.

`Sigeo.query` raised a bare `RuntimeError` for "no result grid", indistinguishable in `main` from a session drop or truncated export. Now it raises `NoResultGridError`, caught ahead of the generic handler and collected separately. Real failures still abort.

The empty stays **observable** rather than becoming quiet loss: the pairs are listed, and the run refuses if *every* pair came back empty — which would mean the grid detection stopped matching, not that the state stopped spending. Deliberately not a majority threshold: an incremental run attempts one exercise, and early in a year most órgãos genuinely have not spent, so a majority rule would fail every January.

## Follow-up

Re-run both production flows with `full_refresh=True`. The 49 mirrors are already uploaded and their external tables exist in `basedosdados-staging`; PE's three are rebuilt as all-STRING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of searches that legitimately return no results, preventing them from being incorrectly reported as failures.
  * Empty result sets no longer cause a failure status or unsuccessful completion code.
  * Added safeguards and warnings when all, or most, attempted searches return no data.
  * Exercise-year values now remain consistent with the dataset schema during export and subsequent processing.

* **Enhancements**
  * Completion summaries now separately report searches with data, empty results, and actual failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->