### PR TITLE
feat(us_cfpb_complaints): add daily recurring Prefect pipeline

### DIFF
--- a/models/us_cfpb_complaints/CLAUDE.md
+++ b/models/us_cfpb_complaints/CLAUDE.md
@@ -112,7 +112,7 @@ Run from `code/`; scratch defaults to `~/Downloads/us_cfpb_complaints_data`
 | Script | What it does |
 |---|---|
 | `gen_architecture.py` | Writes `sheet_complaint.tsv` / `sheet_dicionario.tsv` — the source of truth |
-| `common.py` | Paths, architecture parsing, USPS→FIPS state crosswalk |
+| `common.py` | Scratch paths; re-exports the shared transform from `pipelines/datasets/us_cfpb_complaints/utils.py` |
 | `download.py` | Downloads + unzips the bulk export |
 | `clean.py` | Streams the CSV → all-STRING parquet, hive-partitioned by year |
 | `gen_dicionario.py` | Builds `dicionario` from the cleaned parquet |
@@ -153,20 +153,75 @@ which drops the production table too.
 well as test time. `tags` and `consumer_complaint_narrative` are exempted: both are
 legitimately sparse in recent years.
 
-## Planned recurring pipeline (not built yet)
+## Recurring pipeline
 
-Daily source; full-snapshot export. The intended shape:
+`pipelines/datasets/us_cfpb_complaints/` — daily, `us_cfpb_complaints_flow`, cron
+`45 7 * * *` America/Sao_Paulo (hour 7 already holds 23, 37 and 51, so 45 keeps five
+minutes' spacing; never default the minute to `0`).
 
-- Download the snapshot, clean it, and **append only complaints whose `complaint_id`
-  is new** — the table is not rebuilt from the snapshot.
-- **An update path for recent partitions is mandatory, not optional.** Existing rows
-  change: `company_response_to_consumer` moves off `In progress`, `timely_response`
-  resolves, `company_public_response` is published within 180 days, and narratives are
-  added months later (hence the 2.4% figure for 2026). Re-cleaning and replacing the
-  current and previous year's partitions on each run covers all four.
-- Daily cadence ⇒ **BD Pro rolling window** applies to `complaint` (`PartBdpro`);
-  `dicionario` has no date column and takes no coverage spec. The pro Coverage
-  (`is_closed=True`) must exist **before** the spec is switched or the run hard-fails
-  at `assert_coverage_topology`.
-- Verify a manual dev run (`materialize_to_prod: False, update_metadata: False,
-  force_run: True`) before arming.
+**The transform lives in `pipelines/datasets/us_cfpb_complaints/utils.py`** and the
+scripts under `code/` import it, so the bootstrap and the pipeline cannot drift. The
+port was verified against the validated bootstrap output: identical row counts per
+year, identical `state_without_fips` (4,327), identical `dicionario` (587 rows), and
+a value-level hash match on `year=2011`, `year=2017`, `year=2026` and `dicionario`.
+
+### Why every partition is rewritten each run
+
+The CFPB publishes a **full snapshot daily**, and complaints are not only added, they
+are revised: `company_response_to_consumer` moves off `In progress`,
+`timely_response` resolves, `company_public_response` is published within 180 days,
+and the narrative arrives months later once scrubbed (2.4% of 2026 complaints carry
+one, against 21.9% overall). An append-only load keyed on `complaint_id` would miss
+all four. Rewriting everything is cheap because parsing the 9.3 GB CSV has to happen
+regardless; the BigQuery cost is one scan of ~1.4 GB of parquet.
+
+`dicionario` is regenerated every run too — a taxonomy revision introduces new values,
+and `complaint`'s `custom_dictionary_coverage` test fails if the register lags.
+
+### Two things in the flow that are not stylistic
+
+- **`dump_mode="append"`, never `"overwrite"`.** Overwrite calls
+  `tb.delete(mode="all")`, which drops the **production** table, and it fires from
+  the dev half of the flow too. Append ends in `Storage.upload(if_exists="replace")`,
+  which replaces each partition blob wholesale — same end state, no delete.
+- **Every table is built before any is tested**, in both environments (`dbt_command="run"`
+  in one loop, `"test"` in a second). `complaint`'s `custom_dictionary_coverage` test
+  reads `dicionario` through `ref()`; interleaved per table, it runs before
+  `dicionario` exists and fails with `Not found: Table ... us_cfpb_complaints.dicionario`.
+  A re-run hides this, because a stale sibling survives — so it only bites in a clean
+  environment, which is prod.
+
+### BD Pro rolling window — NOT yet armed, needs a decision
+
+The flow declares `PartBdpro(free_lag=6 months)` on `complaint`, per the house rule
+that any table refreshed monthly or more often paywalls its most recent window. This
+has **not** been applied to any backend yet, and the pipeline will hard-fail at
+`assert_coverage_topology` until it is:
+
+    part_bdpro exige Coverage free + pro
+
+**Before arming**, either
+(a) create the pro Coverage on staging and prod —
+`create_update_coverage(table_id=…, area_id=<us>, is_closed=True, env=…)` plus its
+`DateTimeRange` with `is_closed=True`, free ending at `source_end - 6 months` and pro
+starting the next day (they must not overlap) — or
+(b) change `_COVERAGE` to `AllFree(date_column=DateOnly(col="date_received"),
+date_format=DateFormat.YEAR_MD)` and leave the table fully open.
+
+`compute_coverage_ranges`, `assert_coverage_topology` and `needs_row_access_policy`
+are pure and unit-testable; `apply_row_access_policies` issues real BigQuery DDL and
+needs the worker's rights, so the paywall itself is **not** exercisable locally.
+
+### Verification status
+
+Local checks pass: flow imports, `deploy_flows.load_flows_from_file` discovers
+`us_cfpb_complaints_flow`, transform parity against the bootstrap, ruff, and pyrefly
+(0 diagnostics). **The dev run has not happened** — it needs the PR pushed with the
+`deploy-flow` label, then a manual trigger with
+`{"materialize_to_prod": False, "update_metadata": False, "force_run": True}`. All
+three matter: the flow defaults to `materialize_to_prod=True, update_metadata=True`,
+and the metadata tasks are pinned `env="prod"` even from the dev pool.
+
+Green does not mean ingested: the poll guard returns early and Prefect still reports
+`COMPLETED`. Read the logs for `dbt run OK` + `dbt test OK` on both tables, and check
+the clone path is `/app/pipelines-<branch>/`, not `/app/pipelines-main/`.

--- a/models/us_cfpb_complaints/code/clean.py
+++ b/models/us_cfpb_complaints/code/clean.py
@@ -1,151 +1,16 @@
-"""Clean the CFPB Consumer Complaint Database bulk export into staging parquet.
+"""Clean the CFPB bulk export into staging parquet (one-shot onboarding entry point).
 
-Reads the 9.3 GB single-file CSV export with Python's ``csv`` module — the narratives
-contain embedded newlines inside quoted fields, which DuckDB's parallel reader
-desynchronises on — and streams it out as Snappy parquet hive-partitioned by year.
+The transform lives in ``pipelines/datasets/us_cfpb_complaints/utils.py`` and is shared
+with the recurring pipeline; this is only the CLI around it.
 
-Every column is written as STRING. Staging is all-STRING by Data Basis convention:
-``pipelines.utils.gcs.dump_header`` stringifies the header file BigQuery infers the
-staging schema from, so typed parquet is rejected once the recurring pipeline writes
-to the same staging dataset. The dbt model ``safe_cast``s each column to its
-architecture type. Values are cast to string by writing them as text, never by
-``astype(str)``, which would turn a NULL into the literal ``"nan"``.
-
-The transform is deliberately narrow: it renames columns to the architecture, derives
-``year`` and ``state_id``, trims whitespace and maps empty strings to NULL. It does
-not reclassify product/issue values across the 2017 and 2023 taxonomy revisions.
+    python clean.py                  # full run over <DATA_DIR>/input
+    python clean.py --limit 200000   # smoke test
 """
 
 import argparse
-import csv
-import sys
-import time
-from collections import Counter, defaultdict
 from pathlib import Path
 
-import pyarrow as pa
-import pyarrow.parquet as pq
-from common import COMPLAINT, CSV_NAME, INPUT, OUTPUT, load_cols, state_id_for
-
-csv.field_size_limit(sys.maxsize)
-
-# Rows buffered per year before a row group is flushed. Bounds peak RAM at roughly
-# (n_years x FLUSH_ROWS) rows held as Python strings.
-FLUSH_ROWS = 50_000
-
-
-def clean_complaint(
-    csv_path: Path, output_dir: Path, limit: int | None = None
-) -> dict:
-    """Stream the bulk CSV into ``<output_dir>/complaint/year=<YYYY>/data.parquet``.
-
-    Args:
-        csv_path: The unzipped ``complaints.csv``.
-        output_dir: Root output directory.
-        limit: Stop after this many source records (for smoke tests).
-
-    Returns:
-        Counters describing the run: rows per year and data-quality tallies.
-    """
-    cols = load_cols(COMPLAINT)
-    order = [c.name for c in cols]
-    schema = pa.schema([pa.field(n, pa.string()) for n in order])
-    # architecture column -> source header, for the columns read straight through
-    src_of = {c.name: c.original for c in cols}
-
-    tdir = output_dir / COMPLAINT
-    tdir.mkdir(parents=True, exist_ok=True)
-
-    writers: dict[str, pq.ParquetWriter] = {}
-    buf: dict[str, list[list]] = defaultdict(list)
-    per_year = Counter()
-    stats = Counter()
-    t0 = time.time()
-
-    def flush(year: str) -> None:
-        rows = buf[year]
-        if not rows:
-            return
-        arrays = [
-            pa.array([r[i] for r in rows], type=pa.string())
-            for i in range(len(order))
-        ]
-        table = pa.Table.from_arrays(arrays, schema=schema)
-        w = writers.get(year)
-        if w is None:
-            pdir = tdir / f"year={year}"
-            pdir.mkdir(parents=True, exist_ok=True)
-            w = pq.ParquetWriter(
-                pdir / "data.parquet", schema, compression="snappy"
-            )
-            writers[year] = w
-        w.write_table(table)
-        buf[year] = []
-
-    n = 0
-    with open(csv_path, encoding="utf-8", newline="") as fh:
-        reader = csv.DictReader(fh)
-        missing = [
-            c.original
-            for c in cols
-            if c.original and c.original not in (reader.fieldnames or [])
-        ]
-        if missing:
-            raise SystemExit(
-                f"source CSV is missing expected columns: {missing}\n"
-                f"header seen: {reader.fieldnames}"
-            )
-        extra = [
-            f
-            for f in (reader.fieldnames or [])
-            if f not in set(src_of.values())
-        ]
-        if extra:
-            # Not fatal, but never silent: a new source column must be a decision.
-            print(f"WARNING: source columns not in the architecture: {extra}")
-
-        for rec in reader:
-            n += 1
-            date_received = (rec["Date received"] or "").strip()
-            year = date_received[:4]
-            if len(date_received) != 10 or not year.isdigit():
-                stats["bad_date_received"] += 1
-                continue
-
-            published_state = (rec["State"] or "").strip()
-            sid = state_id_for(published_state)
-            if published_state and sid is None:
-                stats["state_without_fips"] += 1
-
-            out = []
-            for c in cols:
-                if c.name == "year":
-                    out.append(year)
-                elif c.name == "state_id":
-                    out.append(sid)
-                else:
-                    v = rec[c.original]
-                    v = v.strip() if v is not None else ""
-                    out.append(v if v != "" else None)
-            buf[year].append(out)
-            per_year[year] += 1
-            if len(buf[year]) >= FLUSH_ROWS:
-                flush(year)
-            if n % 2_000_000 == 0:
-                print(
-                    f"  ...{n:,} rows  ({time.time() - t0:.0f}s)", flush=True
-                )
-            if limit and n >= limit:
-                break
-
-    for year in list(buf):
-        flush(year)
-    for w in writers.values():
-        w.close()
-
-    stats["source_rows"] = n
-    stats["written_rows"] = sum(per_year.values())
-    return {"per_year": dict(per_year), "stats": dict(stats)}
+from common import COMPLAINT, CSV_NAME, INPUT, OUTPUT, clean_complaint
 
 
 def main() -> None:
@@ -156,12 +21,13 @@ def main() -> None:
     args = ap.parse_args()
 
     res = clean_complaint(args.csv, args.output, args.limit)
-    print("\n=== ROWS PER YEAR ===")
+    print(f"\n=== {COMPLAINT}: ROWS PER YEAR ===")
     for y in sorted(res["per_year"]):
         print(f"  {y}  {res['per_year'][y]:>10,}")
     print("\n=== STATS ===")
     for k, v in sorted(res["stats"].items()):
         print(f"  {k:24s} {v:>12,}")
+    print(f"\nmax date_received: {res['max_date_received']}")
 
 
 if __name__ == "__main__":

--- a/models/us_cfpb_complaints/code/common.py
+++ b/models/us_cfpb_complaints/code/common.py
@@ -1,17 +1,40 @@
-"""Shared paths, architecture parsing and lookups for the us_cfpb_complaints onboarding.
+"""Scratch paths for the us_cfpb_complaints onboarding, plus the shared transform.
 
-Scratch data lives under ``~/Downloads/us_cfpb_complaints_data/`` (never in the repo
-or in Dropbox), overridable via ``CFPB_COMPLAINTS_DATA_DIR``. The architecture TSVs
-in this directory are the source of truth for column names, order, types and the
-raw -> clean name mapping; they are produced by ``gen_architecture.py``.
+The cleaning transform itself lives in ``pipelines/datasets/us_cfpb_complaints/utils.py``
+and is imported here rather than duplicated, so the one-shot bootstrap and the
+recurring pipeline can never drift. This module only adds what the bootstrap needs on
+top: where the scratch data lives.
+
+Scratch data goes under ``~/Downloads/us_cfpb_complaints_data/`` (never in the repo or
+in Dropbox), overridable via ``CFPB_COMPLAINTS_DATA_DIR``. The architecture TSVs in
+this directory remain the source of truth for column names, order, types and the
+raw -> clean name mapping; ``gen_architecture.py`` writes them.
 """
 
-import csv
 import os
-from dataclasses import dataclass
+import sys
 from pathlib import Path
 
 CODE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = CODE_DIR.parents[2]
+# These scripts run from their own directory with bare sibling imports, so the repo
+# root is not otherwise importable.
+sys.path.insert(0, str(REPO_ROOT))
+
+from pipelines.datasets.us_cfpb_complaints.constants import (  # noqa: E402
+    constants,
+)
+from pipelines.datasets.us_cfpb_complaints.utils import (  # noqa: E402,F401
+    Col,
+    assert_all_string,
+    build_dicionario,
+    clean_all,
+    clean_complaint,
+    download_snapshot,
+    load_cols,
+    state_id_for,
+)
+
 DATA_DIR = Path(
     os.environ.get(
         "CFPB_COMPLAINTS_DATA_DIR",
@@ -21,143 +44,13 @@ DATA_DIR = Path(
 INPUT = DATA_DIR / "input"
 OUTPUT = DATA_DIR / "output"
 
-DATASET_ID = "us_cfpb_complaints"
-COMPLAINT = "complaint"
-DICIONARIO = "dicionario"
+DATASET_ID = constants.DATASET_ID.value
+COMPLAINT = constants.COMPLAINT.value
+DICIONARIO = constants.DICIONARIO.value
 
-CSV_NAME = "complaints.csv"
-ZIP_NAME = "complaints.csv.zip"
-BULK_URL = "https://files.consumerfinance.gov/ccdb/complaints.csv.zip"
-
-# Columns whose values are enumerated in the `dicionario` table. The CFPB publishes
-# these as readable labels rather than codes, so `dicionario.valor` repeats
-# `dicionario.chave`; the information the dictionary adds is `cobertura_temporal`,
-# which records the taxonomy revisions of April 2017 and August 2023.
-DICT_COLUMNS = [
-    "product",
-    "sub_product",
-    "issue",
-    "sub_issue",
-    "tags",
-    "submitted_via",
-    "company_public_response",
-    "company_response_to_consumer",
-    "timely_response",
-]
-
-# USPS abbreviation -> FIPS state code, taken from
-# `basedosdados.br_bd_diretorios_us.state` (columns `abbreviation`, `id_state`),
-# which is the directory `state_id` links to. Military post codes (AA, AE, AP) are
-# deliberately absent: they are not states and have no FIPS code.
-STATE_FIPS = {
-    "AK": "02",
-    "AL": "01",
-    "AR": "05",
-    "AS": "60",
-    "AZ": "04",
-    "CA": "06",
-    "CO": "08",
-    "CT": "09",
-    "DC": "11",
-    "DE": "10",
-    "FL": "12",
-    "FM": "64",
-    "GA": "13",
-    "GU": "66",
-    "HI": "15",
-    "IA": "19",
-    "ID": "16",
-    "IL": "17",
-    "IN": "18",
-    "KS": "20",
-    "KY": "21",
-    "LA": "22",
-    "MA": "25",
-    "MD": "24",
-    "ME": "23",
-    "MH": "68",
-    "MI": "26",
-    "MN": "27",
-    "MO": "29",
-    "MP": "69",
-    "MS": "28",
-    "MT": "30",
-    "NC": "37",
-    "ND": "38",
-    "NE": "31",
-    "NH": "33",
-    "NJ": "34",
-    "NM": "35",
-    "NV": "32",
-    "NY": "36",
-    "OH": "39",
-    "OK": "40",
-    "OR": "41",
-    "PA": "42",
-    "PR": "72",
-    "PW": "70",
-    "RI": "44",
-    "SC": "45",
-    "SD": "46",
-    "TN": "47",
-    "TX": "48",
-    "UM": "74",
-    "UT": "49",
-    "VA": "51",
-    "VI": "78",
-    "VT": "50",
-    "WA": "53",
-    "WI": "55",
-    "WV": "54",
-    "WY": "56",
-}
-
-# The CFPB publishes this one territory as a literal name where every other row
-# carries a two-letter code. Mapped to the same FIPS code as `UM`; the published
-# spelling is preserved untouched in `state_abbreviation`.
-STATE_ALIASES = {"UNITED STATES MINOR OUTLYING ISLANDS": "UM"}
-
-
-@dataclass
-class Col:
-    """One column of an architecture table."""
-
-    name: str  # clean BigQuery column name
-    bq_type: str  # INT64 / STRING / DATE
-    original: str  # header token in the source CSV, empty if derived
-    covered_by_dictionary: bool
-    directory_column: str
-    measurement_unit: str
-
-
-def load_cols(table: str) -> list[Col]:
-    """Load ordered column specs from the architecture TSV for a table."""
-    path = CODE_DIR / f"sheet_{table}.tsv"
-    cols = []
-    with open(path, encoding="utf-8") as fh:
-        for r in csv.DictReader(fh, delimiter="\t"):
-            cols.append(
-                Col(
-                    name=r["name"].strip(),
-                    bq_type=r["bigquery_type"].strip().upper(),
-                    original=r["original_name"].strip(),
-                    covered_by_dictionary=r["covered_by_dictionary"].strip()
-                    == "yes",
-                    directory_column=r["directory_column"].strip(),
-                    measurement_unit=r["measurement_unit"].strip(),
-                )
-            )
-    return cols
-
-
-def state_id_for(published_state: str) -> str | None:
-    """Map a published `State` value to its FIPS code, or None when there is none.
-
-    Returns None for the empty value, for the military post codes AA/AE/AP, and for
-    anything else absent from the directory — never a guess.
-    """
-    v = (published_state or "").strip()
-    if not v:
-        return None
-    v = STATE_ALIASES.get(v.upper(), v)
-    return STATE_FIPS.get(v.upper())
+CSV_NAME = constants.CSV_NAME.value
+ZIP_NAME = constants.ZIP_NAME.value
+BULK_URL = constants.BULK_URL.value
+DICT_COLUMNS = constants.DICT_COLUMNS.value
+STATE_FIPS = constants.STATE_FIPS.value
+STATE_ALIASES = constants.STATE_ALIASES.value

--- a/models/us_cfpb_complaints/code/download.py
+++ b/models/us_cfpb_complaints/code/download.py
@@ -1,110 +1,26 @@
 """Download and unzip the CFPB Consumer Complaint Database bulk export.
 
-    python download.py            # download + unzip into <DATA_DIR>/input
-    python download.py --keep-zip # leave the .zip in place afterwards
+The downloader lives in ``pipelines/datasets/us_cfpb_complaints/utils.py`` and is
+shared with the recurring pipeline; this is only the CLI around it.
 
-The bulk export at files.consumerfinance.gov is the only usable route. The
-documented REST/CSV API at www.consumerfinance.gov is behind Akamai, which returns
-"Access Denied" to scripted clients regardless of user agent, and since release 23
-(July 2026) its filtered CSV export is capped at 100,000 complaints and its JSON
-export has been discontinued.
+The bulk export is the only usable route. The documented REST/CSV API at
+www.consumerfinance.gov is behind Akamai, which returns "Access Denied" to scripted
+clients regardless of user agent, and since release 23 (July 2026) its filtered CSV
+export is capped at 100,000 complaints and its JSON export has been discontinued.
 
 The export is a full snapshot of the whole database refreshed daily, roughly 1.4 GB
 zipped and 9.3 GB as a single CSV.
+
+    python download.py
 """
 
 import argparse
-import shutil
-import subprocess
-import sys
-import time
 from pathlib import Path
 
-import requests
-from common import BULK_URL, CSV_NAME, INPUT, ZIP_NAME
-
-CHUNK = 8 * 1024 * 1024
-
-
-def head() -> dict:
-    """Return the export's Content-Length and Last-Modified without downloading."""
-    r = requests.head(BULK_URL, timeout=60, allow_redirects=True)
-    r.raise_for_status()
-    return {
-        "content_length": int(r.headers.get("content-length", 0)),
-        "last_modified": r.headers.get("last-modified", ""),
-    }
-
-
-def download(input_dir: Path) -> Path:
-    input_dir.mkdir(parents=True, exist_ok=True)
-    meta = head()
-    size = meta["content_length"]
-    print(f"source: {BULK_URL}")
-    print(f"  last-modified: {meta['last_modified']}")
-    print(f"  size:          {size / 1e9:.2f} GB")
-
-    zip_path = input_dir / ZIP_NAME
-    if zip_path.exists() and zip_path.stat().st_size == size:
-        print(f"  already downloaded: {zip_path}")
-        return zip_path
-
-    t0 = time.time()
-    got = 0
-    with requests.get(BULK_URL, stream=True, timeout=(30, 300)) as r:
-        r.raise_for_status()
-        # decode_content=True so a Content-Encoding'd body is decompressed rather
-        # than written as raw transport bytes.
-        r.raw.decode_content = True
-        with open(zip_path, "wb") as fh:
-            while True:
-                block = r.raw.read(CHUNK)
-                if not block:
-                    break
-                fh.write(block)
-                got += len(block)
-                if got % (256 * 1024 * 1024) < CHUNK:
-                    print(
-                        f"  ...{got / 1e9:.2f}/{size / 1e9:.2f} GB "
-                        f"({time.time() - t0:.0f}s)",
-                        flush=True,
-                    )
-    if size and zip_path.stat().st_size != size:
-        raise SystemExit(
-            f"short download: got {zip_path.stat().st_size} bytes, expected {size}"
-        )
-    print(f"  downloaded in {time.time() - t0:.0f}s -> {zip_path}")
-    return zip_path
-
-
-def unzip(zip_path: Path, input_dir: Path) -> Path:
-    csv_path = input_dir / CSV_NAME
-    print(f"unzipping -> {csv_path}")
-    subprocess.run(
-        ["unzip", "-o", str(zip_path), "-d", str(input_dir)],
-        check=True,
-        stdout=subprocess.DEVNULL,
-    )
-    if not csv_path.exists():
-        raise SystemExit(f"expected {csv_path} after unzip")
-    print(f"  {csv_path.stat().st_size / 1e9:.2f} GB")
-    return csv_path
-
-
-def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--input", type=Path, default=INPUT)
-    ap.add_argument("--keep-zip", action="store_true")
-    a = ap.parse_args()
-
-    if shutil.which("unzip") is None:
-        sys.exit("`unzip` not found on PATH")
-    zip_path = download(a.input)
-    unzip(zip_path, a.input)
-    if not a.keep_zip:
-        zip_path.unlink()
-        print(f"removed {zip_path}")
-
+from common import INPUT, download_snapshot
 
 if __name__ == "__main__":
-    main()
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--input", type=Path, default=INPUT)
+    csv_path = download_snapshot(ap.parse_args().input)
+    print(f"ready: {csv_path}")

--- a/models/us_cfpb_complaints/code/gen_dicionario.py
+++ b/models/us_cfpb_complaints/code/gen_dicionario.py
@@ -1,88 +1,22 @@
 """Build the `dicionario` table from the cleaned complaint parquet.
 
-The CFPB publishes its categorical fields as readable English labels rather than
-codes, so `valor` reproduces `chave`. What the dictionary adds is
-`cobertura_temporal`: the years in which each value actually appears. The complaint
-form's product/issue taxonomy was revised in April 2017 and again in August 2023 and
-values are preserved exactly as published, never remapped, so the same concept shows
-up under several labels with disjoint coverage — for example:
+The builder lives in ``pipelines/datasets/us_cfpb_complaints/utils.py`` and is shared
+with the recurring pipeline, which regenerates the register on every run; this is only
+the CLI around it.
 
-    product  Credit reporting                                              2012(1)2017
-    product  Credit reporting, credit repair services, or other personal…  2017(1)2023
-    product  Credit reporting or other personal consumer reports           2023(1)2026
-
-Reading the parquet rather than the raw CSV keeps the dictionary consistent with
-what is actually published to BigQuery.
+The CFPB publishes its categorical fields as readable English labels rather than codes,
+so `valor` reproduces `chave`. What the register adds is `cobertura_temporal`: the years
+in which each value actually appears, which exposes the April 2017 and August 2023
+revisions of the complaint form's taxonomy. Values are preserved as published, never
+remapped, so the same concept shows up under several labels with disjoint coverage.
 """
 
 import argparse
-from collections import defaultdict
 from pathlib import Path
 
-import pyarrow as pa
-import pyarrow.parquet as pq
-from common import COMPLAINT, DICIONARIO, DICT_COLUMNS, OUTPUT, load_cols
-
-
-def build(output_dir: Path) -> int:
-    """Write `<output_dir>/dicionario/data.parquet`; returns the row count."""
-    parts = sorted((output_dir / COMPLAINT).glob("year=*/data.parquet"))
-    if not parts:
-        raise SystemExit(
-            f"no complaint parquet under {output_dir / COMPLAINT}"
-        )
-
-    # (column, value) -> [min_year, max_year]
-    span: dict[tuple[str, str], list[int]] = defaultdict(lambda: [9999, 0])
-    for p in parts:
-        year = int(p.parent.name.split("=", 1)[1])
-        # ParquetFile.read, not pq.read_table: the latter infers a hive dataset from
-        # the `year=<YYYY>` directory and then refuses to merge that inferred
-        # dictionary<int32> `year` with the STRING `year` inside the file. BigQuery
-        # reads the in-file column, which is the one that matters.
-        tbl = pq.ParquetFile(p).read(columns=DICT_COLUMNS)
-        for col in DICT_COLUMNS:
-            for v in tbl.column(col).unique().to_pylist():
-                if v is None or v == "":
-                    continue
-                s = span[(col, v)]
-                s[0] = min(s[0], year)
-                s[1] = max(s[1], year)
-        print(f"  read {p.parent.name}", flush=True)
-
-    rows = []
-    for (col, value), (y0, y1) in sorted(span.items()):
-        rows.append(
-            {
-                "id_tabela": COMPLAINT,
-                "nome_coluna": col,
-                "chave": value,
-                # Data Basis temporal-coverage notation: START(INTERVAL)END
-                "cobertura_temporal": f"{y0}(1){y1}",
-                "valor": value,
-            }
-        )
-
-    order = [c.name for c in load_cols(DICIONARIO)]
-    schema = pa.schema([pa.field(n, pa.string()) for n in order])
-    table = pa.Table.from_arrays(
-        [pa.array([r[n] for r in rows], type=pa.string()) for n in order],
-        schema=schema,
-    )
-    ddir = output_dir / DICIONARIO
-    ddir.mkdir(parents=True, exist_ok=True)
-    pq.write_table(table, ddir / "data.parquet", compression="snappy")
-
-    print(f"\nwrote {ddir / 'data.parquet'}  ({len(rows)} rows)")
-    per_col: dict[str, int] = defaultdict(int)
-    for r in rows:
-        per_col[r["nome_coluna"]] += 1
-    for col in DICT_COLUMNS:
-        print(f"  {col:32s} {per_col[col]:>4} values")
-    return len(rows)
-
+from common import OUTPUT, build_dicionario
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--output", type=Path, default=OUTPUT)
-    build(ap.parse_args().output)
+    build_dicionario(ap.parse_args().output)

--- a/pipelines/datasets/us_cfpb_complaints/constants.py
+++ b/pipelines/datasets/us_cfpb_complaints/constants.py
@@ -1,0 +1,131 @@
+"""Constants for the us_cfpb_complaints recurring pipeline (Prefect 3).
+
+CFPB Consumer Complaint Database. See models/us_cfpb_complaints/CLAUDE.md for the
+full design, including why the documented REST API is unusable and why the CSV is
+parsed with Python's ``csv`` rather than DuckDB.
+"""
+
+from enum import Enum
+from pathlib import Path
+
+# Repo root, then the committed architecture TSVs (the single schema source of
+# truth — column order, bigquery_type and the raw -> clean name mapping).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class constants(Enum):
+    """Constants for the us_cfpb_complaints pipeline.
+
+    Lowercase class name follows the repo-wide convention for dataset constant
+    enums. ``ARCHITECTURE_DIR`` points at the architecture TSVs under
+    ``models/us_cfpb_complaints/code/``, shared with the one-shot bootstrap.
+    """
+
+    DATASET_ID = "us_cfpb_complaints"
+
+    COMPLAINT = "complaint"
+    DICIONARIO = "dicionario"
+    # Order matters: dbt builds complaint first, but every table is built before
+    # any is tested — complaint's custom_dictionary_coverage test reads dicionario.
+    ALL_TABLES = ["complaint", "dicionario"]
+
+    ARCHITECTURE_DIR = _REPO_ROOT / "models" / "us_cfpb_complaints" / "code"
+
+    # The full-database export, refreshed daily: ~1.4 GB zipped, 9.3 GB as CSV.
+    # The documented REST API at www.consumerfinance.gov is behind Akamai and
+    # returns "Access Denied" to every scripted client, so this is the only route.
+    BULK_URL = "https://files.consumerfinance.gov/ccdb/complaints.csv.zip"
+    ZIP_NAME = "complaints.csv.zip"
+    CSV_NAME = "complaints.csv"
+
+    # Columns enumerated in the `dicionario` table. The CFPB publishes these as
+    # readable labels rather than codes, so `valor` repeats `chave`; the register
+    # exists for `cobertura_temporal`, which exposes the April 2017 and August
+    # 2023 revisions of the complaint form's taxonomy.
+    DICT_COLUMNS = [
+        "product",
+        "sub_product",
+        "issue",
+        "sub_issue",
+        "tags",
+        "submitted_via",
+        "company_public_response",
+        "company_response_to_consumer",
+        "timely_response",
+    ]
+
+    # USPS abbreviation -> FIPS state code, from
+    # `basedosdados.br_bd_diretorios_us.state` (`abbreviation`, `id_state`), the
+    # directory `state_id` links to. The military post codes AA, AE and AP are
+    # deliberately absent: they are not states and have no FIPS code.
+    STATE_FIPS = {
+        "AK": "02",
+        "AL": "01",
+        "AR": "05",
+        "AS": "60",
+        "AZ": "04",
+        "CA": "06",
+        "CO": "08",
+        "CT": "09",
+        "DC": "11",
+        "DE": "10",
+        "FL": "12",
+        "FM": "64",
+        "GA": "13",
+        "GU": "66",
+        "HI": "15",
+        "IA": "19",
+        "ID": "16",
+        "IL": "17",
+        "IN": "18",
+        "KS": "20",
+        "KY": "21",
+        "LA": "22",
+        "MA": "25",
+        "MD": "24",
+        "ME": "23",
+        "MH": "68",
+        "MI": "26",
+        "MN": "27",
+        "MO": "29",
+        "MP": "69",
+        "MS": "28",
+        "MT": "30",
+        "NC": "37",
+        "ND": "38",
+        "NE": "31",
+        "NH": "33",
+        "NJ": "34",
+        "NM": "35",
+        "NV": "32",
+        "NY": "36",
+        "OH": "39",
+        "OK": "40",
+        "OR": "41",
+        "PA": "42",
+        "PR": "72",
+        "PW": "70",
+        "RI": "44",
+        "SC": "45",
+        "SD": "46",
+        "TN": "47",
+        "TX": "48",
+        "UM": "74",
+        "UT": "49",
+        "VA": "51",
+        "VI": "78",
+        "VT": "50",
+        "WA": "53",
+        "WI": "55",
+        "WV": "54",
+        "WY": "56",
+    }
+
+    # The CFPB publishes this one territory as a literal name where every other
+    # row carries a two-letter code. Mapped to the same FIPS code as `UM`; the
+    # published spelling stays untouched in `state_abbreviation`.
+    STATE_ALIASES = {"UNITED STATES MINOR OUTLYING ISLANDS": "UM"}
+
+    # Rows buffered per year before a parquet row group is flushed. Bounds peak
+    # RAM at roughly (n_years x FLUSH_ROWS) rows held as Python strings.
+    FLUSH_ROWS = 50_000

--- a/pipelines/datasets/us_cfpb_complaints/flows.py
+++ b/pipelines/datasets/us_cfpb_complaints/flows.py
@@ -1,0 +1,217 @@
+"""
+Flows for us_cfpb_complaints — Prefect 3.
+
+CFPB Consumer Complaint Database. The CFPB publishes a **full snapshot of the whole
+database every day**, so each run re-cleans the entire export and rewrites every year
+partition. That is deliberate rather than lazy: complaints do not only get added, they
+get *revised*. On an existing row, ``company_response_to_consumer`` moves off
+``In progress``, ``timely_response`` resolves, ``company_public_response`` is published
+within 180 days, and the consumer narrative arrives months later once the CFPB has
+scrubbed it (only 2.4% of 2026 complaints carry one, against 21.9% overall). An
+append-only load keyed on ``complaint_id`` would capture none of those.
+
+Rewriting everything is cheap here because the expensive step — parsing the 9.3 GB CSV —
+has to happen regardless. The BigQuery cost is one scan of the ~1.4 GB parquet.
+
+``dump_mode="append"`` is load-bearing: ``"overwrite"`` calls ``tb.delete(mode="all")``,
+which drops the **production** table, and fires from the dev half of the flow too. With
+``"append"`` the upload ends in ``Storage.upload(if_exists="replace")``, which replaces
+each partition blob wholesale — the same end state, without the delete.
+
+Deploy: `.github/scripts/deploy_flows.py` auto-discovers `us_cfpb_complaints_flow`; the
+dev pool ignores the schedule, the prod pool activates it.
+"""
+
+import shutil
+import tempfile
+
+from prefect import flow
+
+from pipelines.datasets.us_cfpb_complaints.constants import constants
+from pipelines.datasets.us_cfpb_complaints.tasks import (
+    clean_complaints,
+    download_complaints,
+)
+from pipelines.utils.metadata.domain import (
+    DateFormat,
+    DateOnly,
+    FreeLag,
+    PartBdpro,
+)
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+COMPLAINT = constants.COMPLAINT.value
+DICIONARIO = constants.DICIONARIO.value
+
+# Coverage spec per table.
+#
+# `complaint` refreshes daily, so it carries the BD Pro rolling window: the most
+# recent 6 months are pro-only, everything older is free. Each run recomputes
+# free_end = source_end - free_lag, rewrites both DateTimeRanges, and re-issues the
+# BigQuery Row Access Policies, so the window slides forward on its own.
+#
+# part_bdpro requires BOTH a free (is_closed=False) and a pro (is_closed=True)
+# Coverage to already exist on the table, or assert_coverage_topology raises before
+# anything is written.
+#
+# `dicionario` has no date column, so it takes no coverage spec at all.
+_COVERAGE = {
+    COMPLAINT: PartBdpro(
+        date_column=DateOnly(col="date_received"),
+        date_format=DateFormat.YEAR_MD,
+        free_lag=FreeLag(unit="months", value=6),
+    ),
+}
+
+
+@flow(name="us_cfpb_complaints", log_prints=True)
+def us_cfpb_complaints_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+) -> None:
+    """Refresh the CFPB Consumer Complaint Database from the daily full snapshot.
+
+    Args:
+        materialize_to_prod: Continue past the dev materialization to write the prod
+            staging bucket and run dbt against ``target="prod"``. Set False to
+            exercise only the dev half — required for a safe test run, since the
+            default writes production and applies the Row Access Policies.
+        update_metadata: After a successful prod materialization, register table
+            coverage and commit the source update. Has no effect when
+            ``materialize_to_prod`` is False.
+        force_run: Materialize even when the source poll reports nothing new.
+    """
+    # pyrefly: ignore [unused-coroutine]
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id=COMPLAINT
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="us_cfpb_complaints_")
+    try:
+        input_dir = download_complaints(work_dir=work_dir)
+        result = clean_complaints(work_dir=work_dir, input_dir=input_dir)
+        max_date = result["max_date_received"]
+        print(f"snapshot max date_received: {max_date}")
+        print(f"row counts: {result['row_counts']}")
+
+        # Skip the run when the CFPB has not published a newer complaint date.
+        # A scheduled run is then a cheap no-op — note Prefect still reports
+        # COMPLETED, so read the logs rather than the state to tell the two apart.
+        has_new_data = poll_source_for_update_task(
+            dataset_id=DATASET_ID,
+            table_id=COMPLAINT,
+            source_max_date=max_date,
+            env="prod",
+            date_format="%Y-%m-%d",
+            compare_against="coverage",
+        )
+        if not has_new_data and not force_run:
+            print("Não há novas atualizações na fonte original")
+            return
+
+        commit_source_update_task(
+            dataset_id=DATASET_ID,
+            table_id=COMPLAINT,
+            source_max_date=max_date,
+            env="prod",
+            date_format="%Y-%m-%d",
+            update_metadata=update_metadata,
+            materialize_after_dump=materialize_to_prod,
+        )
+
+        tables = constants.ALL_TABLES.value
+
+        # Build EVERY table before testing ANY of them, in both environments.
+        # complaint's custom_dictionary_coverage test reads dicionario via ref();
+        # interleaved run/test per table, that test would run before dicionario
+        # exists and fail with "Not found: Table ... us_cfpb_complaints.dicionario".
+        # A re-run hides it, because a stale sibling from an earlier build survives
+        # — so it only bites in a clean environment, which is exactly prod.
+        if not materialize_to_prod:
+            for table in tables:
+                upload_to_gcs(
+                    data_path=result[table],
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    bucket_name="basedosdados-dev",
+                    dump_mode="append",
+                    source_format="parquet",
+                )
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="run",
+                    target="dev",
+                )
+            for table in tables:
+                run_dbt(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    dbt_command="test",
+                    target="dev",
+                )
+            return
+
+        for table in tables:
+            upload_to_gcs(
+                data_path=result[table],
+                dataset_id=DATASET_ID,
+                table_id=table,
+                bucket_name="basedosdados",
+                dump_mode="append",
+                source_format="parquet",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="run",
+                target="prod",
+            )
+        for table in tables:
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=table,
+                dbt_command="test",
+                target="prod",
+            )
+
+        if update_metadata:
+            for table, coverage in _COVERAGE.items():
+                register_table_materialization_task(
+                    dataset_id=DATASET_ID,
+                    table_id=table,
+                    coverage=coverage,
+                    env="prod",
+                    bq_project="basedosdados",
+                )
+    finally:
+        # Covers both early returns (no new data, dev-only) and any exception. The
+        # snapshot is ~1.4 GB zipped and 9.3 GB unzipped, plus ~1.4 GB of parquet.
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# The CFPB refreshes the export daily, early UTC. Poll once a day at 07:45 BRT; the
+# source-poll guard no-ops when nothing new has landed. The minute is chosen, not
+# defaulted: hour 7 already holds 23 (daily), 37 and 51 (monthly), so 45 keeps at
+# least five minutes' spacing from each. Defaulting to :00 piles every pipeline onto
+# the same instant, where they compete for BigQuery slots and trip the daily quota
+# together.
+# pyrefly: ignore [missing-attribute]
+us_cfpb_complaints_flow.deploy_schedules = [
+    {"cron": "45 7 * * *", "timezone": "America/Sao_Paulo"}
+]
+# The clean step streams the CSV and buffers at most ~800k rows of Python strings,
+# but the 9.3 GB unzipped snapshot and ~1.4 GB of parquet share the pod's disk.
+# pyrefly: ignore [missing-attribute]
+us_cfpb_complaints_flow.job_variables = {"memory": "8Gi"}

--- a/pipelines/datasets/us_cfpb_complaints/tasks.py
+++ b/pipelines/datasets/us_cfpb_complaints/tasks.py
@@ -1,0 +1,49 @@
+"""Prefect 3 tasks for us_cfpb_complaints — thin wrappers over utils.py."""
+
+from pathlib import Path
+
+from prefect import task
+
+from pipelines.datasets.us_cfpb_complaints.utils import (
+    clean_all,
+    download_snapshot,
+)
+
+
+@task(retries=2, retry_delay_seconds=60)
+def download_complaints(work_dir: str) -> str:
+    """Download and unzip the CFPB full-database export.
+
+    Retries twice: the export is ~1.4 GB over a single connection and
+    files.consumerfinance.gov intermittently drops it — a broken pipe part-way
+    through was observed during the initial load.
+
+    Args:
+        work_dir: Directory to download into; files land in ``<work_dir>/input``.
+
+    Returns:
+        The input directory path, as a string (Prefect serializes task results).
+    """
+    input_dir = Path(work_dir) / "input"
+    download_snapshot(input_dir)
+    return str(input_dir)
+
+
+@task
+def clean_complaints(work_dir: str, input_dir: str) -> dict:
+    """Build both tables from the downloaded snapshot.
+
+    Args:
+        work_dir: Directory to write into; tables land under ``<work_dir>/output``.
+        input_dir: Directory holding the unzipped CSV, from :func:`download_complaints`.
+
+    Returns:
+        Table slug -> partitioned output directory (as strings), plus
+        ``"max_date_received"`` — the latest ``"YYYY-MM-DD"`` in the snapshot,
+        which drives the source-update poll — and ``"row_counts"``.
+    """
+    output_dir = Path(work_dir) / "output"
+    result = clean_all(Path(input_dir), output_dir)
+    return {
+        k: (str(v) if isinstance(v, Path) else v) for k, v in result.items()
+    }

--- a/pipelines/datasets/us_cfpb_complaints/utils.py
+++ b/pipelines/datasets/us_cfpb_complaints/utils.py
@@ -1,0 +1,379 @@
+"""Pure download and transform helpers for us_cfpb_complaints — no Prefect imports.
+
+This module is the single home of the cleaning transform. The one-shot onboarding
+scripts under ``models/us_cfpb_complaints/code/`` import these functions rather than
+duplicating them, so the recurring pipeline and the bootstrap can never drift.
+
+Two decisions are load-bearing and documented where they are made:
+
+* The CSV is read with Python's ``csv`` module. Narratives contain newlines inside
+  quoted fields and DuckDB's parallel reader desynchronises on them; the file itself
+  is well-formed RFC4180.
+* Output parquet is **all-STRING**. ``pipelines.utils.gcs.dump_header`` stringifies
+  the header BigQuery infers the staging schema from, so typed parquet is rejected.
+  The dbt model ``safe_cast``s every column to its architecture type.
+"""
+
+import csv
+import shutil
+import subprocess
+import sys
+import time
+import zipfile
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+
+from pipelines.datasets.us_cfpb_complaints.constants import constants
+
+csv.field_size_limit(sys.maxsize)
+
+DOWNLOAD_CHUNK = 8 * 1024 * 1024
+
+
+@dataclass
+class Col:
+    """One column of an architecture table.
+
+    The transform only needs ``name``/``bq_type``/``original``; the remaining fields
+    are carried so the onboarding metadata scripts can read the same TSV through the
+    same parser instead of writing a second one.
+    """
+
+    name: str  # clean BigQuery column name
+    bq_type: str  # INT64 / STRING / DATE
+    original: str  # header token in the source CSV, empty if derived
+    covered_by_dictionary: bool = False
+    directory_column: str = ""
+    measurement_unit: str = ""
+
+
+def load_cols(table: str) -> list[Col]:
+    """Load ordered column specs from the architecture TSV for a table."""
+    path = Path(constants.ARCHITECTURE_DIR.value) / f"sheet_{table}.tsv"
+    cols = []
+    with open(path, encoding="utf-8") as fh:
+        for r in csv.DictReader(fh, delimiter="\t"):
+            cols.append(
+                Col(
+                    name=r["name"].strip(),
+                    bq_type=r["bigquery_type"].strip().upper(),
+                    original=r["original_name"].strip(),
+                    covered_by_dictionary=(
+                        r["covered_by_dictionary"].strip() == "yes"
+                    ),
+                    directory_column=r["directory_column"].strip(),
+                    measurement_unit=r["measurement_unit"].strip(),
+                )
+            )
+    return cols
+
+
+def state_id_for(published_state: str) -> str | None:
+    """Map a published ``State`` value to its FIPS code, or None when there is none.
+
+    Returns None for the empty value, for the military post codes AA/AE/AP, and for
+    anything else absent from the directory — never a guess.
+    """
+    v = (published_state or "").strip()
+    if not v:
+        return None
+    v = constants.STATE_ALIASES.value.get(v.upper(), v)
+    return constants.STATE_FIPS.value.get(v.upper())
+
+
+def source_last_modified() -> str:
+    """Return the export's ``Last-Modified`` header, without downloading it."""
+    r = requests.head(
+        constants.BULK_URL.value, timeout=60, allow_redirects=True
+    )
+    r.raise_for_status()
+    return r.headers.get("last-modified", "")
+
+
+def download_snapshot(input_dir: Path) -> Path:
+    """Download and unzip the full-database export into ``input_dir``.
+
+    Returns:
+        Path to the unzipped ``complaints.csv``.
+    """
+    input_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = input_dir / constants.ZIP_NAME.value
+    csv_path = input_dir / constants.CSV_NAME.value
+
+    r = requests.head(
+        constants.BULK_URL.value, timeout=60, allow_redirects=True
+    )
+    r.raise_for_status()
+    size = int(r.headers.get("content-length", 0))
+    print(f"source: {constants.BULK_URL.value}")
+    print(f"  last-modified: {r.headers.get('last-modified', '')}")
+    print(f"  size: {size / 1e9:.2f} GB")
+
+    t0 = time.time()
+    got = 0
+    with requests.get(
+        constants.BULK_URL.value, stream=True, timeout=(30, 300)
+    ) as resp:
+        resp.raise_for_status()
+        # decode_content=True so a Content-Encoding'd body is decompressed rather
+        # than written as raw transport bytes.
+        resp.raw.decode_content = True
+        with open(zip_path, "wb") as fh:
+            while True:
+                block = resp.raw.read(DOWNLOAD_CHUNK)
+                if not block:
+                    break
+                fh.write(block)
+                got += len(block)
+    if size and zip_path.stat().st_size != size:
+        raise RuntimeError(
+            f"short download: got {zip_path.stat().st_size} bytes, expected {size}"
+        )
+    print(f"  downloaded {got / 1e9:.2f} GB in {time.time() - t0:.0f}s")
+
+    if shutil.which("unzip"):
+        subprocess.run(
+            ["unzip", "-o", str(zip_path), "-d", str(input_dir)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+    else:
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(input_dir)
+    if not csv_path.exists():
+        raise RuntimeError(f"expected {csv_path} after unzip")
+    # Free the ~1.4 GB archive: the worker pod's disk is not generous.
+    zip_path.unlink()
+    print(f"  unzipped: {csv_path.stat().st_size / 1e9:.2f} GB")
+    return csv_path
+
+
+def clean_complaint(
+    csv_path: Path, output_dir: Path, limit: int | None = None
+) -> dict:
+    """Stream the bulk CSV into ``<output_dir>/complaint/year=<YYYY>/data.parquet``.
+
+    Args:
+        csv_path: The unzipped ``complaints.csv``.
+        output_dir: Root output directory.
+        limit: Stop after this many source records (for smoke tests).
+
+    Returns:
+        ``{"per_year": {...}, "stats": {...}, "max_date_received": "YYYY-MM-DD"}``.
+    """
+    table_slug = constants.COMPLAINT.value
+    cols = load_cols(table_slug)
+    order = [c.name for c in cols]
+    schema = pa.schema([pa.field(n, pa.string()) for n in order])
+    src_of = {c.name: c.original for c in cols}
+
+    tdir = output_dir / table_slug
+    tdir.mkdir(parents=True, exist_ok=True)
+
+    writers: dict[str, pq.ParquetWriter] = {}
+    buf: dict[str, list[list]] = defaultdict(list)
+    per_year: Counter = Counter()
+    stats: Counter = Counter()
+    max_date = ""
+    flush_rows = constants.FLUSH_ROWS.value
+    t0 = time.time()
+
+    def flush(year: str) -> None:
+        rows = buf[year]
+        if not rows:
+            return
+        arrays = [
+            pa.array([r[i] for r in rows], type=pa.string())
+            for i in range(len(order))
+        ]
+        w = writers.get(year)
+        if w is None:
+            pdir = tdir / f"year={year}"
+            pdir.mkdir(parents=True, exist_ok=True)
+            w = pq.ParquetWriter(
+                pdir / "data.parquet", schema, compression="snappy"
+            )
+            writers[year] = w
+        w.write_table(pa.Table.from_arrays(arrays, schema=schema))
+        buf[year] = []
+
+    n = 0
+    with open(csv_path, encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        missing = [
+            c.original
+            for c in cols
+            if c.original and c.original not in (reader.fieldnames or [])
+        ]
+        if missing:
+            raise RuntimeError(
+                f"source CSV is missing expected columns: {missing}\n"
+                f"header seen: {reader.fieldnames}"
+            )
+        extra = [
+            f
+            for f in (reader.fieldnames or [])
+            if f not in set(src_of.values())
+        ]
+        if extra:
+            # Not fatal, but never silent: a new source column is a decision.
+            print(f"WARNING: source columns not in the architecture: {extra}")
+
+        for rec in reader:
+            n += 1
+            date_received = (rec["Date received"] or "").strip()
+            year = date_received[:4]
+            if len(date_received) != 10 or not year.isdigit():
+                stats["bad_date_received"] += 1
+                continue
+            if date_received > max_date:
+                max_date = date_received
+
+            published_state = (rec["State"] or "").strip()
+            sid = state_id_for(published_state)
+            if published_state and sid is None:
+                stats["state_without_fips"] += 1
+
+            out = []
+            for c in cols:
+                if c.name == "year":
+                    out.append(year)
+                elif c.name == "state_id":
+                    out.append(sid)
+                else:
+                    v = rec[c.original]
+                    v = v.strip() if v is not None else ""
+                    out.append(v if v != "" else None)
+            buf[year].append(out)
+            per_year[year] += 1
+            if len(buf[year]) >= flush_rows:
+                flush(year)
+            if n % 2_000_000 == 0:
+                print(f"  ...{n:,} rows ({time.time() - t0:.0f}s)", flush=True)
+            if limit and n >= limit:
+                break
+
+    for year in list(buf):
+        flush(year)
+    for w in writers.values():
+        w.close()
+
+    stats["source_rows"] = n
+    stats["written_rows"] = sum(per_year.values())
+    print(
+        f"complaint: {stats['written_rows']:,} rows across {len(per_year)} year "
+        f"partitions in {time.time() - t0:.0f}s"
+    )
+    return {
+        "per_year": dict(per_year),
+        "stats": dict(stats),
+        "max_date_received": max_date,
+    }
+
+
+def build_dicionario(output_dir: Path) -> int:
+    """Build ``<output_dir>/dicionario/data.parquet`` from the cleaned complaint parquet.
+
+    Regenerated on every run: a taxonomy revision introduces new values, and the
+    complaint table's ``custom_dictionary_coverage`` test fails if the register
+    lags behind the data.
+
+    Returns:
+        The number of dictionary rows written.
+    """
+    complaint_dir = output_dir / constants.COMPLAINT.value
+    parts = sorted(complaint_dir.glob("year=*/data.parquet"))
+    if not parts:
+        raise RuntimeError(f"no complaint parquet under {complaint_dir}")
+
+    dict_columns = constants.DICT_COLUMNS.value
+    span: dict[tuple[str, str], list[int]] = defaultdict(lambda: [9999, 0])
+    for p in parts:
+        year = int(p.parent.name.split("=", 1)[1])
+        # ParquetFile.read, not pq.read_table: the latter infers a hive dataset
+        # from the `year=<YYYY>` directory and then refuses to merge that inferred
+        # `year` with the STRING `year` inside the file.
+        tbl = pq.ParquetFile(p).read(columns=dict_columns)
+        for col in dict_columns:
+            for v in tbl.column(col).unique().to_pylist():
+                if v is None or v == "":
+                    continue
+                s = span[(col, v)]
+                s[0] = min(s[0], year)
+                s[1] = max(s[1], year)
+
+    rows = [
+        {
+            "id_tabela": constants.COMPLAINT.value,
+            "nome_coluna": col,
+            "chave": value,
+            # Data Basis temporal-coverage notation: START(INTERVAL)END
+            "cobertura_temporal": f"{y0}(1){y1}",
+            "valor": value,
+        }
+        for (col, value), (y0, y1) in sorted(span.items())
+    ]
+
+    order = [c.name for c in load_cols(constants.DICIONARIO.value)]
+    schema = pa.schema([pa.field(n, pa.string()) for n in order])
+    table = pa.Table.from_arrays(
+        [pa.array([r[n] for r in rows], type=pa.string()) for n in order],
+        schema=schema,
+    )
+    ddir = output_dir / constants.DICIONARIO.value
+    ddir.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, ddir / "data.parquet", compression="snappy")
+    print(f"dicionario: {len(rows)} rows")
+    return len(rows)
+
+
+def assert_all_string(output_dir: Path) -> None:
+    """Fail if any output parquet column is not STRING, or the order drifted.
+
+    A typed staging column matches the dev table built from the same parquet and
+    only fails once the flow recreates the table from a stringified header — i.e.
+    on the first prod run, which is the worst place to find out.
+    """
+    for table in constants.ALL_TABLES.value:
+        expected = [c.name for c in load_cols(table)]
+        for p in sorted((output_dir / table).rglob("*.parquet")):
+            sch = pq.ParquetFile(p).schema_arrow
+            if list(sch.names) != expected:
+                raise RuntimeError(
+                    f"{p}: column order/name mismatch {list(sch.names)}"
+                )
+            bad = [
+                (nm, str(t))
+                for nm, t in zip(sch.names, sch.types, strict=True)
+                if str(t) != "string"
+            ]
+            if bad:
+                raise RuntimeError(f"{p}: non-string columns {bad}")
+
+
+def clean_all(input_dir: Path, output_dir: Path) -> dict:
+    """Clean the snapshot into both tables and verify the staging schema.
+
+    Returns:
+        Table slug -> output directory, plus ``"max_date_received"`` (the poll's
+        source date) and ``"row_counts"``.
+    """
+    csv_path = input_dir / constants.CSV_NAME.value
+    res = clean_complaint(csv_path, output_dir)
+    n_dic = build_dicionario(output_dir)
+    assert_all_string(output_dir)
+    return {
+        constants.COMPLAINT.value: output_dir / constants.COMPLAINT.value,
+        constants.DICIONARIO.value: output_dir / constants.DICIONARIO.value,
+        "max_date_received": res["max_date_received"],
+        "row_counts": {
+            constants.COMPLAINT.value: res["stats"]["written_rows"],
+            constants.DICIONARIO.value: n_dic,
+        },
+        "per_year": res["per_year"],
+    }


### PR DESCRIPTION
> #1987 has merged, and this branch has been rebased onto `main`, so the diff is now only the pipeline change. The prod tables are materialised and verified (`complaint` 17,589,039 rows, `dicionario` 587).

Adds the daily recurring Prefect 3 pipeline for `us_cfpb_complaints`, and moves the cleaning transform into `pipelines/datasets/us_cfpb_complaints/utils.py` so the one-shot bootstrap and the pipeline share one implementation.

## Why every partition is rewritten, rather than appending new complaint ids

The CFPB republishes the **whole database as one snapshot every day**. Appending only rows whose `complaint_id` is new would be cheaper, and wrong: complaints are not only added, they are **revised**.

| Field | How it changes after the complaint is first published |
|---|---|
| `company_response_to_consumer` | moves off `In progress` when the company closes it |
| `timely_response` | resolves once the response window passes |
| `company_public_response` | published within 180 days, if the company opts in |
| `consumer_complaint_narrative` | arrives months later, once the CFPB has scrubbed it |

That last one is measurable in the data: narratives are present on **21.9%** of all complaints but on only **2.4%** of complaints received in 2026. An append-only load keyed on `complaint_id` would freeze all four at their first-seen values.

Rewriting everything costs little, because parsing the 9.3 GB CSV has to happen either way. The BigQuery cost is one scan of ~1.4 GB of parquet.

## Two details that are load-bearing, not stylistic

**`dump_mode="append"`, never `"overwrite"`.** Overwrite calls `tb.delete(mode="all")`, which drops the **production** table — and it fires from the dev half of the flow too, because `bd.Table` resolves its projects from the pod config rather than from `bucket_name`. Append ends in `Storage.upload(if_exists="replace")`, which replaces each partition blob wholesale: same end state, no delete.

**Every table is built before any is tested**, in separate loops, in both environments. `complaint`'s `custom_dictionary_coverage` test reads `dicionario` through `ref()`. Interleaved `run/test` per table, that test runs before `dicionario` exists and fails with `Not found: Table … us_cfpb_complaints.dicionario`. A re-run hides it, because a stale sibling from an earlier build survives — so it would only bite in a clean environment, which is prod.

`dicionario` is regenerated on every run too: a taxonomy revision introduces new values, and the coverage test fails if the register lags the data.

## Shared transform

`clean.py`, `common.py`, `download.py` and `gen_dicionario.py` under `models/us_cfpb_complaints/code/` now import from `pipelines/datasets/us_cfpb_complaints/utils.py` instead of carrying their own copy.

The port was verified against the validated bootstrap output, not assumed:

- identical row counts for all 16 year partitions (17,571,890 total)
- identical `state_without_fips` (4,327 — the AA/AE/AP military post codes)
- identical `dicionario` (587 rows)
- **value-level hash match** on `year=2011`, `year=2017`, `year=2026` and `dicionario`

## Schedule

`45 7 * * *` America/Sao_Paulo. The minute is chosen, not defaulted: hour 7 already carries 23 (daily), 37 and 51 (monthly), so 45 keeps at least five minutes' spacing. The source poll uses `compare_against="coverage"`, so a scheduled run is a cheap no-op until the CFPB publishes a newer complaint date.

## BD Pro rolling window — coverages created

`complaint` refreshes daily, so it carries `PartBdpro(free_lag=6 months)` per the house rule that a table refreshed monthly or more often paywalls its most recent window. `dicionario` has no date column and takes no coverage spec.

The required pro Coverage now exists on **both** staging and prod, with `is_closed=True` on the Coverage *and* its `DateTimeRange` (the pipeline never writes the latter, so what is registered is what stays), and the free range trimmed so the two do not overlap:

| | free (`is_closed=False`) | pro (`is_closed=True`) |
|---|---|---|
| staging | 2011-12-01 → 2026-03-06 | 2026-03-07 → 2026-09-06 |
| prod | 2011-12-01 → 2026-03-06 | 2026-03-07 → 2026-09-06 |

Checked by running the real policy functions against the read-back backend state: `assert_coverage_topology` passes on both, `compute_coverage_ranges(source_end=2026-09-06)` reproduces exactly those bounds, and `needs_row_access_policy` is `True`. The window rolls on its own — `source_end 2026-10-15` gives `free_end 2026-04-15`, `2027-01-31` gives `2026-07-31`.

`apply_row_access_policies` issues real BigQuery DDL with the worker's rights, so the paywall itself is **not** exercisable locally and is applied for the first time on the first armed prod run. Until then the Pro window is advertised in metadata but not enforced in BigQuery — which is why the dataset is deliberately still `under_review` on prod.

## Verification

**A dev run passed end to end** on the `basedosdados-dev` pool — flow run `sandy-cicada`, 29 minutes, zero WARNING or ERROR lines:

| Stage | Result |
|---|---|
| Download | 1.43 GB in 16s |
| Unzip | 9.29 GB |
| Clean | 17,589,039 rows, 16 partitions, 862s |
| dicionario | 587 rows |
| Upload | `Tabela já existe` → append branch, both tables |
| `dbt run` | OK — complaint, then dicionario |
| `dbt test` | OK — complaint, then dicionario |

Four things confirmed rather than inferred:

- The deployment's `git_clone` pull step was pinned to `branch: pipeline/us_cfpb_complaints`, so the run exercised this PR's code and not `main`.
- It **ingested a real update** rather than no-opping: the poll logged `Comparando fonte em 2026-09-06 contra coverage em 2026-09-05 — Há atualizações na fonte original`, and the row count moved +17,149 over the bootstrap load. Green state alone would not show this, since the poll guard returns early and still reports `COMPLETED`.
- The run/test ordering held — both models built before either test ran.
- The upload took the append branch, not the overwrite branch that would drop the prod table.

Local checks also pass: `deploy_flows.load_flows_from_file` discovers `us_cfpb_complaints_flow` (it swallows import errors and returns `{}`, so this catches what a broken import would otherwise hide), transform parity as above, ruff clean, pyrefly 0 diagnostics.

Triggered with `{"materialize_to_prod": false, "update_metadata": false, "force_run": true}` — all three matter, since the flow defaults to writing prod data and prod metadata, and the metadata tasks are pinned `env="prod"` even from the dev pool.

## After merge

The prod deployment lands **paused**, and the backend sync registers an unknown deployment with `is_schedule_active=False`, so merging does not start the schedule. Arming is a manual tick in Django admin (`/admin/admin_data_tools/disabledflowschedule/`). The first armed run is the first-ever execution of the prod upload and of `apply_row_access_policies` — worth watching.
