### PR TITLE
[Fix] us_census_bps — make the source-update pass idempotent, so the pipeline can poll at all

### DIFF
--- a/models/us_census_bps/code/metadata_stage2.py
+++ b/models/us_census_bps/code/metadata_stage2.py
@@ -117,11 +117,30 @@ def register_source_update(env: str) -> int:
     for source in prior:
         level = by_url[source["url"]]
         latest = SOURCE_MAX_PERIOD[level]
+        # create_update_update duplicates the record when called without an
+        # id, and a raw data source carrying two Updates makes the pipeline's
+        # commit_source_update_task raise ("allUpdate: mais de um nó
+        # encontrado"), which killed a prod run. Read the existing id first.
+        query = (
+            '{ allUpdate(rawDataSource_Id: "'
+            + source["id"]
+            + '") { edges { node { id } } } }'
+        )
+        existing = [
+            server._strip_id(e["node"]["id"])
+            for e in server._gql(query, {}, env=env)["allUpdate"]["edges"]
+        ]
+        if len(existing) > 1:
+            raise RuntimeError(
+                f"{level}: raw source has {len(existing)} Update records; "
+                "the pipeline cannot resolve more than one. Delete the extras."
+            )
         server.create_update_update(
             entity_id=entity["month"],
             frequency=1,
             latest=latest,
             raw_data_source_id=source["id"],
+            id=existing[0] if existing else None,
             env=env,
         )
         print(f"source update {level:7s} -> {latest[:10]}")


### PR DESCRIPTION
## The bug

`create_update_update` creates a **new** record when called without an `id`, so running
the `us_census_bps` source-update pass twice left every raw data source with two `Update`
records.

The backend client cannot resolve a source that has more than one:

```
ValueError: allUpdate: mais de um nó encontrado para
  {'rawDataSource_Id': 'ccdb0d43-...'}; refine os parâmetros para retornar um único objeto.
```

Both `poll_source_for_update_task` and `commit_source_update_task` go through that lookup,
so **the first production run of the pipeline died at `commit_source_update_task`** before
uploading anything. It failed safely — no upload, no prefix clear, no dbt, no row access
policy change — but the pipeline could not have run at all until the duplicates were gone.

## The fix

`register_source_update` now reads the existing `Update` id and passes it, so a re-run
updates rather than duplicating. If it ever finds more than one it **raises** with a
message naming the cause, instead of quietly adding to the pile.

## Data already repaired

The ten duplicate records (five sources × two environments) have been deleted. The
metropolitan source kept its correct `2023-12` date — its series ended when the survey moved
to the CBSA basis — rather than the `2026-07` a first, wrong run had written. Verified
afterwards: exactly one `Update` per raw source in both staging and production, and no table
carries a duplicate either.

The pipeline's production run then completed cleanly: 11 uploads, `dbt run OK` ×11,
`dbt test OK` ×11, zero errors.

## Scope

One file, `models/us_census_bps/code/metadata_stage2.py` — a one-shot onboarding script, not
pipeline or dbt code. Nothing in `pipelines/` or `models/**/*.sql` changes, so no flow is
redeployed and no model is re-materialised.
