### PR TITLE
[Data] br_bd_execucao_estadual — add Rio Grande do Sul (CAGE Gasto-RS)

### DIFF
--- a/models/br_bd_execucao_estadual/br_bd_execucao_estadual__despesa.sql
+++ b/models/br_bd_execucao_estadual/br_bd_execucao_estadual__despesa.sql
@@ -40,3 +40,6 @@ from {{ ref("br_bd_execucao_estadual__despesa_pe_legado") }}
 union all
 select *
 from {{ ref("br_bd_execucao_estadual__despesa_es") }}
+union all
+select *
+from {{ ref("br_bd_execucao_estadual__despesa_rs") }}

--- a/models/br_bd_execucao_estadual/code/clean_rs.py
+++ b/models/br_bd_execucao_estadual/code/clean_rs.py
@@ -1,0 +1,440 @@
+"""Convert Rio Grande do Sul source files to all-STRING staging parquet.
+
+RS publishes one flat table (CAGE's `Gasto-RS`) as twelve monthly ZIPs per exercise,
+2012-2026 -- 175 archives, 52,224,456 rows. Each holds a single Windows-1252 CSV.
+
+Each archive is expanded, repaired, converted, and its temporary CSV deleted before the
+next is opened. The series is ~2.3 GB zipped but ~36 GB expanded, so extracting
+everything up front would need more scratch than the other four states combined.
+
+Three source defects are handled here, each measured rather than assumed: see
+`_transcode` for the encoding and the ragged rows, and `superset_columns` for the
+schema drift.
+
+Staging is all-STRING by house convention, and it must be all-STRING here specifically:
+the recurring-pipeline upload path stringifies its header, so a typed external table
+left behind by onboarding collides with the pipeline's later overwrite. See
+.claude/rules/prefect-pipeline-conventions.md, "Staging parquet must be all-STRING".
+"""
+
+from __future__ import annotations
+
+import argparse
+import codecs
+import io
+import sys
+import zipfile
+from pathlib import Path
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from constants import (
+    INPUT_DIR,
+    OUTPUT_DIR,
+    RS_ENCODING,
+    RS_SEP,
+    RS_TABLE,
+    normalise_column,
+)
+
+RS_INPUT = INPUT_DIR / "rs"
+
+# `Exercicio` and `Mes` are carried INSIDE the file, so they are used rather than the
+# file name -- the same rule as MG's `ano_particao`. `Exercicio` is renamed to the
+# house name so the models and the coverage refresh find it where they expect.
+RENAME = {"exercicio": "ano"}
+
+# The five bytes cp1252 leaves undefined. RS's 2012 files carry a handful each.
+CP1252_UNDEFINED = (b"\x81", b"\x8d", b"\x8f", b"\x90", b"\x9d")
+
+# The temp file is written with SOH as its delimiter, not the source's semicolon.
+#
+# This is what makes the ragged-row repair expressible at all. The source is unquoted,
+# so rejoining a split free-text field with `;` puts the separator straight back into
+# the field and the row is still ragged -- the repair silently accomplishes nothing.
+# There is no way to say "this semicolon is data" in a file with no quoting.
+#
+# Re-emitting with a delimiter that cannot appear in the data sidesteps quoting
+# entirely: no escaping, no quote character for a stray `"` to trip over (Bahia's
+# failure), and the repaired field keeps its semicolons verbatim.
+#
+# The delimiter is CHOSEN PER FILE rather than fixed, because RS's data does contain
+# control bytes -- 2016-02 carries a literal 0x01. `_transcode` refuses to write a
+# delimiter it has seen in the input, and `clean_archive` moves to the next candidate.
+# Since the delimiter only ever describes the throwaway temp file, files may disagree
+# about it without any effect on the parquet they produce.
+#
+# US (0x1F, "unit separator") is first because separating fields is precisely what it
+# was defined for.
+OUT_SEP_CANDIDATES = ("\x1f", "\x1e", "\x02", "\x03", "\x04", "\x1d", "\x01")
+
+
+class DelimiterCollisionError(Exception):
+    """The chosen output delimiter occurs in the source; try the next candidate."""
+
+
+def _partition_of(archive: Path) -> str:
+    """The YYYYMM this archive's file name claims."""
+    return archive.stem.rsplit("-", 1)[-1]
+
+
+def _member_size(archive: Path) -> int:
+    with zipfile.ZipFile(archive) as z:
+        return _sole_csv(z, archive).file_size
+
+
+def _cp1252_fallback(exc: UnicodeDecodeError) -> tuple[str, int]:
+    """Decode a byte cp1252 leaves undefined as its latin-1 character.
+
+    Lossless and round-trippable, where `errors="replace"` would silently swap in
+    U+FFFD and lose the byte.
+    """
+    return "".join(chr(b) for b in exc.object[exc.start : exc.end]), exc.end
+
+
+codecs.register_error("rs_cp1252_fallback", _cp1252_fallback)
+
+
+def _sole_csv(z: zipfile.ZipFile, archive: Path) -> zipfile.ZipInfo:
+    members = [m for m in z.infolist() if m.filename.lower().endswith(".csv")]
+    if len(members) != 1:
+        raise SystemExit(
+            f"{archive.name}: expected exactly one CSV, found "
+            f"{[m.filename for m in members]}"
+        )
+    return members[0]
+
+
+def _header_of(archive: Path) -> list[str]:
+    with zipfile.ZipFile(archive) as z, z.open(_sole_csv(z, archive)) as fh:
+        raw = fh.read(16000)
+    text = raw.decode(RS_ENCODING, errors="rs_cp1252_fallback")
+    return text.split("\n", 1)[0].rstrip("\r").split(RS_SEP)
+
+
+def _normalised(columns: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: dict[str, int] = {}
+    for name in columns:
+        norm = RENAME.get(normalise_column(name), normalise_column(name))
+        # Defensive: two source names could fold to one legal name, and BigQuery would
+        # reject the duplicate at load time rather than here.
+        if norm in seen:
+            seen[norm] += 1
+            norm = f"{norm}_{seen[norm]}"
+        else:
+            seen[norm] = 0
+        out.append(norm)
+    return out
+
+
+def superset_columns(archives: list[Path]) -> list[str]:
+    """The union of every era's columns, in first-seen order.
+
+    RS changed its schema three times: 62 columns for 2012-01..2025-05, 66 from 2025-06
+    (adding the fonte/natureza code and name pairs), and 67 from 2025-07 (adding
+    `Historico`, and dropping the accent from `Informações Complementares`).
+
+    Every partition must be written with the SAME columns, or the upload silently loses
+    the difference: a wildcard parquet load infers one schema, keeps those columns, and
+    loads every other file's rows as all-NULL while reporting the full row count. That
+    cost PE 25 columns and 1,031,326 rows before `upload.py` grew a guard against it.
+
+    Normalisation is what folds the accent rename onto one name, so the two spellings
+    do not become two columns.
+    """
+    seen: list[str] = []
+    for archive in archives:
+        for norm in _normalised(_header_of(archive)):
+            if norm not in seen:
+                seen.append(norm)
+    return seen
+
+
+def _transcode(
+    z: zipfile.ZipFile, member: zipfile.ZipInfo, dest: Path, out_sep: str
+) -> tuple[int, int]:
+    """Unpack one CSV to UTF-8, repairing ragged rows. Returns (recovered, repaired).
+
+    **Encoding.** The source is Windows-1252, not the ISO-8859-1 its accents suggest:
+    it carries smart quotes and en-dashes in the C1 range (0x91-0x96) that latin-1
+    leaves undefined, so duckdb refuses every file with `Invalid Input Error: File is
+    not latin-1 encoded`. That refusal is correct and useful -- Python's latin-1
+    decodes ANY byte sequence, so a "try utf-8, else latin-1" probe reports success and
+    yields mojibake. duckdb has no cp1252 reader, so the conversion happens here, on a
+    pass the unpacking was already paying for.
+
+    **Ragged rows.** The source uses no quoting convention: the final column
+    (`Informacoes Complementares`) is free text and its semicolons are left unescaped,
+    e.g. `NFSe:4306; Comp:06/2025; CTR: 2023/20385`. 17,366 rows across the 13 files
+    from 2025-07 carry up to 7 surplus fields. `strict_mode=false` does not fix this
+    (it mis-parses rather than rejects) and `null_padding` only pads rows that are too
+    SHORT.
+
+    The surplus always belongs to the last column, which makes the repair unambiguous.
+    Verified over every ragged row in the corpus by checking that the field preceding
+    the free text is still the natureza code: **17,366 of 17,366 hold, 0 violate.**
+
+    Quotes are left as ordinary characters. 1,619 rows contain one, but since embedded
+    separators are demonstrably NOT quoted, `"` carries no structural meaning here --
+    the reader is given `quote=''` so a stray unpaired quote cannot swallow the rest of
+    the file, as one did in Bahia.
+    """
+    fields: int | None = None
+    repaired = 0
+    with z.open(member) as raw:
+        stream = io.TextIOWrapper(
+            raw, encoding=RS_ENCODING, errors="rs_cp1252_fallback", newline=""
+        )
+        with dest.open("w", encoding="utf-8", newline="") as out:
+            for line in stream:
+                line = line.rstrip("\r\n")
+                if not line:
+                    continue
+                if out_sep in line:
+                    raise DelimiterCollisionError(out_sep)
+                parts = line.split(RS_SEP)
+                if fields is None:
+                    fields = len(parts)
+                elif len(parts) > fields:
+                    # Surplus fields belong to the trailing free-text column, verified
+                    # over all 17,366 ragged rows in the corpus. Rejoined with the
+                    # ORIGINAL separator so the text keeps its semicolons; that is only
+                    # unambiguous because the output uses a different delimiter.
+                    parts = [
+                        *parts[: fields - 1],
+                        RS_SEP.join(parts[fields - 1 :]),
+                    ]
+                    repaired += 1
+                out.write(out_sep.join(parts) + "\n")
+
+    recovered = 0
+    with z.open(member) as raw:
+        while chunk := raw.read(1 << 20):
+            recovered += sum(chunk.count(b) for b in CP1252_UNDEFINED)
+    return recovered, repaired
+
+
+def _projection(columns: list[str], superset: list[str]) -> str:
+    """Project one era's columns into the superset, NULL for the ones it lacks."""
+    present = dict(zip(_normalised(columns), columns, strict=True))
+    return ", ".join(
+        f'"{present[c]}" AS {c}'
+        if c in present
+        else f"CAST(NULL AS VARCHAR) AS {c}"
+        for c in superset
+    )
+
+
+def clean_archive(
+    con: duckdb.DuckDBPyConnection,
+    archive: Path,
+    dest: Path,
+    superset: list[str],
+) -> int:
+    tmp = RS_INPUT / f".{archive.stem}.csv"
+    for out_sep in OUT_SEP_CANDIDATES:
+        try:
+            with zipfile.ZipFile(archive) as z:
+                recovered, repaired = _transcode(
+                    z, _sole_csv(z, archive), tmp, out_sep
+                )
+            break
+        except DelimiterCollisionError:
+            print(
+                f"    {archive.name}: contains {out_sep!r}, trying the next "
+                f"delimiter",
+                flush=True,
+            )
+    else:
+        tmp.unlink(missing_ok=True)
+        raise SystemExit(
+            f"{archive.name}: every candidate delimiter occurs in the source"
+        )
+    notes = []
+    if recovered:
+        notes.append(f"{recovered} byte(s) undefined in cp1252 -> latin-1")
+    if repaired:
+        notes.append(f"{repaired} ragged row(s) rejoined into the last column")
+
+    try:
+        # The temp file uses SOH as its delimiter (see OUT_SEP) and no quoting, so
+        # `"` and `;` are both ordinary data by construction.
+        rel = (
+            f"read_csv('{tmp}', delim='{out_sep}', header=true, all_varchar=true, "
+            f"encoding='utf-8', quote='', ignore_errors=false)"
+        )
+        out_path = dest / f"data_{_partition_of(archive)}.parquet"
+        con.execute(
+            f"COPY (SELECT {_projection(_header_of(archive), superset)} FROM {rel}) "
+            f"TO '{out_path}' (FORMAT PARQUET, COMPRESSION SNAPPY)"
+        )
+        n = con.execute(
+            f"SELECT count(*) FROM read_parquet('{out_path}')"
+        ).fetchone()[0]
+    finally:
+        # Always: a 660 MB temp left behind on failure fills the disk within a dozen
+        # archives.
+        tmp.unlink(missing_ok=True)
+
+    if n == 0:
+        # An empty first partition makes dump_header infer INTEGER for every column and
+        # poisons the staging schema. See
+        # reference_empty_parquet_partition_poisons_staging_schema.
+        out_path.unlink()
+        print(f"    {archive.name}: 0 rows, parquet dropped")
+        return 0
+    suffix = f"   [{'; '.join(notes)}]" if notes else ""
+    print(f"    {archive.name}: {n:,} rows{suffix}", flush=True)
+    return n
+
+
+def main(only_year: int | None = None) -> None:
+    archives = sorted(RS_INPUT.glob("*.zip"))
+    if not archives:
+        raise SystemExit(
+            f"no archives under {RS_INPUT}; run download_rs.py first"
+        )
+
+    # Built from EVERY archive, not just the ones being converted, so a single-year
+    # rerun still writes the full column set and stays union-compatible with the
+    # partitions already on disk.
+    superset = superset_columns(archives)
+    print(
+        f"superset schema: {len(superset)} columns across {len(archives)} archives"
+    )
+
+    if only_year is not None:
+        archives = [a for a in archives if a.name.startswith(str(only_year))]
+        if not archives:
+            raise SystemExit(f"no archives for {only_year}")
+
+    dest = OUTPUT_DIR / RS_TABLE
+    dest.mkdir(parents=True, exist_ok=True)
+
+    con = duckdb.connect()
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("PRAGMA memory_limit='2GB'")
+    con.execute("PRAGMA threads=2")
+
+    # Resumable. Each archive is independent, and the whole series is a ~40 minute
+    # job that has been killed mid-run by memory pressure more than once; restarting
+    # from zero each time is how a long conversion never finishes. A partition already
+    # written against the CURRENT superset is trusted, and anything else is rebuilt.
+    # Six months are published TWICE under the neighbouring month's file name, as a
+    # partial and a complete snapshot of the same month (2020-07 appears as 121,940 and
+    # 205,468 rows). Two archives therefore target one partition, and the previous code
+    # kept whichever sorted last -- which happened to be the complete one in all six
+    # cases, by luck rather than design. Choose the larger member explicitly, so a
+    # reordering upstream cannot silently swap in the partial snapshot.
+    by_partition: dict[str, list[Path]] = {}
+    for archive in archives:
+        by_partition.setdefault(_partition_of(archive), []).append(archive)
+    chosen: list[Path] = []
+    for name, group in sorted(by_partition.items()):
+        if len(group) > 1:
+            group = sorted(group, key=_member_size, reverse=True)
+            print(
+                f"    data_{name}: {len(group)} archives claim this month; keeping "
+                f"{group[0].name} ({_member_size(group[0]) / 1e6:.0f} MB) over "
+                + ", ".join(
+                    f"{a.name} ({_member_size(a) / 1e6:.0f} MB)"
+                    for a in group[1:]
+                )
+            )
+        chosen.append(group[0])
+    archives = sorted(chosen)
+
+    total = 0
+    for archive in archives:
+        out_path = dest / f"data_{_partition_of(archive)}.parquet"
+        if out_path.exists():
+            existing = con.execute(
+                f"SELECT count(*) FROM (DESCRIBE SELECT * FROM "
+                f"read_parquet('{out_path}'))"
+            ).fetchone()[0]
+            if existing == len(superset):
+                n = con.execute(
+                    f"SELECT count(*) FROM read_parquet('{out_path}')"
+                ).fetchone()[0]
+                total += n
+                print(
+                    f"    {archive.name}: {n:,} rows (already built)",
+                    flush=True,
+                )
+                continue
+            out_path.unlink()
+        total += clean_archive(con, archive, dest, superset)
+
+    files = sorted(dest.glob("data_*.parquet"))
+    if not files:
+        print(f"  {RS_TABLE}: no non-empty partitions")
+        return
+
+    # Every partition must agree on its columns, or the BigQuery load drops the
+    # difference in silence. `union_by_name=false` makes a disagreement raise here
+    # rather than being papered over locally and failing later.
+    widths = con.execute(
+        f"SELECT count(*) FROM (DESCRIBE SELECT * FROM "
+        f"read_parquet('{dest}/data_*.parquet', union_by_name=false))"
+    ).fetchone()[0]
+    if widths != len(superset):
+        raise SystemExit(
+            f"{RS_TABLE}: partitions disagree -- {widths} columns read against a "
+            f"{len(superset)}-column superset"
+        )
+
+    typed = con.execute(
+        f"SELECT DISTINCT column_name, column_type FROM (DESCRIBE SELECT * FROM "
+        f"read_parquet('{dest}/data_*.parquet')) WHERE column_type <> 'VARCHAR'"
+    ).fetchall()
+    if typed:
+        raise SystemExit(
+            f"{RS_TABLE}: staging must be all-STRING, found {typed}"
+        )
+
+    # The calendar gap that no file count can see. RS publishes six months under the
+    # NEIGHBOURING month's file name, so the series arrives with 175 archives, every
+    # CRC valid, twelve files per exercise -- and six months absent: 2020-06, 2020-08,
+    # 2022-04, 2023-02, 2023-06 and 2023-08. Only grouping by the data's own
+    # (Exercicio, Mes) reveals it, so that check lives here rather than in a
+    # to-do somewhere.
+    present = {
+        (int(a), int(m))
+        for a, m in con.execute(
+            f"SELECT DISTINCT ano, mes FROM read_parquet('{dest}/data_*.parquet') "
+            f"WHERE ano IS NOT NULL AND mes IS NOT NULL"
+        ).fetchall()
+    }
+    if present:
+        lo, hi = min(present), max(present)
+        expected = {
+            (y, m)
+            for y in range(lo[0], hi[0] + 1)
+            for m in range(1, 13)
+            if (y, m) >= lo and (y, m) <= hi
+        }
+        gaps = sorted(expected - present)
+        if gaps:
+            print(
+                f"  WARNING {len(gaps)} month(s) absent from the source between "
+                f"{lo[0]}-{lo[1]:02d} and {hi[0]}-{hi[1]:02d}: "
+                + ", ".join(f"{y}-{m:02d}" for y, m in gaps)
+            )
+
+    span = con.execute(
+        f"SELECT min(ano), max(ano), count(DISTINCT ano), count(DISTINCT fasegasto) "
+        f"FROM read_parquet('{dest}/data_*.parquet')"
+    ).fetchone()
+    print(
+        f"  {RS_TABLE}: {total:,} rows across {len(files)} files, {widths} columns "
+        f"-> ano {span[0]}-{span[1]} ({span[2]} distinct), {span[3]} phases"
+    )
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--year", type=int, help="convert a single exercise")
+    args = ap.parse_args()
+    main(only_year=args.year)

--- a/models/br_bd_execucao_estadual/code/constants.py
+++ b/models/br_bd_execucao_estadual/code/constants.py
@@ -289,3 +289,47 @@ ES_ENCODING = "utf-8-sig"
 
 # ES's 2004-2008 aggregate rows name the withheld creditor this way.
 ES_ANONYMISED = "Informação não disponivel."
+
+# --------------------------------------------------------------------------- RS
+
+RS_CKAN = "https://dados.rs.gov.br/api/3/action/package_show"
+RS_PACKAGE_LIST = "https://dados.rs.gov.br/api/3/action/package_list"
+
+# RS is only reachable over some network paths: `dados.rs.gov.br` resolves everywhere
+# but refused a residential Australian ISP outright while answering fine from a
+# university range. It is not a country block -- both routes tried were Australian --
+# so treat a timeout here as "try another egress", not as "the source is down".
+#
+# Package slugs change convention FOUR times across the series
+# (`despesas-do-estado-em-2012` ... `despesas-do-estado-2022` ... `despesas-2023` ...
+# `2024-despesas-do-estado`), so they are discovered from the catalogue rather than
+# built from a template. A single f-string pattern silently misses whole years.
+RS_FIRST_YEAR, RS_LAST_YEAR = 2012, 2026
+
+# One flat table, published as twelve monthly ZIPs per exercise. Each archive holds one
+# CSV (`Gasto-RS-<ano><mes>.csv`), ~180 MB uncompressed against ~9 MB zipped -- a 20x
+# ratio, so the whole series is ~1.6 GB to fetch and ~36 GB to process.
+RS_TABLE = "rs_despesa"
+
+RS_SEP = ";"
+# **Windows-1252, not the ISO-8859-1 the accents suggest.** The files carry smart
+# quotes and en-dashes in the C1 range (0x91-0x96), which latin-1 leaves undefined, so
+# duckdb refuses every one of them with `Invalid Input Error: File is not latin-1
+# encoded`. That refusal is correct and useful: Python's latin-1 decodes ANY byte
+# sequence, so a "try utf-8, else latin-1" probe reports success and yields mojibake.
+#
+# duckdb has no cp1252 reader, so clean_rs transcodes to UTF-8 while unpacking. The
+# five bytes cp1252 itself leaves undefined (0x81, 0x8D, 0x8F, 0x90, 0x9D -- 2012 has
+# one) are decoded as their latin-1 characters, which is lossless, rather than replaced.
+RS_ENCODING = "cp1252"
+
+# RS publishes ONE ROW PER PHASE (`FaseGasto` = Empenho / Liquidação / Pagamento /
+# Retenção), where MG, BA, PE and SP all put the phase values as columns on one row.
+# That is the MiDES ledger shape and the opposite of this dataset's `despesa` design.
+# Staging mirrors the source either way; the decision belongs in the dbt model.
+RS_PHASE_COLUMN = "FaseGasto"
+
+# CPFs are published as all zeros rather than partially masked, so unlike MG
+# (`***.195.606-**`) and ES (`###.743.147-##`) there is no partial identifier at all
+# for natural persons.
+RS_NULL_DOCUMENT = "000.000.000-00"

--- a/models/br_bd_execucao_estadual/code/download_rs.py
+++ b/models/br_bd_execucao_estadual/code/download_rs.py
@@ -1,0 +1,147 @@
+"""Download the Rio Grande do Sul source files from dados.rs.gov.br.
+
+CAGE publishes one flat table as twelve monthly ZIPs per exercise, 2012-2026. Small to
+fetch (~1.6 GB total, 20x compression) and slow to process (~36 GB expanded).
+
+Two things need care here that the other states did not need:
+
+1. **Reachability is path-dependent, not country-dependent.** `dados.rs.gov.br`
+   resolves everywhere but refused a residential Australian ISP outright while
+   answering fine from a university range. A timeout means "try another egress", not
+   "the source is down", so failures are collected and reported rather than swallowed.
+
+2. **The package slug convention changes four times** across the series
+   (`despesas-do-estado-em-2012` ... `despesas-do-estado-2022` ... `despesas-2023` ...
+   `2024-despesas-do-estado`). Packages are therefore discovered from the catalogue and
+   matched on shape; a single f-string template silently misses whole exercises.
+
+Resources are enumerated POSITIONALLY, never by name: the 2020 package lists "Agosto"
+twice and has no "Setembro", so a name-keyed dict loses a month without a word.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from constants import BROWSER_UA, INPUT_DIR, RS_CKAN, RS_PACKAGE_LIST
+
+RS_INPUT = INPUT_DIR / "rs"
+CHUNK = 1 << 20
+YEAR = re.compile(r"(?<!\d)(20\d{2})(?!\d)")
+
+
+def is_intact(path: Path) -> bool:
+    """A ZIP is intact only when every member's CRC checks out.
+
+    `testzip()` decompresses each member, so a truncated download fails here rather
+    than several steps later inside the cleaner. RS drops connections often enough on
+    a long transfer that a size-only check is not enough.
+    """
+    if not path.exists() or path.stat().st_size == 0:
+        return False
+    try:
+        with zipfile.ZipFile(path) as z:
+            return z.testzip() is None
+    except (zipfile.BadZipFile, OSError):
+        return False
+
+
+def despesa_packages(session: requests.Session) -> list[str]:
+    r = session.get(RS_PACKAGE_LIST, timeout=120)
+    r.raise_for_status()
+    return sorted(
+        n
+        for n in r.json()["result"]
+        if YEAR.search(n) and "despesa" in n.lower()
+    )
+
+
+def planned(
+    session: requests.Session, years: set[int] | None
+) -> list[tuple[str, str]]:
+    """(destination file name, url) for every monthly archive to fetch."""
+    out: list[tuple[str, str]] = []
+    for package in despesa_packages(session):
+        m = YEAR.search(package)
+        year = int(m.group(1)) if m else 0
+        if years is not None and year not in years:
+            continue
+        r = session.get(RS_CKAN, params={"id": package}, timeout=120)
+        r.raise_for_status()
+        for i, res in enumerate(r.json()["result"].get("resources", [])):
+            url = res.get("url") or ""
+            if not url.lower().endswith(".zip"):
+                continue
+            stem = Path(url).name or f"{year}_{i:02d}.zip"
+            # The positional index is part of the name so two resources sharing a
+            # label ("Agosto" twice in 2020) cannot overwrite each other.
+            out.append((f"{year}__{i:02d}__{stem}", url))
+    return out
+
+
+def download(session: requests.Session, name: str, url: str) -> bool:
+    dest = RS_INPUT / name
+    if is_intact(dest):
+        return True
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    with session.get(url, stream=True, timeout=900) as r:
+        r.raise_for_status()
+        with tmp.open("wb") as fh:
+            for chunk in r.iter_content(CHUNK):
+                fh.write(chunk)
+    if not is_intact(tmp):
+        tmp.unlink(missing_ok=True)
+        return False
+    tmp.replace(dest)
+    return True
+
+
+def main(retries: int = 3, years: set[int] | None = None) -> None:
+    RS_INPUT.mkdir(parents=True, exist_ok=True)
+    session = requests.Session()
+    session.headers.update({"User-Agent": BROWSER_UA})
+
+    wanted = planned(session, years)
+    print(f"{len(wanted)} monthly archives planned -> {RS_INPUT}")
+
+    pending = dict(wanted)
+    for attempt in range(1, retries + 1):
+        failed: dict[str, str] = {}
+        for name, url in sorted(pending.items()):
+            ok = False
+            try:
+                ok = download(session, name, url)
+            except requests.RequestException as exc:
+                print(f"  {name}: {type(exc).__name__}")
+            if ok:
+                continue
+            failed[name] = url
+            print(f"  {name}: incomplete, will retry", flush=True)
+        if not failed:
+            break
+        pending = failed
+        print(f"attempt {attempt}: {len(failed)} to retry")
+    else:
+        # Loud and non-zero. A resumable harvest that reports success with a month
+        # missing turns a transient network error into permanent silent loss.
+        print(f"STILL FAILING after {retries} attempts: {sorted(pending)}")
+        raise SystemExit(1)
+
+    archives = sorted(RS_INPUT.glob("*.zip"))
+    total = sum(p.stat().st_size for p in archives)
+    print(f"OK: {len(archives)} archives, {total / 1e9:.2f} GB")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--retries", type=int, default=3)
+    ap.add_argument("--year", type=int, action="append", help="repeatable")
+    args = ap.parse_args()
+    main(retries=args.retries, years=set(args.year) if args.year else None)

--- a/models/br_bd_execucao_estadual/code/register_coverage.py
+++ b/models/br_bd_execucao_estadual/code/register_coverage.py
@@ -35,47 +35,70 @@ MCP = "/Users/rdahis/Dropbox/BD/mcp"
 # (area slug, start_year, start_month, end_year, end_month).
 # A None month means the range is year-granular; None years mean no range at all, which is
 # correct for the two tables that carry no date column.
+# One entry per (table, area). The second element is a LIST of ranges, because a
+# state's series is not always continuous: Rio Grande do Sul is missing six months
+# that its own catalogue does not publish, and a single 2012-2026 range would promise
+# data that is not there.
+#
+# Multiple RANGES rather than multiple coverages: a Coverage is keyed by area, so
+# duplicating it for one state produces ambiguous records the backend has no tool to
+# delete, and duplicates break CreateUpdateTable later. DateTimeRange is the repeating
+# child meant for exactly this.
+#
+# `None` in place of the list means the table carries no date column at all.
 PLAN: dict[
-    str, list[tuple[str, int | None, int | None, int | None, int | None]]
+    str, list[tuple[str, list[tuple[int, int | None, int, int | None]] | None]]
 ] = {
     "despesa": [
-        ("br_mg", 2002, 1, 2026, 8),
-        ("br_pe", 2008, None, 2026, None),
+        ("br_mg", [(2002, 1, 2026, 8)]),
+        ("br_pe", [(2008, None, 2026, None)]),
         # Measured 2026-09-08. ES carries a full `Data` on every expense row, so
         # unlike PE it is genuinely month-granular across the whole series.
-        ("br_es", 2009, 1, 2026, 9),
-        # Measured 2026-09-08. Six months are absent from RS's own
-        # catalogue (2020-06/08, 2022-04, 2023-02/06/08), so the range is
-        # continuous but the series inside it is not.
-        ("br_rs", 2012, 1, 2026, 7),
+        ("br_es", [(2009, 1, 2026, 9)]),
+        # Seven spans, derived from the data on 2026-09-08 and summing to exactly the
+        # 169 months present. The gaps are 2020-06, 2020-08, 2022-04, 2023-02, 2023-06
+        # and 2023-08: RS's catalogue serves the NEIGHBOURING month's file in those
+        # slots, so the months were never published rather than lost in transit.
+        (
+            "br_rs",
+            [
+                (2012, 1, 2020, 5),
+                (2020, 7, 2020, 7),
+                (2020, 9, 2022, 3),
+                (2022, 5, 2023, 1),
+                (2023, 3, 2023, 5),
+                (2023, 7, 2023, 7),
+                (2023, 9, 2026, 7),
+            ],
+        ),
     ],
-    "pagamento": [("br_pe", 2008, 1, 2026, 8)],
-    "despesa_mensal": [("br_ba", 2013, 1, 2026, 8)],
-    "despesa_anual": [("br_sp", 2010, None, 2026, None)],
-    "empenho_credor": [("br_ba", 2019, 1, 2026, 8)],
+    "pagamento": [("br_pe", [(2008, 1, 2026, 8)])],
+    "despesa_mensal": [("br_ba", [(2013, 1, 2026, 8)])],
+    "despesa_anual": [("br_sp", [(2010, None, 2026, None)])],
+    "empenho_credor": [("br_ba", [(2019, 1, 2026, 8)])],
     "licitacao": [
-        ("br_ba", 2004, 1, 2026, 12),
-        ("br_mg", 2009, 1, 2024, 3),
-        ("br_es", 2009, 8, 2026, 8),
+        ("br_ba", [(2004, 1, 2026, 12)]),
+        ("br_mg", [(2009, 1, 2024, 3)]),
+        ("br_es", [(2009, 8, 2026, 8)]),
     ],
     "licitacao_item": [
-        ("br_ba", 2004, None, 2026, None),
-        ("br_mg", 2009, None, 2025, None),
+        ("br_ba", [(2004, None, 2026, None)]),
+        ("br_mg", [(2009, None, 2025, None)]),
         # Year-granular: the canonical licitacao_item has no `mes`.
-        ("br_es", 2009, None, 2026, None),
+        ("br_es", [(2009, None, 2026, None)]),
     ],
     "licitacao_participante": [
-        ("br_ba", 2004, None, 2026, None),
-        ("br_es", 2009, None, 2026, None),
+        ("br_ba", [(2004, None, 2026, None)]),
+        ("br_es", [(2009, None, 2026, None)]),
     ],
     "relacionamentos": [
-        ("br_ba", None, None, None, None),
-        ("br_mg", None, None, None, None),
-        ("br_es", None, None, None, None),
+        ("br_ba", None),
+        ("br_mg", None),
+        ("br_es", None),
     ],
     "dicionario": [
-        ("br_mg", None, None, None, None),
-        ("br_es", None, None, None, None),
+        ("br_mg", None),
+        ("br_es", None),
     ],
 }
 
@@ -129,10 +152,11 @@ def check(env: str) -> int:
     seen = measured(project)
     stale = 0
     for slug, entries in PLAN.items():
-        for area, y0, _, y1, _ in entries:
+        for area, ranges in entries:
             uf = area.removeprefix("br_").upper()
-            if y0 is None:
+            if ranges is None:
                 continue
+            y0, y1 = ranges[0][0], ranges[-1][2]
             got = seen.get((slug, uf))
             if got is None:
                 print(f"  {slug} {uf}: no rows in the table")
@@ -171,9 +195,9 @@ def apply(env: str) -> None:
         # because every entry was rewritten in the same pass; a PLAN shorter than the
         # backend's list, or a failure midway, would leave ranges on the wrong states.
         existing = {c["area_slug"]: c for c in table["coverages"]}
-        for area, y0, m0, y1, m1 in entries:
-            # Reuse the coverage already on the table where there is one: the backend has
-            # no delete-coverage tool, and duplicates break CreateUpdateTable later.
+        for area, ranges in entries:
+            # Reuse the coverage already on the table where there is one: the backend
+            # has no delete-coverage tool, and duplicates break CreateUpdateTable later.
             kwargs = {
                 "table_id": table["id"],
                 "area_id": areas[area],
@@ -183,23 +207,36 @@ def apply(env: str) -> None:
             if prior_cov:
                 kwargs["id"] = prior_cov["id"]
             coverage = server.create_update_coverage(**kwargs)
-            if y0 is None:
+            if ranges is None:
                 print(f"  {slug:24} {area}  no range")
                 continue
-            rng = {
-                "coverage_id": coverage["id"],
-                "start_year": y0,
-                "end_year": y1,
-                "interval": 1,
-                "env": env,
-            }
-            if m0:
-                rng.update(start_month=m0, end_month=m1)
-            prior = prior_cov.get("datetime_ranges") if prior_cov else None
-            if prior:
-                rng["id"] = prior[0]["id"]
-            server.create_update_datetime_range(**rng)
-            label = f"{y0}-{m0:02d}..{y1}-{m1:02d}" if m0 else f"{y0}..{y1}"
+
+            prior = (prior_cov or {}).get("datetime_ranges") or []
+            if len(prior) > len(ranges):
+                # There is no delete tool for a DateTimeRange either, so a shrinking
+                # list would leave stale spans claiming coverage that was withdrawn.
+                # Refuse rather than half-apply.
+                raise SystemExit(
+                    f"{slug}/{area}: {len(prior)} range(s) registered but only "
+                    f"{len(ranges)} planned; the extra ones cannot be deleted here"
+                )
+            for i, (y0, m0, y1, m1) in enumerate(ranges):
+                rng = {
+                    "coverage_id": coverage["id"],
+                    "start_year": y0,
+                    "end_year": y1,
+                    "interval": 1,
+                    "env": env,
+                }
+                if m0:
+                    rng.update(start_month=m0, end_month=m1)
+                if i < len(prior):
+                    rng["id"] = prior[i]["id"]
+                server.create_update_datetime_range(**rng)
+            label = ", ".join(
+                f"{y0}-{m0:02d}..{y1}-{m1:02d}" if m0 else f"{y0}..{y1}"
+                for y0, m0, y1, m1 in ranges
+            )
             print(f"  {slug:24} {area}  {label}")
 
 

--- a/models/br_bd_execucao_estadual/code/register_coverage.py
+++ b/models/br_bd_execucao_estadual/code/register_coverage.py
@@ -164,8 +164,14 @@ def apply(env: str) -> None:
     dataset = server.get_dataset(slug="execucao_estadual", env=env)
     for slug, entries in PLAN.items():
         table = dataset["tables"][slug]
-        existing = table["coverages"]
-        for i, (area, y0, m0, y1, m1) in enumerate(entries):
+        # Matched BY AREA, never by position. The backend does not return coverages in
+        # PLAN order -- on `licitacao` it has br_mg before br_ba where PLAN has BA
+        # first -- so an index-based pairing writes each state's range onto another
+        # state's coverage record. The end state happened to come out right only
+        # because every entry was rewritten in the same pass; a PLAN shorter than the
+        # backend's list, or a failure midway, would leave ranges on the wrong states.
+        existing = {c["area_slug"]: c for c in table["coverages"]}
+        for area, y0, m0, y1, m1 in entries:
             # Reuse the coverage already on the table where there is one: the backend has
             # no delete-coverage tool, and duplicates break CreateUpdateTable later.
             kwargs = {
@@ -173,8 +179,9 @@ def apply(env: str) -> None:
                 "area_id": areas[area],
                 "env": env,
             }
-            if i < len(existing):
-                kwargs["id"] = existing[i]["id"]
+            prior_cov = existing.get(area)
+            if prior_cov:
+                kwargs["id"] = prior_cov["id"]
             coverage = server.create_update_coverage(**kwargs)
             if y0 is None:
                 print(f"  {slug:24} {area}  no range")
@@ -188,11 +195,7 @@ def apply(env: str) -> None:
             }
             if m0:
                 rng.update(start_month=m0, end_month=m1)
-            prior = (
-                existing[i].get("datetime_ranges")
-                if i < len(existing)
-                else None
-            )
+            prior = prior_cov.get("datetime_ranges") if prior_cov else None
             if prior:
                 rng["id"] = prior[0]["id"]
             server.create_update_datetime_range(**rng)

--- a/models/br_bd_execucao_estadual/code/register_coverage.py
+++ b/models/br_bd_execucao_estadual/code/register_coverage.py
@@ -44,6 +44,10 @@ PLAN: dict[
         # Measured 2026-09-08. ES carries a full `Data` on every expense row, so
         # unlike PE it is genuinely month-granular across the whole series.
         ("br_es", 2009, 1, 2026, 9),
+        # Measured 2026-09-08. Six months are absent from RS's own
+        # catalogue (2020-06/08, 2022-04, 2023-02/06/08), so the range is
+        # continuous but the series inside it is not.
+        ("br_rs", 2012, 1, 2026, 7),
     ],
     "pagamento": [("br_pe", 2008, 1, 2026, 8)],
     "despesa_mensal": [("br_ba", 2013, 1, 2026, 8)],

--- a/models/br_bd_execucao_estadual/code/validate_rs.py
+++ b/models/br_bd_execucao_estadual/code/validate_rs.py
@@ -1,0 +1,244 @@
+"""Reconcile the pivoted RS rows against their raw staging mirror.
+
+RS is the only state whose model changes the SHAPE of the data: the source publishes one
+row per phase and `despesa_rs` pivots it to one row per empenho x budget line, with the
+phases as columns. That introduces failure modes the other states do not have, so the
+checks here are different from validate_es:
+
+  * A pivot can drop money silently. Any `FaseGasto` the model does not name simply
+    vanishes from all three value columns, and the row count still looks plausible. The
+    phase inventory below is therefore a HARD gate: a seventh phase appearing upstream
+    must fail this script, not be quietly excluded.
+  * A pivot can multiply rows if the grouping key is wrong. Grain is checked directly.
+  * `Retenção` is excluded on purpose, so its exclusion is asserted rather than assumed
+    -- if it ever leaked into `valor_pago` the total would move by R$27.5bn.
+
+Usage:
+    uv run python models/br_bd_execucao_estadual/code/validate_rs.py [--env dev]
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+
+warnings.filterwarnings("ignore")
+
+from google.cloud import bigquery  # noqa: E402
+
+_argv = sys.argv[1:]
+ENV = "dev"
+if "--env" in _argv:
+    ENV = _argv[_argv.index("--env") + 1]
+
+PROJECT = "basedosdados" if ENV == "prod" else "basedosdados-dev"
+DATASET = "br_bd_execucao_estadual"
+STAGING = f"{PROJECT}.{DATASET}_staging"
+PUB = f"{PROJECT}.{DATASET}"
+
+# Every phase the model knows how to place. Anything else is money with nowhere to go.
+KNOWN_PHASES = {
+    "Empenho": "valor_empenhado",
+    "Prescrição de Empenho": "valor_empenhado",
+    "Liquidação": "valor_liquidado",
+    "Prescrição de Liquidação": "valor_liquidado",
+    "Pagamento": "valor_pago",
+    "Retenção": "(excluded: withheld within a payment, not extra expenditure)",
+    # 270 rows carry no phase at all (-R$33.1M). Listed explicitly as a KNOWN
+    # exclusion rather than special-cased out of the check: printing "UNKNOWN" while
+    # passing is the worst of both, and a growing count here is worth seeing.
+    None: "(excluded: no phase published, cannot be attributed)",
+}
+
+PHASES = f"""
+select
+    trim(fasegasto) as fase,
+    count(*) as n,
+    round(sum(safe_cast(replace(valor, ',', '.') as float64)), 2) as total
+from `{STAGING}.rs_despesa`
+group by 1
+"""
+
+RAW = f"""
+select
+    count(distinct nullif(trim(empenho), '')) as n_empenhos,
+    round(sum(if(trim(fasegasto) in ('Empenho', 'Prescrição de Empenho'),
+        safe_cast(replace(valor, ',', '.') as float64), 0)), 2) as v_emp,
+    round(sum(if(trim(fasegasto) in ('Liquidação', 'Prescrição de Liquidação'),
+        safe_cast(replace(valor, ',', '.') as float64), 0)), 2) as v_liq,
+    round(sum(if(trim(fasegasto) = 'Pagamento',
+        safe_cast(replace(valor, ',', '.') as float64), 0)), 2) as v_pago
+from `{STAGING}.rs_despesa`
+where nullif(trim(empenho), '') is not null
+"""
+
+MODEL = f"""
+select
+    count(*) as n_rows,
+    count(distinct id_empenho) as n_empenhos,
+    round(sum(valor_empenhado), 2) as v_emp,
+    round(sum(valor_liquidado), 2) as v_liq,
+    round(sum(valor_pago), 2) as v_pago,
+    min(ano) as ano_min,
+    max(ano) as ano_max
+from `{PUB}.despesa`
+where sigla_uf = 'RS'
+"""
+
+GRAIN = f"""
+select
+    count(*) as linhas,
+    count(distinct id_empenho) as empenhos,
+    countif(n > 1) as empenhos_multi_linha
+from (
+    select id_empenho, count(*) as n
+    from `{PUB}.despesa` where sigla_uf = 'RS' group by id_empenho
+)
+"""
+
+NULLS = f"""
+select
+    count(*) as n,
+    countif(data is null) / count(*) as data_null,
+    countif(mes is null) / count(*) as mes_null,
+    countif(nome_credor is null) / count(*) as credor_null,
+    countif(documento_credor is null) / count(*) as doc_null,
+    countif(tipo_documento_credor is null) / count(*) as tipo_doc_null,
+    countif(descricao is null) / count(*) as descricao_null,
+    countif(modalidade_licitacao is null) / count(*) as modalidade_null
+from `{PUB}.despesa`
+where sigla_uf = 'RS'
+"""
+
+# The six months absent from RS's catalogue. Pinned so a SEVENTH gap is a failure
+# rather than a shrug -- nothing else in the pipeline can see a missing month.
+KNOWN_GAPS = {(2020, 6), (2020, 8), (2022, 4), (2023, 2), (2023, 6), (2023, 8)}
+
+MONTHS = f"""
+select distinct ano, mes from `{PUB}.despesa`
+where sigla_uf = 'RS' and ano is not null and mes is not null
+"""
+
+
+def one(client: bigquery.Client, sql: str) -> dict:
+    return dict(next(iter(client.query(sql).result())).items())
+
+
+def main() -> None:
+    client = bigquery.Client(project=PROJECT)
+    failures: list[str] = []
+
+    print(f"=== phases present in staging ({ENV}) ===")
+    seen = {}
+    for r in client.query(PHASES).result():
+        seen[r.fase] = (r.n, r.total)
+        placement = KNOWN_PHASES.get(
+            r.fase, "!!! UNKNOWN -- money with nowhere to go"
+        )
+        print(
+            f"  {r.fase!s:26} {r.n:>12,}  R$ {r.total:>18,.2f}  -> {placement}"
+        )
+        if r.fase not in KNOWN_PHASES:
+            failures.append(
+                f"unknown FaseGasto {r.fase!r} ({r.n:,} rows, R$ {r.total:,.2f}) is "
+                "excluded from every value column by the pivot"
+            )
+
+    sem_fase = seen.get(None, (0, 0.0))[0]
+    if sem_fase > 1000:
+        failures.append(
+            f"{sem_fase:,} rows carry no FaseGasto (was 270 at onboarding); that is "
+            "money the pivot cannot place"
+        )
+
+    raw, model = one(client, RAW), one(client, MODEL)
+    print(f"\n=== despesa / RS ({ENV}) ===")
+    print(f"{'metric':16} {'raw':>22} {'model':>22}  status")
+    ok = raw["n_empenhos"] == model["n_empenhos"]
+    print(
+        f"{'n_empenhos':16} {raw['n_empenhos']!s:>22} {model['n_empenhos']!s:>22}  "
+        f"{'OK' if ok else 'MISMATCH'}"
+    )
+    if not ok:
+        failures.append(
+            f"n_empenhos: raw {raw['n_empenhos']} vs model {model['n_empenhos']}"
+        )
+
+    # Tolerance is looser than validate_es's 1e-12 for a specific reason: the pivot
+    # regroups 50.6M float64 additions, and summation ORDER alone moves the total by
+    # ~R$8 on R$887bn (8.7e-12). Verified exact under DECIMAL(20,2) locally, so the
+    # residue here is representation, not data.
+    for key, label in (
+        ("v_emp", "valor_empenhado"),
+        ("v_liq", "valor_liquidado"),
+        ("v_pago", "valor_pago"),
+    ):
+        r, m = raw[key] or 0.0, model[key] or 0.0
+        rel = abs(r - m) / max(abs(r), 1.0)
+        ok = rel < 1e-9
+        print(
+            f"{label:16} {r:>22,.2f} {m:>22,.2f}  "
+            f"{'OK' if ok else f'MISMATCH rel={rel:.2e}'}"
+        )
+        if not ok:
+            failures.append(f"{label}: relative difference {rel:.2e}")
+
+    span = f"{model['ano_min']}-{model['ano_max']}"
+    print(f"{'ano span':16} {'':>22} {span:>22}")
+
+    print("\n=== grain ===")
+    g = one(client, GRAIN)
+    print(f"  rows {g['linhas']:,}  distinct empenhos {g['empenhos']:,}")
+    print(
+        f"  empenhos on >1 budget line: {g['empenhos_multi_linha']:,} "
+        f"({g['empenhos_multi_linha'] / max(g['empenhos'], 1):.3%})"
+    )
+    # Measured at 222 of 14,763,432. A pivot with a wrong key would blow this up.
+    if g["empenhos_multi_linha"] > g["empenhos"] * 0.001:
+        failures.append(
+            f"{g['empenhos_multi_linha']:,} empenhos span >1 row -- the pivot key is "
+            "probably wrong"
+        )
+
+    print("\n=== null rates ===")
+    n = one(client, NULLS)
+    total = n.pop("n")
+    print(f"rows: {total:,}")
+    for key, rate in n.items():
+        flag = "   <-- ENTIRELY NULL" if rate >= 1.0 else ""
+        print(f"  {key:20} {rate:7.2%}{flag}")
+        if rate >= 1.0:
+            failures.append(f"{key} is 100% null")
+
+    print("\n=== calendar coverage ===")
+    have = {(r.ano, r.mes) for r in client.query(MONTHS).result()}
+    lo, hi = min(have), max(have)
+    expected = {
+        (y, m)
+        for y in range(lo[0], hi[0] + 1)
+        for m in range(1, 13)
+        if lo <= (y, m) <= hi
+    }
+    gaps = sorted(expected - have)
+    print(
+        f"  months present {len(have)}  span {lo[0]}-{lo[1]:02d}..{hi[0]}-{hi[1]:02d}"
+    )
+    print(f"  gaps: {[f'{y}-{m:02d}' for y, m in gaps] or 'none'}")
+    new_gaps = set(gaps) - KNOWN_GAPS
+    if new_gaps:
+        failures.append(
+            f"new month gap(s) not present at onboarding: "
+            f"{[f'{y}-{m:02d}' for y, m in sorted(new_gaps)]}"
+        )
+
+    print()
+    if failures:
+        print(f"FAILED ({len(failures)}):")
+        for f in failures:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("ALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/br_bd_execucao_estadual/schema.yml
+++ b/models/br_bd_execucao_estadual/schema.yml
@@ -8,14 +8,20 @@ models:
       linha corresponde a um documento de empenho combinado a uma linha orçamentária,
       com
       os valores empenhado, liquidado e pago. Dados extraídos dos sistemas financeiros
-      estaduais (SIAFI/MG, e-Fisco/PE, SIGEFES/ES) e harmonizados em um esquema comum.
+      estaduais (SIAFI/MG, e-Fisco/PE, SIGEFES/ES, CAGE/RS) e harmonizados em um esquema
+      comum.
       Só entram
       aqui
       os estados cuja fonte publica o número do empenho, o credor e os valores na
       mesma
       linha; estados cuja fonte publica apenas agregados estão em despesa_mensal e
       despesa_anual. A granularidade temporal varia por estado, e Pernambuco não publica
-      data nem mês, apenas o exercício, de modo que um filtro por mês exclui PE.
+      data nem mês, apenas o exercício, de modo que um filtro por mês exclui PE. O
+      Rio Grande do Sul publica uma linha por fase (empenho, liquidação, pagamento);
+      aqui elas são pivotadas para uma linha por empenho, e a retenção — que é
+      descontada de dentro do pagamento — fica de fora para não contá-la duas vezes.
+      Seis meses não constam do catálogo do RS: 2020-06, 2020-08, 2022-04, 2023-02,
+      2023-06 e 2023-08.
     # Sem teste de unicidade, e isso é deliberado: a tabela não tem chave de linha. Em
     # 2023 Minas Gerais publica 9,3% de linhas integralmente idênticas (mesmo empenho,
     # documento, data e valor), o que a fonte permite. Não são multiplicação do modelo:

--- a/models/br_bd_execucao_estadual/states/br_bd_execucao_estadual__despesa_rs.sql
+++ b/models/br_bd_execucao_estadual/states/br_bd_execucao_estadual__despesa_rs.sql
@@ -1,0 +1,195 @@
+{{ config(materialized="ephemeral") }}
+
+-- Rio Grande do Sul execution, PIVOTED onto the canonical `despesa` schema.
+--
+-- Source: CAGE's `Gasto-RS` via dados.rs.gov.br, monthly ZIPs, 2012-2026, CC0.
+--
+-- **RS is the only source here published as one row per PHASE.** MG, BA, PE and SP all
+-- put `empenhado` / `liquidado` / `pago` side by side on one row, which is why this
+-- dataset has one `despesa` table rather than MiDES's three. RS instead emits a
+-- movement per phase, so it is pivoted here to match. That direction works and the
+-- reverse does not: unpivoting a three-column row invents documents and dates the
+-- source never published, while pivoting only aggregates rows that already exist.
+--
+-- The phases nest cleanly, which is what makes the pivot safe -- every row carries its
+-- empenho, and each later phase adds its own document number:
+--
+-- Empenho      15,021,610 rows   empenho only
+-- Liquidação   15,692,456        empenho + liquidacao
+-- Pagamento    14,921,596        empenho + liquidacao + pagamento
+-- Retenção      4,930,110        empenho + liquidacao + retencao
+--
+-- Two phases are corrections and one is a different concept:
+--
+-- * `Prescrição de Empenho` (687 rows, -R$86.4M) and `Prescrição de Liquidação`
+-- (626, -R$1.7M) are lapsed commitments, carrying negative values. They are folded
+-- into the phase they correct, so the totals are net of write-offs.
+-- * **`Retenção` is EXCLUDED** (4,930,110 rows, R$27.5bn). A retenção is tax or
+-- charge withheld from within a payment, not additional expenditure; adding it to
+-- any of the three columns would double-count money already in `valor_pago`. The
+-- canonical schema has no column for it, so it is dropped rather than misfiled.
+-- * 270 rows carry no `FaseGasto` at all (-R$33.1M) and cannot be attributed.
+--
+-- Grain is one row per empenho x budget line, matching the other states. That is
+-- almost one row per empenho: of 14,763,432 empenhos, only 222 (0.002%) touch a second
+-- budget line and NONE has more than one creditor.
+--
+-- `ano`, `mes` and `data` come from the empenho's own commitment row, so a 2020
+-- commitment paid in 2021 stays in 2020 with its payment beside it -- the same
+-- semantics as MG. 173,649 empenhos (1.18%) have no commitment row, because they were
+-- committed before 2012 or inside one of the six months missing from RS's catalogue;
+-- those fall back to their earliest movement.
+with
+    fonte as (
+        select *
+        from {{ set_datalake_project("br_bd_execucao_estadual_staging.rs_despesa") }}
+    ),
+    movimento as (
+        select
+            nullif(trim(empenho), '') as empenho,
+            trim(fasegasto) as fase,
+            safe_cast(ano as int64) as ano_mov,
+            safe_cast(mes as int64) as mes_mov,
+            safe.parse_date('%d/%m/%Y', substr(trim(data), 1, 10)) as data_mov,
+            -- BR decimal comma, no thousands separator ('182,63', '300000,00'), the
+            -- same shape as BA and ES. Do NOT copy this to SP, where 76% of values
+            -- carry a '.' thousands separator and this expression would null them.
+            safe_cast(replace(valor, ',', '.') as float64) as valor,
+            trim(cod_orgao) as cod_orgao,
+            trim(orgao) as nome_orgao,
+            trim(cod_uo) as cod_uo,
+            trim(uo) as nome_uo,
+            trim(cod_funcao) as cod_funcao,
+            trim(cod_subfuncao) as cod_subfuncao,
+            trim(cod_programa) as cod_programa,
+            trim(cod_acao) as cod_acao,
+            trim(cod_categoria) as cod_categoria,
+            trim(cod_grupo) as cod_grupo,
+            trim(cod_modalidade) as cod_modalidade,
+            trim(cod_elemento) as cod_elemento,
+            trim(cod_rubrica) as cod_rubrica,
+            trim(cod_recurso) as cod_recurso,
+            nullif(trim(cnpj), '') as documento_credor,
+            nullif(trim(favorecido), '') as nome_credor,
+            nullif(trim(procedimentolicitatorio), '') as modalidade_licitacao,
+            nullif(trim(informacoes_complementares), '') as descricao
+        from fonte
+        where nullif(trim(empenho), '') is not null
+    ),
+    pivotado as (
+        select
+            empenho,
+            cod_orgao,
+            cod_uo,
+            cod_funcao,
+            cod_subfuncao,
+            cod_programa,
+            cod_acao,
+            cod_categoria,
+            cod_grupo,
+            cod_modalidade,
+            cod_elemento,
+            cod_rubrica,
+            cod_recurso,
+            -- ONE row supplies ano, mes and data together. Minimising them separately
+            -- invents pairs that never occurred: an empenho with movements in 2020-07
+            -- and 2021-03 came out as 2020-03, which silently filled all six months
+            -- missing from RS's catalogue and reported a complete calendar.
+            --
+            -- The ordering prefers the empenho's own commitment row, then the earliest
+            -- movement, so a 2020 commitment paid in 2021 keeps its 2020 date with the
+            -- payment beside it -- the same semantics as MG.
+            array_agg(
+                struct(ano_mov as ano, mes_mov as mes, data_mov as data)
+                order by
+                    if(fase = 'Empenho', 0, 1),
+                    -- Sentinels rather than `nulls last`: BigQuery rejects that
+                    -- combination inside an aggregate's ORDER BY, and a row whose
+                    -- exercise failed to cast must not win the ordering.
+                    coalesce(ano_mov, 9999),
+                    coalesce(mes_mov, 99),
+                    coalesce(data_mov, date '9999-12-31')
+                limit 1
+            )[safe_offset(0)] as first_mov,
+            max(nome_orgao) as nome_orgao,
+            max(nome_uo) as nome_uo,
+            max(descricao) as descricao,
+            max(modalidade_licitacao) as modalidade_licitacao,
+            max(documento_credor) as documento_credor,
+            max(nome_credor) as nome_credor,
+            sum(
+                if(fase in ('Empenho', 'Prescrição de Empenho'), valor, 0)
+            ) as valor_empenhado,
+            sum(
+                if(fase in ('Liquidação', 'Prescrição de Liquidação'), valor, 0)
+            ) as valor_liquidado,
+            sum(if(fase = 'Pagamento', valor, 0)) as valor_pago
+        from movimento
+        group by
+            empenho,
+            cod_orgao,
+            cod_uo,
+            cod_funcao,
+            cod_subfuncao,
+            cod_programa,
+            cod_acao,
+            cod_categoria,
+            cod_grupo,
+            cod_modalidade,
+            cod_elemento,
+            cod_rubrica,
+            cod_recurso
+    )
+
+select
+    first_mov.ano as ano,
+    first_mov.mes as mes,
+    first_mov.data as data,
+    'RS' as sigla_uf,
+    cod_orgao as orgao,
+    nome_orgao as nome_orgao,
+    cod_uo as id_unidade_gestora,
+    nome_uo as nome_unidade_gestora,
+    concat('RS-', empenho) as id_empenho_bd,
+    empenho as id_empenho,
+    empenho as numero_empenho,
+    -- RS publishes no empenho type (ordinário / estimativo / global). `TipoGasto` has
+    -- two values and describes the spending route, not that classification.
+    safe_cast(null as string) as tipo_empenho,
+    descricao as descricao,
+    -- RS publishes no tender table at all -- a 14-keyword sweep of its 412 CKAN
+    -- packages found no licitações -- so there is nothing for a tender id to reach.
+    -- Emitting one from `Processo` would leave every key dangling, which reads as a
+    -- link; see despesa_es for the same decision made the other way once a tender
+    -- table existed.
+    safe_cast(null as string) as id_licitacao_bd,
+    safe_cast(null as string) as id_licitacao,
+    modalidade_licitacao as modalidade_licitacao,
+    documento_credor as documento_credor,
+    nome_credor as nome_credor,
+    -- Derived from the published format, not inferred from content: RS prints natural
+    -- persons as `000.000.000-00` (fully zeroed, unlike MG's `***.195.606-**`) and
+    -- companies as a full CNPJ, and the two masks are structurally distinct.
+    case
+        when documento_credor like '%/%'
+        then 'PJ'
+        when documento_credor is not null
+        then 'PF'
+    end as tipo_documento_credor,
+    cod_funcao as funcao,
+    cod_subfuncao as subfuncao,
+    cod_programa as programa,
+    cod_acao as acao,
+    cod_categoria as categoria_economica,
+    cod_grupo as grupo_despesa,
+    cod_modalidade as modalidade_aplicacao,
+    cod_elemento as elemento_despesa,
+    cod_rubrica as item_despesa,
+    cod_recurso as fonte_recurso,
+    -- The document type IS the phase in this source, and the pivot has just consumed
+    -- it, so there is nothing left for this column to carry.
+    safe_cast(null as string) as tipo_documento,
+    valor_empenhado as valor_empenhado,
+    valor_liquidado as valor_liquidado,
+    valor_pago as valor_pago
+from pivotado

--- a/pipelines/datasets/br_bd_execucao_estadual/constants.py
+++ b/pipelines/datasets/br_bd_execucao_estadual/constants.py
@@ -60,6 +60,7 @@ class constants(Enum):
     # mg_dm_acao. This pipeline is what populates prod staging, by uploading every
     # mirror below to the prod bucket itself.
     STAGING_BY_STATE = {
+        "RS": ["rs_despesa"],
         "ES": [
             "es_despesa",
             "es_licitacao",

--- a/pipelines/datasets/br_bd_execucao_estadual/coverage.py
+++ b/pipelines/datasets/br_bd_execucao_estadual/coverage.py
@@ -42,6 +42,9 @@ MONTHLY = {
     # `ano` and no `mes`, so there is no month to report.
     ("despesa", "ES"),
     ("licitacao", "ES"),
+    # RS carries a full date on every movement, and the pivot keeps the
+    # commitment row's month, so despesa/RS is month-granular.
+    ("despesa", "RS"),
 }
 
 # Tables with no date column at all: their coverage carries no range to refresh.

--- a/pipelines/datasets/br_bd_execucao_estadual/flows.py
+++ b/pipelines/datasets/br_bd_execucao_estadual/flows.py
@@ -61,6 +61,13 @@ DATASET_ID = constants.DATASET_ID.value
 # once per state would run the same model twice for no gain.
 # ES is per-year bulk CSV like MG, so it belongs in the daily group rather
 # than the weekly one, which exists only for SP's per-(exercise, orgao) scrape.
+# RS is deliberately absent from BOTH schedules, though `refresh_rs` exists and works.
+#
+# `dados.rs.gov.br` refused a residential Australian ISP outright while answering from a
+# university range, and has since gone unreachable again -- the reachability is
+# path-dependent, and whether a GKE worker can reach it AT ALL is untested. Scheduling
+# it before that is known would fail the daily run every day and bury the states that do
+# work. Add "RS" here once a flow run has actually fetched from the cluster.
 DAILY_STATES = ["MG", "BA", "PE", "ES"]
 WEEKLY_STATES = ["SP"]
 

--- a/pipelines/datasets/br_bd_execucao_estadual/utils.py
+++ b/pipelines/datasets/br_bd_execucao_estadual/utils.py
@@ -139,6 +139,24 @@ def refresh_es(work_dir: str, year: int, full: bool) -> None:
     clean_es.main()
 
 
+def refresh_rs(work_dir: str, year: int, full: bool) -> None:
+    """Rio Grande do Sul, year-scoped like MG and ES.
+
+    RS publishes one ZIP per month per exercise, so a scoped run re-fetches only the
+    open years' twelve archives. The conversion is the expensive half: ~36 GB expanded
+    across the full series, one archive at a time.
+    """
+    _ensure_code_on_path(work_dir)
+    # pyrefly: ignore [missing-import]
+    import clean_rs
+
+    # pyrefly: ignore [missing-import]
+    import download_rs
+
+    download_rs.main(years=_years(year, full))
+    clean_rs.main()
+
+
 def refresh_sp(work_dir: str, year: int, full: bool) -> None:
     """São Paulo, scraped one (exercise, órgão) at a time.
 
@@ -166,6 +184,7 @@ REFRESHERS = {
     "BA": refresh_ba,
     "PE": refresh_pe,
     "ES": refresh_es,
+    "RS": refresh_rs,
     "SP": refresh_sp,
 }
 


### PR DESCRIPTION
Adds **Rio Grande do Sul** as the sixth state: 50.6M staging movements pivoted to **14,763,654 rows** over 2012–2026, under **CC0-1.0** — the most permissive licence in the dataset.

> Stacked on #1991 (Espírito Santo). Base is `data/br_bd_execucao_estadual_es`, so this diff shows only the RS changes. Merge #1991 first.

## RS is the only source published one row per phase

MG, BA, PE, SP and ES all put `empenhado` / `liquidado` / `pago` side by side on one row — the reason this dataset has one `despesa` table rather than MiDES's three. RS instead emits a movement per phase, so it is **pivoted** to match.

That direction works and the reverse does not: unpivoting a three-column row invents documents and dates the source never published, while pivoting only aggregates rows that already exist. The phases nest cleanly, which is what makes it safe — every row carries its empenho, and each later phase adds its own document.

Three judgement calls inside the pivot:

- **`Retenção` is excluded** (4,930,110 rows, R$27.5bn). Tax withheld from *within* a payment, not additional expenditure; adding it anywhere would double-count money already in `valor_pago`.
- **`Prescrição de Empenho` / `de Liquidação`** (1,313 rows, −R$88.2M) are lapsed commitments and fold into the phase they correct, so totals are net of write-offs.
- **`id_licitacao*` is null.** RS publishes no tender table at all — a 14-keyword sweep of its 412 CKAN packages found none — so a key built from `Processo` would dangle on every row.

## Five source defects, each hidden behind the previous one

- **Windows-1252, not latin-1.** Smart quotes at `0x91`–`0x96` that latin-1 leaves undefined; duckdb refuses the file outright. **Python's latin-1 decodes any byte sequence**, so a probe "confirms" latin-1 and yields mojibake. Transcoded on unpacking, with cp1252's five undefined bytes decoded losslessly rather than replaced.
- **Schema drifts three times** (62 → 66 → 67 columns, plus an accent dropped from a column name). Every partition is written to the superset, or the wildcard load keeps one schema and NULLs the rest — the failure that cost PE 25 columns and 1,031,326 rows.
- **17,366 ragged rows.** No quoting convention anywhere, so the trailing free-text column's semicolons split the row. Verified the surplus always belongs to that column: **17,366 of 17,366, 0 violations**. Repaired by re-emitting with a delimiter absent from the data — rejoining with `;` provably does nothing, since there is no way to say "this semicolon is data" in an unquoted file.
- **Control bytes as data** — `2016-02` carries `0x01`, `0x1E` *and* `0x1F` — so the temp delimiter is chosen per file and refused if seen in the input.
- **Six months are missing from RS's own catalogue** (2020-06, 2020-08, 2022-04, 2023-02, 2023-06, 2023-08): those slots serve the neighbouring month's file. 175 archives, every CRC valid, twelve files per exercise — only grouping by the data's own `(Exercicio, Mes)` finds it.

Coverage therefore registers as **seven ranges**, not one, summing to exactly the 169 months present. Multiple ranges rather than multiple coverages: a `Coverage` is keyed by area, so duplicating it produces ambiguous records the backend cannot delete.

## Verification

- `dbt run` **10/10**, `dbt test` **38/38**, sqlfmt/ruff/pyrefly clean
- `validate_rs` reconciles `n_empenhos` and all three money columns against the raw mirror: **R$886.97bn empenhado / R$874.22bn liquidado / R$834.50bn pago**
- The pivot is **exact to the cent** under `DECIMAL(20,2)`; the ~R$8 residue in float64 is summation order, verified separately
- The phase inventory is a **hard gate** — an unrecognised `FaseGasto` would otherwise vanish from every value column in silence
- The six gaps are pinned, so a *seventh* fails the check

`despesa` is now **115.3M rows** across six states.

## Not scheduled, deliberately

`refresh_rs` works, but `dados.rs.gov.br` refused a residential Australian ISP while answering from a university range, and whether a GKE worker can reach it at all is untested. Scheduling it before that is known would fail the daily run every day and bury the states that do work.