### PR TITLE
fix(br_pncp): the source poll compared a year against a date, so nothing ingested

### DIFF
--- a/pipelines/datasets/br_pncp/tasks.py
+++ b/pipelines/datasets/br_pncp/tasks.py
@@ -62,14 +62,37 @@ def clean_window(work_dir: str, input_dir: str, table: str) -> dict:
 
 @task
 def max_publication_date(summaries: list[dict]) -> str:
-    """Latest publication year present in this run, as ``YYYY-01-01``.
+    """Latest partition date present in this run, as ``YYYY-MM-DD``.
 
     PNCP is a continuously-updated register with no release calendar, so there
     is no "new period published" signal comparable to a monthly statistical
-    release. The source's coverage therefore advances by publication year, which
-    is the granularity the coverage metadata records.
+    release. What stands in for one is the latest date the run actually saw --
+    `data_publicacao` for the procurement tables, `data_inclusao` for
+    instrumento_cobranca (`utils.PARTITION_SOURCE`).
+
+    **This must be a day, not a year.** The value is handed to
+    `poll_source_for_update_task(..., compare_against="coverage")`, which tests
+    ``source_max > Coverage.DateTimeRange`` -- and that range is day-granular,
+    because `register_table_materialization_task` reads the real max date out
+    of BigQuery. This used to return ``f"{max(years)}-01-01"``, so from the
+    first materialization onward the comparison was a January 1st against a
+    mid-year date and could not be true again until the next calendar year. The
+    prod run of 2026-09-09 harvested 151,488 records, compared 2026-01-01
+    against a coverage of 2026-08-28, concluded there was nothing new, and
+    exited Completed having ingested none of it. A year-granular value here
+    silently converts a daily pipeline into an annual one.
+
+    The max is taken across every fact table rather than contratacao alone,
+    matching what the poll is asking: whether the *source* has anything newer
+    than what is published. That errs toward materializing, which is the safe
+    direction for this comparison -- a needless run costs time, a skipped one
+    loses a day of data.
     """
-    years = [int(y) for s in summaries for y in (s.get("years") or [])]
-    if not years:
-        return f"{constants.START_YEAR.value}-01-01"
-    return f"{max(years)}-01-01"
+    dates = [
+        d for s in summaries if (d := s.get("max_partition_date")) is not None
+    ]
+    if dates:
+        return max(dates)
+    # No dated record in this run. Fall back to the year floor, which is older
+    # than any registered coverage and therefore reads as "nothing new".
+    return f"{constants.START_YEAR.value}-01-01"

--- a/pipelines/datasets/br_pncp/tests/test_transform.py
+++ b/pipelines/datasets/br_pncp/tests/test_transform.py
@@ -1331,3 +1331,137 @@ class TestDicionarioIsDerivedFromTheModels:
         ), (
             "the upload loop is back on ALL_TABLES, which has no dicionario data"
         )
+
+
+class TestSourceFreshnessIsDayGranular:
+    """The poll guard compares against a day-granular coverage, so the source
+    date it is handed must be a day too.
+
+    `max_publication_date` used to return ``f"{max(years)}-01-01"``. From the
+    first materialization onward that is a January 1st being compared against a
+    mid-year `Coverage.DateTimeRange`, so `should_update_raw_source` — which is
+    ``source_max > api_latest`` — could not be true again until the next
+    calendar year. The prod run of 2026-09-09 harvested 151,488 records,
+    compared 2026-01-01 against a coverage of 2026-08-28, and exited Completed
+    having ingested none of them. Nothing failed; a daily pipeline had quietly
+    become an annual one.
+    """
+
+    def _write_chunk(self, input_dir, table, name, records):
+        target = input_dir / table
+        target.mkdir(parents=True, exist_ok=True)
+        with gzip.open(
+            target / f"{name}.jsonl.gz", "wt", encoding="utf-8"
+        ) as fh:
+            for record in records:
+                fh.write(json.dumps(record) + "\n")
+
+    def _record(self, control, published):
+        return {
+            "numeroControlePNCP": control,
+            "dataPublicacaoPncp": published,
+            "dataAtualizacaoGlobal": published,
+            "orgaoEntidade": {"cnpj": "1", "esferaId": "M"},
+            "unidadeOrgao": {"ufSigla": "PB", "codigoIbge": "2516904"},
+            "valorGlobal": 100.0,
+        }
+
+    def test_partition_date_keeps_the_day(self):
+        assert (
+            utils.partition_date(
+                {"dataPublicacaoPncp": "2026-09-09T23:59:00"}, "contrato"
+            )
+            == "2026-09-09"
+        )
+
+    def test_partition_date_uses_inclusion_date_for_instrumento_cobranca(self):
+        # Its coverage keys on data_inclusao, so its freshness must too.
+        assert (
+            utils.partition_date(
+                {"dataInclusao": "2026-09-08T10:00:00"}, "instrumento_cobranca"
+            )
+            == "2026-09-08"
+        )
+
+    def test_pca_has_only_a_year_so_it_sits_at_january_first(self):
+        # anoPca carries no month or day; this is the one honest Jan 1st.
+        assert (
+            utils.partition_date({"anoPca": 2026}, "plano_contratacao_anual")
+            == "2026-01-01"
+        )
+
+    def test_an_undated_record_yields_no_date(self):
+        assert (
+            utils.partition_date({"dataPublicacaoPncp": None}, "contrato")
+            is None
+        )
+
+    def test_partition_year_still_agrees_with_partition_date(self):
+        record = {"dataPublicacaoPncp": "2026-09-09T23:59:00"}
+        assert utils.partition_year(record, "contrato") == 2026
+
+    def test_summary_reports_the_latest_date_the_run_saw(self, tmp_path):
+        input_dir, output_dir = tmp_path / "input", tmp_path / "output"
+        self._write_chunk(
+            input_dir,
+            "contrato",
+            "w1",
+            [
+                self._record("A-1/2026", "2026-08-30T00:00:00"),
+                self._record("B-1/2026", "2026-09-09T00:00:00"),
+                self._record("C-1/2025", "2025-01-02T00:00:00"),
+            ],
+        )
+        summary = utils.clean_table(input_dir, output_dir, "contrato")
+        assert summary["max_partition_date"] == "2026-09-09"
+
+    def test_undated_records_do_not_contribute_a_date(self, tmp_path):
+        input_dir, output_dir = tmp_path / "input", tmp_path / "output"
+        self._write_chunk(
+            input_dir,
+            "contrato",
+            "w1",
+            [self._record("A-1/2026", None)],
+        )
+        summary = utils.clean_table(input_dir, output_dir, "contrato")
+        assert summary["max_partition_date"] is None
+
+    def test_the_poll_beats_a_mid_year_coverage(self):
+        """The regression, stated as the comparison the flow actually makes."""
+        from pipelines.datasets.br_pncp.tasks import max_publication_date
+        from pipelines.utils.metadata.policy import should_update_raw_source
+
+        summaries = [
+            {"years": ["2026"], "max_partition_date": "2026-09-09"},
+            {"years": ["2026"], "max_partition_date": "2026-09-08"},
+        ]
+        source_max = max_publication_date.fn(summaries)
+        assert source_max == "2026-09-09"
+        # The coverage registered for contratacao on the day this broke.
+        assert should_update_raw_source(
+            date(2026, 8, 28), date.fromisoformat(source_max)
+        )
+
+    def test_a_run_of_only_backdated_amendments_still_no_ops(self):
+        """The guard's actual job — don't re-materialize for old records."""
+        from pipelines.datasets.br_pncp.tasks import max_publication_date
+        from pipelines.utils.metadata.policy import should_update_raw_source
+
+        source_max = max_publication_date.fn(
+            [{"years": ["2024"], "max_partition_date": "2024-03-01"}]
+        )
+        assert not should_update_raw_source(
+            date(2026, 8, 28), date.fromisoformat(source_max)
+        )
+
+    def test_an_empty_run_falls_back_below_any_coverage(self):
+        from pipelines.datasets.br_pncp.tasks import max_publication_date
+        from pipelines.utils.metadata.policy import should_update_raw_source
+
+        source_max = max_publication_date.fn(
+            [{"years": [], "max_partition_date": None}]
+        )
+        assert source_max == f"{constants.START_YEAR.value}-01-01"
+        assert not should_update_raw_source(
+            date(2026, 8, 28), date.fromisoformat(source_max)
+        )

--- a/pipelines/datasets/br_pncp/utils.py
+++ b/pipelines/datasets/br_pncp/utils.py
@@ -623,16 +623,34 @@ def convert(value, bq_type: str):
     return as_string(value)
 
 
-def partition_year(record: dict, table: str) -> int | None:
+def partition_date(record: dict, table: str) -> str | None:
+    """The record's partition date, as a full ISO ``YYYY-MM-DD`` string.
+
+    This is the date the `ano` partition is derived from -- `data_publicacao`
+    for the three procurement tables, `data_inclusao` for instrumento_cobranca
+    (see PARTITION_SOURCE). It is also the column each table's coverage spec
+    keys on, which is the point: the source-freshness poll compares its result
+    against `Coverage.DateTimeRange`, and that range is day-granular because
+    `register_table_materialization_task` reads the real max date out of
+    BigQuery. Returning a day here keeps both sides of that comparison on the
+    same clock. See `tasks.max_publication_date`.
+
+    plano_contratacao_anual is the exception: it is keyed on `anoPca`, a bare
+    year with no month or day, so it can only be placed at January 1st.
+    """
     raw = record.get(PARTITION_SOURCE[table])
     if raw in (None, ""):
         return None
     if table == "plano_contratacao_anual":
         try:
-            return int(raw)
+            return f"{int(raw):04d}-01-01"
         except (TypeError, ValueError):
             return None
-    iso = as_date(raw)
+    return as_date(raw)
+
+
+def partition_year(record: dict, table: str) -> int | None:
+    iso = partition_date(record, table)
     return int(iso[:4]) if iso else None
 
 
@@ -736,7 +754,9 @@ def clean_table(
             millions without pre-seeding a 0-row 00_header.parquet.
 
     Returns:
-        Summary with raw and written row counts and the years touched. Note that
+        Summary with raw and written row counts, the years touched, and
+        ``max_partition_date`` -- the latest partition date seen in this run,
+        as ``YYYY-MM-DD``, or None when the run wrote nothing. Note that
         ``written_rows`` counts rows *before* deduplication, which is what
         staging will contain; the materialized table will hold fewer.
     """
@@ -755,6 +775,7 @@ def clean_table(
     raw_rows = 0
     written = 0
     undated = 0
+    max_date: str | None = None
 
     def flush(year: str) -> int:
         rows = buffers.pop(year, None)
@@ -776,6 +797,11 @@ def clean_table(
         return len(rows)
 
     for record in iter_raw(input_dir, table):
+        record_date = partition_date(record, table)
+        if record_date is not None and (
+            max_date is None or record_date > max_date
+        ):
+            max_date = record_date
         for row in flatten(record, table, columns):
             raw_rows += 1
             year = row["ano"]
@@ -795,6 +821,7 @@ def clean_table(
         "written_rows": written,
         "undated_dropped": undated,
         "years": sorted(parts),
+        "max_partition_date": max_date,
     }
 
 


### PR DESCRIPTION
## The bug

The first armed prod run of `br_pncp` harvested 151,488 records and ingested none of them, exiting **Completed**:

```
07:18  instrumento_cobranca: harvested 3,891 records for 2026-08-30..2026-09-09
07:21  ata_registro_preco:   harvested 18,995
09:21  contratacao:          harvested 61,977
09:29  contrato:             harvested 66,625
09:29  Não há novas atualizações na fonte original —
         fonte em 2026-01-01, coverage em 2026-08-28
```

Zero uploads, zero `dbt run`, zero `dbt test`. Run `01a08389-b189-71df-acd0-bf92621d180f`.

`max_publication_date` returned `f"{max(years)}-01-01"`. That value goes to `poll_source_for_update_task(compare_against="coverage")`, whose test is `should_update_raw_source` = `source_max > api_latest`, and `api_latest` is `Coverage.DateTimeRange` — **day-granular**, because `register_table_materialization_task` reads the real max date out of BigQuery.

So from the first materialization onward the guard compared a January 1st against a mid-year date, and could not be true again until the next calendar year. Left alone, the pipeline burns 2h15m of PNCP API time nightly until 2027-01-01, discards every result, and reports success each time — a daily pipeline silently turned annual, in the shape of the `br_ibge_ipca` failure (4 ingests in 60 completed runs).

The old docstring claimed the coverage metadata records year granularity. It does not: `contratacao`'s spec is `PartBdpro(DateOnly("data_publicacao"), YEAR_MD)`. The two sides were never on the same clock.

## The fix

Fixed at the source of the number rather than at the comparison. `clean_table` now tracks `max_partition_date` — the latest ISO date it actually saw — and `max_publication_date` returns that.

Apples-to-apples by construction: `PARTITION_SOURCE` is the same raw field each table's coverage keys on (`dataPublicacaoPncp` for the procurement tables, `dataInclusao` for `instrumento_cobranca`), so the poll and the coverage read the same column. The guard's real job is preserved — a run of only backdated amendments yields an old max date and still correctly no-ops.

`partition_year` is now derived from `partition_date`, so the two cannot drift. `plano_contratacao_anual` keeps a January 1st, which is honest there: `anoPca` is a bare year.

## Why it wasn't caught

Both dev validation runs passed `force_run=True`, which bypasses the guard entirely. Today's scheduled run was the first ever to exercise it.

## Tests

Ten new tests in `TestSourceFreshnessIsDayGranular`, including the comparison as the flow actually makes it — a 2026-09-09 harvest against the 2026-08-28 coverage that broke — plus the no-op-on-amendments case and the empty-run fallback. Verified the old value fails that first test and the new one passes:

```
old source_max 2026-01-01 -> guard passes: False
new source_max 2026-09-09 -> guard passes: True
```

Full suite: 91 passed. `pyrefly check pipelines/datasets/br_pncp/`: 0 diagnostics.

## Notes

- Scoped entirely to `pipelines/datasets/br_pncp/` — no shared `pipelines/utils` changes.
- `as_date` now runs twice per record. Measured at 15.2 µs: 152 s on a full 10M-row backfill, ~2 s on an incremental run. Left alone deliberately — the backfill is API-bound and already complete.
- **Timing matters for the catch-up.** `LOOKBACK_DAYS = 10` and coverage sits at 2026-08-28, so a run within roughly the next week closes the gap with no missed records. Later than that, the first corrected run needs a widened `lookback_days` or there will be a hole.
- Unrelated to the dbt-test failure on #1993, which was a different defect and is already fixed and merged.
