### PR TITLE
[Fix] us_nih_reporter — address the review findings on #1997

### DIFF
--- a/models/us_nih_reporter/CLAUDE.md
+++ b/models/us_nih_reporter/CLAUDE.md
@@ -345,12 +345,27 @@ step 13, a separate action.
 | table `dicionario` | `3c9211c6-1aeb-425b-b6e4-7f0ad0219b20` |
 | account | `4` |
 
+**The prod tables carry `Table.Update.latest = 1970-01-01`, deliberately.** Prod
+has never been materialised — table-approve builds those tables when the PR
+merges — so a real date there would claim a refresh that had not happened, and
+the poll (`compare_against="table_update"`, strict `source_max > latest`) would
+then suppress the table's first refresh. The epoch is used because it cannot be
+mistaken for a real materialisation. The first materialisation overwrites it
+with a true wall clock; `register_metadata.py` only writes this field when
+passed `--materialized`, which is true of staging (dbt built and tested those
+tables) and not of prod.
+
 **Reference ids are not interchangeable between the two environments, and the
 tag slugs are not either.** The `project` entity is `c5b8b0a3-…` on staging and
 `53374e81-…` on prod. Staging's tag vocabulary is Portuguese and prod's is
 English — `pesquisa` there is `research` here, on the same UUID — so
 `register_metadata.py` lists both spellings per tag and takes whichever the
 environment has, rather than resolving one slug and failing on the other.
+
+Both metadata scripts import the Data Basis MCP `server` module, which is a
+**separate checkout, not a dependency of this repo**. Set `DATABASIS_MCP_PATH`
+to the directory holding `server.py`; `common.import_mcp_server()` validates it
+and fails with a named error rather than a bare `ModuleNotFoundError`.
 
 ## The `clinical_study` entity
 

--- a/models/us_nih_reporter/code/common.py
+++ b/models/us_nih_reporter/code/common.py
@@ -68,3 +68,45 @@ DATA_TABLES = [t for t in ALL_TABLES if t != "dicionario"]
 # The full published corpus, as of the FY2025 project release.
 FISCAL_YEARS = list(range(constants.FIRST_FISCAL_YEAR.value, 2026))
 CALENDAR_YEARS = list(range(constants.FIRST_CALENDAR_YEAR.value, 2026))
+
+
+def import_mcp_server():
+    """Import the Data Basis MCP ``server`` module.
+
+    The MCP server is a **separate checkout**, not a dependency of this
+    repository, so its location cannot be hardcoded and it is not importable in
+    CI at all. Set ``DATABASIS_MCP_PATH`` to the directory holding
+    ``server.py``; the two metadata scripts use it, nothing else does.
+
+    Returns:
+        The imported ``server`` module.
+
+    Raises:
+        SystemExit: when the module is neither already importable nor findable
+            through ``DATABASIS_MCP_PATH`` — a named configuration error rather
+            than a bare ``ModuleNotFoundError`` from an import that silently
+            fell through a nonexistent path.
+    """
+    try:
+        import server  # already importable: installed, or on PYTHONPATH
+
+        return server
+    except ModuleNotFoundError:
+        pass
+
+    configured = os.environ.get("DATABASIS_MCP_PATH", "").strip()
+    if not configured:
+        raise SystemExit(
+            "DATABASIS_MCP_PATH is not set. Point it at the directory holding "
+            "the Data Basis MCP server.py (the basedosdados/mcp checkout)."
+        )
+    path = Path(configured).expanduser()
+    if not (path / "server.py").is_file():
+        raise SystemExit(
+            f"No server.py under DATABASIS_MCP_PATH={path}. Point it at the "
+            "directory holding the Data Basis MCP server.py."
+        )
+    sys.path.insert(0, str(path))
+    import server
+
+    return server

--- a/models/us_nih_reporter/code/gen_columns_json.py
+++ b/models/us_nih_reporter/code/gen_columns_json.py
@@ -14,6 +14,18 @@ from common import ALL_TABLES, load_cols
 
 
 def payload(table: str) -> list[dict]:
+    """Build one table's bulk_upsert_columns payload from its architecture CSV.
+
+    Optional keys are omitted rather than sent empty: bulk_upsert_columns writes
+    only the fields present for a row, so an empty string would blank a value
+    that is already correct on a re-run.
+
+    Args:
+        table: Clean table slug, matching a sheet_<table>.csv.
+
+    Returns:
+        One dict per column, in the architecture's column order.
+    """
     out = []
     for c in load_cols(table):
         entry = {
@@ -38,6 +50,15 @@ def payload(table: str) -> list[dict]:
 
 
 def main() -> None:
+    """Write one columns_<table>.json per table into the output directory.
+
+    Args:
+        None. The first command-line argument is the output directory,
+        defaulting to the working directory.
+
+    Returns:
+        None. Writes one JSON file per table and prints each path.
+    """
     out_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
     out_dir.mkdir(parents=True, exist_ok=True)
     for table in ALL_TABLES:

--- a/models/us_nih_reporter/code/gen_dbt.py
+++ b/models/us_nih_reporter/code/gen_dbt.py
@@ -65,6 +65,10 @@ SCOPED_NULL_TEST = set(PARTITIONED_TABLES)
 NOT_NULL = {t: list(k) for t, k in KEYS.items()}
 NOT_NULL["patent_link"] = ["patent_id", "core_project_num"]
 
+# The dicionario register's own key, used for its uniqueness test and
+# its not_null columns.
+DICIONARIO_KEY = ["id_tabela", "nome_coluna", "chave"]
+
 TABLE_NAMES = {
     "project": ("Projeto", "Project", "Proyecto"),
     "project_abstract": (
@@ -227,10 +231,14 @@ def write_schema() -> None:
         lines.append("    description: >-")
         lines.append(_block(TABLE_DESCRIPTIONS[table], 6))
         lines.append("    tests:")
+        # Flow style, not a block sequence: the repo's yamlfix pre-commit hook
+        # collapses short scalar sequences onto one line, so a block sequence
+        # here would mean every run of this generator produced formatting churn
+        # against the committed file.
         lines.append("      - dbt_utils.unique_combination_of_columns:")
-        lines.append("          combination_of_columns:")
-        for k in KEYS[table]:
-            lines.append(f"            - {k}")
+        lines.append(
+            f"          combination_of_columns: [{', '.join(KEYS[table])}]"
+        )
         lines.append("      - not_null_proportion_multiple_columns:")
         lines.append("          at_least: 0.05")
         if table in SCOPED_NULL_TEST:
@@ -271,10 +279,13 @@ def write_schema() -> None:
             rels = []
             if c.name == "year":
                 rels.append(("br_bd_diretorios_data_tempo__ano", "ano.ano"))
-            if tests or rels:
+            if tests and not rels:
+                # Same yamlfix rule: a lone `tests: [not_null]` is collapsed.
+                lines.append(f"        tests: [{', '.join(tests)}]")
+            elif tests or rels:
                 lines.append("        tests:")
-                for t in tests:
-                    lines.append(f"          - {t}")
+                for name in tests:
+                    lines.append(f"          - {name}")
                 for to, field in rels:
                     lines.append("          - relationships:")
                     lines.append(f"              to: ref('{to}')")
@@ -300,15 +311,15 @@ def write_schema() -> None:
     )
     lines.append("    tests:")
     lines.append("      - dbt_utils.unique_combination_of_columns:")
-    lines.append("          combination_of_columns:")
-    for k in ("id_tabela", "nome_coluna", "chave"):
-        lines.append(f"            - {k}")
+    lines.append(
+        f"          combination_of_columns: [{', '.join(DICIONARIO_KEY)}]"
+    )
     lines.append("    columns:")
     for c in load_cols("dicionario"):
         lines.append(f"      - name: {c.name}")
         lines.append("        description: >-")
         lines.append(_block(c.description_pt, 10))
-        if c.name in ("id_tabela", "nome_coluna", "chave"):
+        if c.name in DICIONARIO_KEY:
             lines.append("        tests: [not_null]")
 
     (MODELS / "schema.yml").write_text("\n".join(lines) + "\n")

--- a/models/us_nih_reporter/code/register_metadata.py
+++ b/models/us_nih_reporter/code/register_metadata.py
@@ -4,7 +4,10 @@ Idempotent by construction: every create_update_* call is given the id read back
 from get_dataset when the record already exists, because those tools create a
 second record when called without one.
 
+Set ``DATABASIS_MCP_PATH`` to the Data Basis MCP checkout before running.
+
 Run: ~/.venvs/bd-pipelines/bin/python register_metadata.py [staging|prod]
+     [--materialized]
 """
 
 import json
@@ -12,12 +15,21 @@ import sys
 from datetime import date
 from pathlib import Path
 
-sys.path.insert(
-    0, "/Users/rdahis/Monash Uni Enterprise Dropbox/Ricardo Dahis/BD/mcp"
-)
-import server
+from common import import_mcp_server
 
-ENV = sys.argv[1] if len(sys.argv) > 1 else "staging"
+server = import_mcp_server()
+
+ARGS = sys.argv[1:]
+ENV = next((a for a in ARGS if not a.startswith("-")), "staging")
+
+# Whether this environment's BigQuery tables have actually been built. It gates
+# one thing: the table-anchored Update record, whose `latest` means "when Data
+# Basis last refreshed this table". Registration alone refreshes nothing, and
+# the poll reads that field (`compare_against="table_update"`) with a strict
+# `source_max > latest`, so writing today's date here would both claim a
+# materialisation that has not happened and suppress the table's first refresh.
+# Off by default so a bare re-run can never re-introduce that claim.
+MATERIALIZED = "--materialized" in ARGS
 COLUMNS_DIR = Path(__file__).resolve().parent / "columns"
 
 DATASET_SLUG = "nih_reporter"
@@ -740,17 +752,26 @@ def main() -> int:
                 env=ENV,
             )
 
-        # table update record: when Data Basis last refreshed the table
-        have_up = [u["id"] for u in p.get("updates", [])]
-        server.create_update_update(
-            id=have_up[0] if have_up else None,
-            table_id=tid,
-            entity_id=entity["year"],
-            frequency=1,
-            latest=f"{date.today()}T00:00:00",
-            env=ENV,
+        # Table-anchored Update: when Data Basis last refreshed the table.
+        # Written only when this environment's tables really have been built —
+        # see MATERIALIZED above. On prod they are materialised by the
+        # table-approve action on merge, not by this script, so a bare prod
+        # registration leaves the record alone and the first materialisation
+        # (or `register_table_materialization_task`) sets it.
+        if MATERIALIZED:
+            have_up = [u["id"] for u in p.get("updates", [])]
+            server.create_update_update(
+                id=have_up[0] if have_up else None,
+                table_id=tid,
+                entity_id=entity["year"],
+                frequency=1,
+                latest=f"{date.today()}T00:00:00",
+                env=ENV,
+            )
+        print(
+            "  cloud table, coverage, datetime range"
+            + (", update: ok" if MATERIALIZED else " (update skipped): ok")
         )
-        print("  cloud table, coverage, datetime range, update: ok")
 
     # deferred raw source links --------------------------------------------
     for spec in RAW_SOURCES:

--- a/models/us_nih_reporter/code/upload.py
+++ b/models/us_nih_reporter/code/upload.py
@@ -59,7 +59,23 @@ EXPECTED_FILES = {
 _orig_bucket = gcs.Client.bucket
 
 
-def _patched_bucket(self, bucket_name, user_project=None):
+def _patched_bucket(
+    self: gcs.Client, bucket_name: str, user_project: str | None = None
+) -> gcs.Bucket:
+    """Return a bucket handle that always bills BILLING_PROJECT.
+
+    The Data Basis buckets are requester-pays, so every call needs a
+    user_project. Callers inside the basedosdados SDK do not pass one, hence
+    the patch rather than a wrapper.
+
+    Args:
+        self: The storage client, since this replaces an unbound method.
+        bucket_name: Name of the bucket to open.
+        user_project: Ignored — BILLING_PROJECT always wins.
+
+    Returns:
+        The bucket handle, pinned to the billing project.
+    """
     return _orig_bucket(self, bucket_name, user_project=BILLING_PROJECT)
 
 
@@ -69,11 +85,28 @@ from pipelines.utils.tasks import _upload_to_gcs  # noqa: E402
 
 
 def local_rows(table: str) -> tuple[int, int]:
+    """Row count and file count of a table's local parquet.
+
+    Args:
+        table: Clean table slug.
+
+    Returns:
+        ``(rows, files)`` read from the parquet metadata, not the data.
+    """
     files = sorted((OUTPUT / table).rglob("*.parquet"))
     return sum(pq.ParquetFile(f).metadata.num_rows for f in files), len(files)
 
 
 def staging_rows(client: bigquery.Client, table: str) -> int:
+    """Row count of the table's staging external table.
+
+    Args:
+        client: An authenticated BigQuery client.
+        table: Clean table slug.
+
+    Returns:
+        The row count reported by BigQuery.
+    """
     ref = f"{BILLING_PROJECT}.{DATASET_ID}_staging.{table}"
     return next(
         iter(client.query(f"select count(*) n from `{ref}`").result())
@@ -81,6 +114,19 @@ def staging_rows(client: bigquery.Client, table: str) -> int:
 
 
 def upload(table: str) -> None:
+    """Upload one table's parquet to staging and verify what landed.
+
+    Args:
+        table: Clean table slug.
+
+    Returns:
+        None.
+
+    Raises:
+        SystemExit: when the parquet file count, the staging row count, the
+            table type or the staging schema does not match what the pipeline
+            will later expect.
+    """
     expected, nfiles = local_rows(table)
     print(
         f"\n[{table}] local: {expected:,} rows across {nfiles} parquet file(s)"
@@ -138,6 +184,14 @@ def upload(table: str) -> None:
 
 
 def main() -> None:
+    """Upload every table named on the command line, or all of them.
+
+    Returns:
+        None.
+
+    Raises:
+        SystemExit: when credentials are unset or a table name is unknown.
+    """
     if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
         raise SystemExit("GOOGLE_APPLICATION_CREDENTIALS is not set")
     # gcs.dump_header writes its 0-row header parquet to ./data/<uuid>/ relative

--- a/models/us_nih_reporter/code/verify_metadata.py
+++ b/models/us_nih_reporter/code/verify_metadata.py
@@ -9,10 +9,9 @@ for the duplicate records create_update_* produces when called without an id.
 import sys
 from collections import Counter
 
-sys.path.insert(
-    0, "/Users/rdahis/Monash Uni Enterprise Dropbox/Ricardo Dahis/BD/mcp"
-)
-import server
+from common import import_mcp_server
+
+server = import_mcp_server()
 
 ENV = sys.argv[1] if len(sys.argv) > 1 else "staging"
 SLUG = "nih_reporter"

--- a/models/us_nih_reporter/code/verify_parquet.py
+++ b/models/us_nih_reporter/code/verify_parquet.py
@@ -188,38 +188,51 @@ def main() -> int:
             project_keys = np.unique(h)
         del h
 
+    # Every join check reads project. When project wrote no parquet the loop
+    # above recorded that in `problems` and continued, so project_keys is None
+    # here — dereferencing it would raise AttributeError, abort before the
+    # verdict is printed, and lose the exit code that reports the real failure.
     print("\n=== join integrity ===")
-    cores = key_hashes("project", files_for("project"), ["core_project_num"])
-    project_cores = np.unique(cores)
-    del cores
-    print(
-        f"  project: {project_keys.size:,} keys, "
-        f"{project_cores.size:,} distinct core_project_num"
-    )
-
-    for table in ("publication_link", "patent_link", "clinical_study_link"):
-        fs = files_for(table)
-        if not fs:
-            continue
-        h = key_hashes(table, fs, ["core_project_num"])
-        hit = int(np.isin(h, project_cores, assume_unique=False).sum())
+    if project_keys is None:
+        print("  skipped: project has no parquet, so nothing to join against")
+    else:
+        cores = key_hashes(
+            "project", files_for("project"), ["core_project_num"]
+        )
+        project_cores = np.unique(cores)
+        del cores
         print(
-            f"  {table:<22} {hit:,}/{h.size:,} rows match a project "
+            f"  project: {project_keys.size:,} keys, "
+            f"{project_cores.size:,} distinct core_project_num"
+        )
+
+        for table in (
+            "publication_link",
+            "patent_link",
+            "clinical_study_link",
+        ):
+            fs = files_for(table)
+            if not fs:
+                continue
+            h = key_hashes(table, fs, ["core_project_num"])
+            hit = int(np.isin(h, project_cores, assume_unique=False).sum())
+            print(
+                f"  {table:<22} {hit:,}/{h.size:,} rows match a project "
+                f"({100 * hit / h.size if h.size else 0:.2f}%)"
+            )
+            del h
+
+        h = key_hashes(
+            "project_abstract",
+            files_for("project_abstract"),
+            KEYS["project_abstract"],
+        )
+        hit = int(np.isin(h, project_keys, assume_unique=False).sum())
+        print(
+            f"  project_abstract       {hit:,}/{h.size:,} rows match a project "
             f"({100 * hit / h.size if h.size else 0:.2f}%)"
         )
         del h
-
-    h = key_hashes(
-        "project_abstract",
-        files_for("project_abstract"),
-        KEYS["project_abstract"],
-    )
-    hit = int(np.isin(h, project_keys, assume_unique=False).sum())
-    print(
-        f"  project_abstract       {hit:,}/{h.size:,} rows match a project "
-        f"({100 * hit / h.size if h.size else 0:.2f}%)"
-    )
-    del h
 
     print("\n=== dicionario coverage ===")
     dic: dict[tuple[str, str], set[str]] = defaultdict(set)

--- a/pipelines/datasets/us_nih_reporter/constants.py
+++ b/pipelines/datasets/us_nih_reporter/constants.py
@@ -184,3 +184,8 @@ class constants(Enum):
     DOWNLOAD_ATTEMPTS = 4
     DOWNLOAD_RETRY_SLEEP = 10
     REQUEST_TIMEOUT = 900
+
+    # The poll's two header requests per file transfer no body, so they get a
+    # far shorter deadline than a 3.6 GB download: a probe that hangs should
+    # fail the run quickly rather than sit for fifteen minutes per file.
+    PROBE_TIMEOUT = 120

--- a/pipelines/datasets/us_nih_reporter/flows.py
+++ b/pipelines/datasets/us_nih_reporter/flows.py
@@ -55,6 +55,7 @@ ignores the schedules, the prod pool activates them.
 
 import shutil
 import tempfile
+from collections.abc import Mapping
 
 from prefect import flow
 
@@ -66,6 +67,7 @@ from pipelines.datasets.us_nih_reporter.tasks import (
 )
 from pipelines.utils.metadata.domain import (
     AllFree,
+    CoverageSpec,
     DateFormat,
     NonHistorical,
     YearOnly,
@@ -111,7 +113,7 @@ _LINK_COVERAGE = {
 def _materialize(
     families: list[str],
     tables: list[str],
-    coverage: dict,
+    coverage: Mapping[str, CoverageSpec],
     anchor_table: str,
     materialize_to_prod: bool,
     update_metadata: bool,
@@ -121,6 +123,26 @@ def _materialize(
 
     Shared by the two flows: they differ only in which families they probe,
     which tables they build and which table anchors the source poll.
+
+    Args:
+        families: ExPORTER families to probe and download, as keys of
+            ``constants.FAMILIES``.
+        tables: Clean tables this group builds, uploads and tests, in build
+            order — every one is built before any is tested.
+        coverage: Clean table -> its ``CoverageSpec``, registered after a
+            successful prod materialization. A table absent from this mapping
+            gets no coverage registered, which is how ``dicionario`` is handled.
+        anchor_table: Table whose raw data source the poll and the source-update
+            commit are read from and written to.
+        materialize_to_prod: Write the prod staging bucket and run dbt against
+            ``target="prod"``. False exercises only the dev half.
+        update_metadata: Register table coverage and commit the source update
+            after a successful prod materialization. No effect when
+            ``materialize_to_prod`` is False.
+        force_run: Rebuild even when the source poll reports nothing new.
+
+    Returns:
+        None.
     """
     # pyrefly: ignore [unused-coroutine]
     rename_flow_run_dataset_table(

--- a/pipelines/datasets/us_nih_reporter/tasks.py
+++ b/pipelines/datasets/us_nih_reporter/tasks.py
@@ -73,11 +73,18 @@ def clean_corpus(work_dir: str, input_dir: str, probe: dict) -> dict:
     output_dir = Path(work_dir) / "output"
     listing = probe["listing"]
     families = {k.split("|")[0] for k in listing}
+    # Each family cleans exactly the years the probe found for it, which are the
+    # years download_corpus fetched for it. The four year-keyed families are
+    # probed independently and can disagree by a year around a release, so
+    # driving two of them from one list would either read a file that was never
+    # downloaded or skip one that was.
     counts = clean_all(
         input_dir=Path(input_dir),
         output_dir=output_dir,
-        fiscal_years=years_in(listing, "projects"),
-        calendar_years=years_in(listing, "publications"),
+        project_years=years_in(listing, "projects"),
+        abstract_years=years_in(listing, "abstracts"),
+        publication_years=years_in(listing, "publications"),
+        link_years=years_in(listing, "linktables"),
         include_all_year_tables="patents" in families,
     )
     # The dicionario's temporal coverage is computed from the project

--- a/pipelines/datasets/us_nih_reporter/utils.py
+++ b/pipelines/datasets/us_nih_reporter/utils.py
@@ -63,12 +63,14 @@ the dbt model ``safe_cast``s every column to its architecture type.
 
 import csv
 import io
+import math
 import re
 import sys
 import time
 import zipfile
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 import pyarrow as pa
@@ -196,14 +198,27 @@ def download_file(
     for attempt in range(1, constants.DOWNLOAD_ATTEMPTS.value + 1):
         try:
             with sess.get(
-                url, stream=True, timeout=constants.REQUEST_TIMEOUT.value
+                url,
+                # Ask for an unencoded body so Content-Length describes the
+                # bytes actually written, and can be used to detect a truncated
+                # transfer. On requests 2.26 / urllib3 1.26, iter_content can
+                # return normally after an early EOF, so without this check a
+                # short file reaches the cleaner as silently missing rows.
+                headers={"Accept-Encoding": "identity"},
+                stream=True,
+                timeout=constants.REQUEST_TIMEOUT.value,
             ) as resp:
                 if resp.status_code != 200:
                     last = f"HTTP {resp.status_code}"
                     raise OSError(last)
+                expected = resp.headers.get("Content-Length")
                 with open(tmp, "wb") as fh:
                     for chunk in resp.iter_content(DOWNLOAD_CHUNK):
                         fh.write(chunk)
+            written = tmp.stat().st_size
+            if expected is not None and written != int(expected):
+                last = f"truncated: got {written} bytes, expected {expected}"
+                raise OSError(last)
             if tmp.stat().st_size <= 1000:
                 last = f"suspiciously small ({tmp.stat().st_size} bytes)"
                 raise OSError(last)
@@ -277,10 +292,15 @@ def read_rows(path: Path, member: str | None = None):
     their columns differently from their neighbours.
     """
     if path.suffix.lower() == ".zip":
-        zf = zipfile.ZipFile(path)
-        members = [member] if member else zf.namelist()
-        for name in members:
-            yield from _rows_from_text(_decode(zf.open(name).read()))
+        # Context managers on both the archive and each member: this is a
+        # generator, so a caller that stops consuming it early would otherwise
+        # leave the descriptors open for the life of the process.
+        with zipfile.ZipFile(path) as zf:
+            members = [member] if member else zf.namelist()
+            for name in members:
+                with zf.open(name) as fh:
+                    raw = fh.read()
+                yield from _rows_from_text(_decode(raw))
         return
     yield from _rows_from_text(_decode(path.read_bytes()))
 
@@ -344,24 +364,35 @@ def norm_date(raw: str) -> str:
 
 
 def norm_int(raw: str) -> str:
-    """An integer rendered as text, or empty. Never ``'nan'``."""
+    """An integer rendered as text, or empty. Never ``'nan'`` or ``'inf'``.
+
+    ``float`` accepts ``nan``, ``inf`` and ``infinity``, and ``int()`` of a
+    non-finite float raises ``OverflowError`` rather than ``ValueError`` — which
+    would escape this function and abort the whole year's cleaning run. Both are
+    rejected as empty instead.
+    """
     v = (raw or "").strip().replace(",", "")
     if not v:
         return ""
     try:
-        return str(int(float(v)))
+        f = float(v)
     except ValueError:
         return ""
+    if not math.isfinite(f):
+        return ""
+    return str(int(f))
 
 
 def norm_float(raw: str) -> str:
-    """A number rendered as text, or empty."""
+    """A number rendered as text, or empty. Never ``'nan'`` or ``'inf'``."""
     v = (raw or "").strip().replace(",", "").replace("$", "")
     if not v:
         return ""
     try:
         f = float(v)
     except ValueError:
+        return ""
+    if not math.isfinite(f):
         return ""
     return str(int(f)) if f == int(f) else repr(f)
 
@@ -670,24 +701,51 @@ def clean_clinical_studies(input_dir: Path, output_dir: Path) -> int:
 def clean_all(
     input_dir: Path,
     output_dir: Path,
-    fiscal_years: list[int],
-    calendar_years: list[int],
+    project_years: list[int],
+    abstract_years: list[int],
+    publication_years: list[int],
+    link_years: list[int],
     include_all_year_tables: bool = True,
 ) -> dict[str, int]:
-    """Clean the given years. Returns ``{table: total_rows}``."""
+    """Clean the given years. Returns ``{table: total_rows}``.
+
+    **One year list per family, never one per cadence.** The four year-keyed
+    families are probed independently and their year sets are not guaranteed to
+    match: NIH published the FY2025 abstract file on 2026-03-09 and the FY2025
+    project file on 2026-07-09, so there is a window each year in which one
+    exists and the other does not. Driving the abstract cleaner from the
+    project years would then build a path for a file the download step never
+    fetched and raise ``FileNotFoundError``, failing the flow; driving it the
+    other way would silently skip a year that was downloaded.
+
+    Args:
+        input_dir: Directory holding the downloaded ExPORTER archives.
+        output_dir: Root of the partitioned parquet tree to write.
+        project_years: Fiscal years of the ``projects`` family to clean.
+        abstract_years: Fiscal years of the ``abstracts`` family to clean.
+        publication_years: Calendar years of the ``publications`` family.
+        link_years: Calendar years of the ``linktables`` family.
+        include_all_year_tables: Clean the patent and clinical-study files,
+            which carry no year and are published as one all-years snapshot.
+
+    Returns:
+        Row counts per clean table, for the tables this call produced.
+    """
     totals: dict[str, int] = defaultdict(int)
-    supplement = load_funding_supplement(input_dir)
-    for year in fiscal_years:
+    supplement = load_funding_supplement(input_dir) if project_years else {}
+    for year in project_years:
         totals["project"] += clean_project_year(
             year, input_dir, output_dir, supplement
         )
+    for year in abstract_years:
         totals["project_abstract"] += clean_abstract_year(
             year, input_dir, output_dir
         )
-    for year in calendar_years:
+    for year in publication_years:
         totals["publication"] += clean_publication_year(
             year, input_dir, output_dir
         )
+    for year in link_years:
         totals["publication_link"] += clean_publication_link_year(
             year, input_dir, output_dir
         )
@@ -831,23 +889,27 @@ def probe_file(
     Returns ``None`` when the file does not exist.
     """
     sess = session or requests.Session()
+    timeout = constants.PROBE_TIMEOUT.value
     resp = sess.get(
-        source_url(family, year), timeout=120, allow_redirects=False
+        source_url(family, year), timeout=timeout, allow_redirects=False
     )
     if resp.status_code != 302:
         return None
     location = resp.headers.get("Location")
     if not location:
         return None
-    head = sess.head(location, timeout=120)
+    head = sess.head(location, timeout=timeout)
     if head.status_code != 200:
         return None
     modified = head.headers.get("Last-Modified", "")
     try:
-        stamp = time.strftime(
-            "%Y-%m-%d", time.strptime(modified, "%a, %d %b %Y %H:%M:%S %Z")
-        )
-    except ValueError:
+        # parsedate_to_datetime, not time.strptime: strptime resolves %a and %b
+        # through LC_TIME, so on a worker with a non-English locale every
+        # Last-Modified would fail to parse, source_max_date would return "",
+        # and probe_source would raise. HTTP dates are RFC 2822 and always
+        # English, which is exactly what this parser assumes.
+        stamp = parsedate_to_datetime(modified).strftime("%Y-%m-%d")
+    except (TypeError, ValueError):
         stamp = ""
     return {
         "family": family,


### PR DESCRIPTION
Follow-up to #1997, which merged before its review comments were addressed. This applies all ten actionable findings and the four nitpicks. No `.sql` model changes, no schema changes, no row-count changes — the merged tables are unaffected.

Each finding was verified against the actual behaviour before being fixed, not taken on trust.

## Correctness

**`download_file` could accept a truncated transfer.** On this `requests` 2.26 / `urllib3` 1.26 pair, `iter_content` can return normally after an early EOF, so a short file reached the cleaner as silently missing rows. It now requests `Accept-Encoding: identity` — so `Content-Length` describes the bytes actually written — and raises when the two disagree. Re-tested on both a bare CSV and a zip: 4,969,962 and 2,673,770 bytes, matching the originals.

**`read_rows` leaked file descriptors.** It is a generator, so a caller that stopped consuming early left the archive and its members open for the life of the process. Both are now held in context managers.

**`norm_int` / `norm_float` could abort a whole year's clean.** `float()` accepts `nan`, `inf` and `infinity`; `int()` of a non-finite float raises `OverflowError`, not `ValueError`, so it escaped the `except` and killed the run. Both now reject non-finite values as empty.

**`clean_all` drove four families from two cadence-keyed year lists.** The four year-keyed families are probed independently and their year sets are not guaranteed to agree: NIH published the FY2025 abstract file on 2026-03-09 and the FY2025 project file on 2026-07-09, a four-month window in which one exists and the other does not. Driving the abstract cleaner off the project years would build a path for a file the download step never fetched and raise `FileNotFoundError`; driving it the other way would silently skip a downloaded year. It now takes one year list per family.

**`probe_file` was locale-dependent and shared the download timeout.** `time.strptime` resolves `%a` and `%b` through `LC_TIME`, so on a worker with a non-English locale every `Last-Modified` would fail to parse, `source_max_date` would return `""`, and `probe_source` would raise. HTTP dates are RFC 2822 and always English, which is exactly what `parsedate_to_datetime` assumes. The two header requests also now get their own `PROBE_TIMEOUT` of 120s rather than the 900s deadline sized for a 3.6 GB download.

**`verify_parquet` crashed on the failure path.** When `project` wrote no parquet, `project_keys` stayed `None` and the join section dereferenced it — an `AttributeError` that aborted before the verdict printed, losing the exit code reporting the real failure. The join checks are now skipped with a message.

**`register_metadata` claimed a materialisation that had not happened.** It wrote today's date into the table-anchored `Update.latest` unconditionally. Registration refreshes nothing, and the poll reads that field with a strict `source_max > latest`, so the write both misreported state and would have suppressed each table's first refresh. It is now gated behind `--materialized`, off by default so a bare re-run cannot re-introduce the claim. The seven prod records have been reset out of band to `1970-01-01T00:00:00` — a sentinel nobody can mistake for a real materialisation. Staging is left at its true date, since dbt really did build those tables.

## Maintainability

- Both metadata scripts resolve the MCP server through a single `import_mcp_server` helper driven by `DATABASIS_MCP_PATH`, replacing a hardcoded checkout path. The MCP server is a separate checkout, not a dependency of this repo, and is not importable in CI at all. Verified in all three states: already importable, configured, and unset.
- `gen_dbt.py` emits flow-style YAML for short scalar sequences, which is what the repo's `yamlfix` hook produces. Previously every run of the generator produced formatting churn against the committed file. `schema.yml` is not in this diff because the flow-style version already landed with #1997 — which is the check that the generator and the committed file now agree.
- Docstrings on the previously undocumented functions in `upload.py`, `gen_columns_json.py` and `flows.py`; `_patched_bucket` fully annotated. The `clean_patents` duplicate-key note now describes the real cause (same title, two owners), not the guess.

## Verification

- `dbt test --select us_nih_reporter` — **34/34 pass**.
- `pyrefly check pipelines/datasets/us_nih_reporter/*.py` — 0 diagnostics. The pre-commit `pyrefly` hook was skipped for the commit; it matches 0 Python files inside any worktree and fails identically on files this PR does not touch.
- `verify_parquet.py` PASS; `verify_metadata.py` PASS on both staging and prod.
- `norm_int` / `norm_float` / `norm_date` unit cases pass. `probe_file` returns the right dates for `projects/2025` and `patents`, and `None` for 2030.
