### PR TITLE
[Fix] br_senado_dados_abertos_administrativos — diretor_coordenador null-proportion test on sparse substitute columns

### DIFF
--- a/models/br_senado_dados_abertos_administrativos/code/gen_dbt.py
+++ b/models/br_senado_dados_abertos_administrativos/code/gen_dbt.py
@@ -73,22 +73,56 @@ def partition_range(frame: pd.DataFrame | None) -> tuple[int, int]:
     return start, CUR_YEAR + 5
 
 
+# Columns that are sparse *by construction*, plus the note explaining why.
+#
+# The measurement below reads whichever extraction it is run against, so a
+# column that merely hovers near the 5% floor gets listed on one run and
+# dropped on the next — and the proportion test then fails in prod the first
+# time the source dips under. Declaring such columns here makes the exclusion
+# stable and records the reason, instead of leaving it to a lucky snapshot.
+STRUCTURALLY_SPARSE: dict[str, tuple[tuple[str, ...], str]] = {
+    "diretor_coordenador": (
+        (
+            "matricula_substituto",
+            "nome_substituto",
+            "data_inicio_substituicao",
+            "data_fim_substituicao",
+        ),
+        "A fonte só preenche o objeto `substituto` nos setores com substituição "
+        "vigente na data de extração — 11 dos 234 setores (4,7%) em 2026-09-07 e "
+        "20 dos 234 (8,5%) em 2026-09-09 — e, quando o preenche, os quatro campos "
+        "vêm sempre juntos. Por serem esparsas por construção, essas colunas ficam "
+        "fora do teste de proporção de nulos.",
+    ),
+}
+
+
 def ignore_values(
     slug: str, spec: dict, frame: pd.DataFrame | None
 ) -> list[str]:
-    """Columns under 5% non-null, which the proportion test must skip.
+    """Columns the proportion test must skip, in architecture order.
 
-    Several columns here are legitimately sparse — `numero_formatado` and
-    `unidade_gestora` exist only for contratos, `cargo` and `categoria` only for
-    cessões pelo Senado, and most `quadro_pessoal` dimensions apply to a single
-    source report.
+    Two sources, unioned: the columns declared structurally sparse in
+    :data:`STRUCTURALLY_SPARSE`, and the columns measured under 5% non-null in
+    the extraction at hand. Several of the measured ones are legitimately
+    sparse — `numero_formatado` and `unidade_gestora` exist only for contratos,
+    `cargo` and `categoria` only for cessões pelo Senado, and most
+    `quadro_pessoal` dimensions apply to a single source report.
+
+    The declared set applies even with no parquet on disk, so regenerating
+    without the extraction cannot silently drop it.
     """
-    if frame is None or not len(frame):
-        return []
+    declared = set(STRUCTURALLY_SPARSE.get(slug, ((), ""))[0])
     out = []
     for col in spec["cols"]:
         name = col[0]
-        if name in frame.columns and frame[name].notna().mean() < 0.05:
+        measured = (
+            frame is not None
+            and len(frame)
+            and name in frame.columns
+            and frame[name].notna().mean() < 0.05
+        )
+        if name in declared or measured:
             out.append(name)
     return out
 
@@ -150,11 +184,23 @@ def gen_sql(slug: str, spec: dict, frame: pd.DataFrame | None) -> str:
     )
 
 
+def desc(slug: str, spec: dict) -> str:
+    """The dbt model description: the table description plus any sparsity note.
+
+    The note is appended here rather than stored in ``spec['desc_pt']`` because
+    that string is the public table description, and has ``desc_en``/``desc_es``
+    counterparts that would silently fall out of sync.
+    """
+    text = spec["desc_pt"].strip()
+    note = STRUCTURALLY_SPARSE.get(slug, ((), ""))[1]
+    return f"{text} {note}".strip() if note else text
+
+
 def gen_schema_entry(slug: str, spec: dict, frame: pd.DataFrame | None) -> str:
     out = [
         f"  - name: {DATASET}__{slug}",
         "    description: >",
-        f"      {spec['desc_pt'].strip()}",
+        f"      {desc(slug, spec)}",
         "    tests:",
         "      - dbt_utils.unique_combination_of_columns:",
         f"          combination_of_columns: [{', '.join(spec['unique'])}]",

--- a/models/br_senado_dados_abertos_administrativos/schema.yml
+++ b/models/br_senado_dados_abertos_administrativos/schema.yml
@@ -1807,6 +1807,11 @@ models:
     description: >
       Titulares e substitutos das direções e coordenações do Senado Federal, com o
       setor dirigido, sua posição na hierarquia administrativa e o contato do titular.
+      A fonte só preenche o objeto `substituto` nos setores com substituição vigente
+      na data de extração — 11 dos 234 setores (4,7%) em 2026-09-07 e 20 dos 234 (8,5%)
+      em 2026-09-09 — e, quando o preenche, os quatro campos vêm sempre juntos. Por
+      serem esparsas por construção, essas colunas ficam fora do teste de proporção
+      de nulos.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -1815,6 +1820,11 @@ models:
             - matricula_titular
       - not_null_proportion_multiple_columns:
           at_least: 0.05
+          ignore_values:
+            - matricula_substituto
+            - nome_substituto
+            - data_inicio_substituicao
+            - data_fim_substituicao
     columns:
       - name: data_extracao
         description: >


### PR DESCRIPTION
## What broke

`br_senado_dados_abertos_administrativos_weekly` failed its prod dbt test on 2026-09-07 (flow run `01a07ae5-caea`):

```
not_null_proportion_multiple_columns_..._diretor_coordenador_0_05
Got 4 results, configured to fail if != 0
```

The four columns, all at **4.7% non-null (11/234)**: `matricula_substituto`, `nome_substituto`, `data_inicio_substituicao`, `data_fim_substituicao`.

## Data bug or stale test?

**Stale test — but not because the source stopped populating the columns.**

The decisive check: all four come from one nested `substituto` object, so a mis-keyed path in the transform would drop *every* row and report **0%**, not a non-zero minority. The parser is fine.

Confirmed against the live API — 234 records, **214 with `substituto: null`**, and the 20 that carry the object have all four subfields populated together.

The source populates `substituto` only for sectors with a substitution **in effect on the extraction date**. That is structurally a small minority that drifts across the 5% floor: **4.7% on 2026-09-07, 8.5% (20/234) on 2026-09-09**. The test was going to fail on some future Monday regardless.

## The actual root cause

`schema.yml` is **generated** by `gen_dbt.py`, whose `ignore_values` was derived by *measuring the onboarding extraction* — "under 5% today, ignore forever". That is unstable for exactly these threshold-adjacent columns, and a hand edit to `schema.yml` would have been reverted on the next regeneration. So both are fixed:

- **`gen_dbt.py`** — new `STRUCTURALLY_SPARSE` map declaring these four as sparse by construction with the reason, unioned with the measured list, applied **even when no parquet is on disk**.
- **`schema.yml`** — the `ignore_values` block and the note in the model description, byte-identical to what the generator now emits.

`at_least` is unchanged; no threshold was relaxed.

The note lives in a `desc()` helper rather than in `spec['desc_pt']`, because that string is the public trilingual table description and has `desc_en`/`desc_es` siblings that would fall out of sync.

## Verification

- The macro's own generated SQL against the **prod** table: **4 rows** without the ignore list (reproducing the failure exactly), **0 rows** with it.
- `dbt test --select br_senado_dados_abertos_administrativos__diretor_coordenador` → **PASS=4 WARN=0 ERROR=0 SKIP=0**.
- `yamlfix` clean and idempotent; `pyrefly check` on `gen_dbt.py` → 0 diagnostics.

Local profiles have no prod target, so the dbt run is against `dev`; the prod check is the direct SQL above.

## Notes for the reviewer

- **No `deploy-flow` label needed** — this touches no `flows.py`, so the staging deploy would pick up nothing either way.
- The weekly deployment stays **PAUSED** (`17 6 * * 1`). Re-arming is a separate, deliberate step (Django admin → `admin_data_tools/disabledflowschedule`), best done after this merges, since the prod run reads the generated file.
- **Separate latent hazard, not fixed here:** with no parquet on disk, `gen_dbt.py::main()` falls back to *empty* measured ignore lists — regenerating without the extraction would silently wipe every measured exclusion in the file (`fax`, `sigla_setor`, `data_fim`, `tipo_cessao`, …). The newly declared set survives that; the measured ones do not. Happy to convert the rest in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that substitute director and coordinator fields are populated only for certain grouped records.
  - Updated documentation to reflect their exclusion from null-proportion checks.

- **Bug Fixes**
  - Sparse fields are now consistently excluded from generated validation checks, including when source data is unavailable.
  - Table descriptions now include notes explaining structurally sparse fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->