### PR TITLE
[Pipeline] br_cgu_orcamento_publico — weekly refresh, unstick the table from 2024

### DIFF
--- a/models/br_cgu_orcamento_publico/br_cgu_orcamento_publico__orcamento.sql
+++ b/models/br_cgu_orcamento_publico/br_cgu_orcamento_publico__orcamento.sql
@@ -1,6 +1,13 @@
 {{
     config(
-        alias="orcamento", schema="br_cgu_orcamento_publico", materialized="table"
+        alias="orcamento",
+        schema="br_cgu_orcamento_publico",
+        materialized="table",
+        partition_by={
+            "field": "ano_exercicio",
+            "data_type": "int64",
+            "range": {"start": 2014, "end": 2031, "interval": 1},
+        },
     )
 }}
 select

--- a/models/br_cgu_orcamento_publico/code/architecture/orcamento.csv
+++ b/models/br_cgu_orcamento_publico/code/architecture/orcamento.csv
@@ -1,0 +1,27 @@
+name,bigquery_type,description,temporal_coverage,covered_by_dictionary,directory_column,measurement_unit,has_sensitive_data,observations,original_name,staging_name
+ano_exercicio,INT64,Ano do exercício financeiro a que se referem os valores orçamentários,,no,br_bd_diretorios_data_tempo.ano:ano,year,no,"Coluna de partição; no staging é a chave hive ano_exercicio=YYYY, não uma coluna do arquivo",EXERCÍCIO,ano_exercicio
+id_orgao_superior,STRING,"Código do órgão superior responsável pela despesa, em geral um ministério",,no,,,no,,CÓDIGO ÓRGÃO SUPERIOR,codigo_orgao_superior
+nome_orgao_superior,STRING,Nome do órgão superior responsável pela despesa,,no,,,no,,NOME ÓRGÃO SUPERIOR,nome_orgao_superior
+id_orgao_subordinado,STRING,"Código do órgão subordinado responsável pela despesa, por exemplo uma autarquia ou fundação",,no,,,no,,CÓDIGO ÓRGÃO SUBORDINADO,codigo_orgao_subordinado
+nome_orgao_subordinado,STRING,Nome do órgão subordinado responsável pela despesa,,no,,,no,,NOME ÓRGÃO SUBORDINADO,nome_orgao_subordinado
+id_unidade_orcamentaria,STRING,"Código da unidade orçamentária, menor nível da estrutura administrativa a que se aloca a dotação",,no,,,no,,CÓDIGO UNIDADE ORÇAMENTÁRIA,codigo_unidade_orcamentaria
+nome_unidade_orcamentaria,STRING,Nome da unidade orçamentária,,no,,,no,,NOME UNIDADE ORÇAMENTÁRIA,nome_unidade_orcamentaria
+id_funcao,STRING,"Código da função de governo em que a despesa foi classificada, maior nível de agregação das áreas de atuação do setor público",,no,,,no,,CÓDIGO FUNÇÃO,codigo_funcao
+nome_funcao,STRING,Nome da função de governo em que a despesa foi classificada,,no,,,no,,NOME FUNÇÃO,nome_funcao
+id_subfuncao,STRING,"Código da subfunção, que detalha a função em áreas de atuação mais específicas",,no,,,no,,CÓDIGO SUBFUNÇÃO,codigo_subfuncao
+nome_subfuncao,STRING,Nome da subfunção,,no,,,no,,NOME SUBFUNÇÃO,nome_subfuncao
+id_programa_orcamentario,STRING,"Código do programa orçamentário, instrumento do plano plurianual que articula ações para um objetivo",,no,,,no,,CÓDIGO PROGRAMA ORÇAMENTÁRIO,codigo_programa_orcamentario
+nome_programa_orcamentario,STRING,Nome do programa orçamentário,,no,,,no,,NOME PROGRAMA ORÇAMENTÁRIO,nome_programa_orcamentario
+id_acao,STRING,"Código da ação orçamentária, menor unidade de programação que gera bem ou serviço",,no,,,no,,CÓDIGO AÇÃO,codigo_acao
+nome_acao,STRING,Nome da ação orçamentária,,no,,,no,,NOME AÇÃO,nome_acao
+id_categoria_economica,STRING,"Código da categoria econômica da despesa, que separa despesas correntes de despesas de capital",,no,,,no,,CÓDIGO CATEGORIA ECONÔMICA,codigo_categoria_economica
+nome_categoria_economica,STRING,Nome da categoria econômica da despesa,,no,,,no,,NOME CATEGORIA ECONÔMICA,nome_categoria_economica
+id_grupo_despesa,STRING,"Código do grupo de natureza da despesa, por exemplo pessoal e encargos sociais, juros da dívida, investimentos",,no,,,no,,CÓDIGO GRUPO DE DESPESA,codigo_grupo_de_despesa
+nome_grupo_despesa,STRING,Nome do grupo de natureza da despesa,,no,,,no,,NOME GRUPO DE DESPESA,nome_grupo_de_despesa
+id_elemento_despesa,STRING,"Código do elemento de despesa, que identifica o objeto do gasto, por exemplo diárias, material de consumo, obras",,no,,,no,,CÓDIGO ELEMENTO DE DESPESA,codigo_elemento_de_despesa
+nome_elemento_despesa,STRING,Nome do elemento de despesa,,no,,,no,,NOME ELEMENTO DE DESPESA,nome_elemento_de_despesa
+orcamento_inicial,FLOAT64,"Dotação inicial aprovada na lei orçamentária anual, em reais correntes",,no,,brl,no,,ORÇAMENTO INICIAL (R$),orcamento_inicial
+orcamento_atualizado,FLOAT64,"Dotação autorizada após créditos adicionais, cancelamentos e remanejamentos, em reais correntes",,no,,brl,no,,ORÇAMENTO ATUALIZADO (R$),orcamento_atualizado
+orcamento_empenhado,FLOAT64,"Valor empenhado, isto é, reservado do orçamento para honrar um compromisso assumido, em reais correntes",,no,,brl,no,,ORÇAMENTO EMPENHADO (R$),orcamento_empenhado
+orcamento_realizado,FLOAT64,"Valor realizado, correspondente à despesa liquidada no exercício, em reais correntes",,no,,brl,no,,ORÇAMENTO REALIZADO (R$),orcamento_realizado
+porcentagem_realizado_orcamento,FLOAT64,"Razão entre o orçamento realizado e o orçamento atualizado, em porcentagem",,no,,percent,no,Assume valores negativos quando a dotação autorizada é negativa; a fonte publica o valor com sufixo %,% REALIZADO DO ORÇAMENTO (COM RELAÇÃO AO ORÇAMENTO ATUALIZADO),porcentagem_realizado_orcamento

--- a/models/br_cgu_orcamento_publico/schema.yml
+++ b/models/br_cgu_orcamento_publico/schema.yml
@@ -2,64 +2,92 @@
 version: 2
 models:
   - name: br_cgu_orcamento_publico__orcamento
-    description: Orçamento Público do Governo Federal
+    description: >-
+      Execução orçamentária anual da despesa da União nos orçamentos fiscal e da
+      seguridade social, com dotação inicial, dotação autorizada, valor empenhado
+      e valor realizado, detalhados pela classificação institucional,
+      funcional-programática e pela natureza da despesa. Fonte: Portal da
+      Transparência (CGU), um arquivo por exercício desde 2014. A fonte republica
+      os exercícios encerrados, então cada atualização reconstrói a série inteira.
+      As colunas de classificação NÃO formam chave única: o arquivo agrega por
+      dimensões que não publica (subtítulo/localizador e fonte de recursos), de
+      modo que uma mesma combinação de órgão, unidade orçamentária, função,
+      programa, ação e natureza da despesa aparece em até 10 linhas com valores
+      distintos. Para o detalhe que desambigua essas linhas, use a execução mensal
+      da despesa.
     tests:
       - not_null_proportion_multiple_columns:
           at_least: 0.95
     columns:
       - name: ano_exercicio
-        description: Ano do exercício a que se referem os valores
+        description: Ano do exercício financeiro a que se referem os valores orçamentários
         tests:
+          - not_null
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__ano')
               field: ano.ano
       - name: id_orgao_superior
-        description: Código do Órgão Superior responsável pela despesa.
+        description: Código do órgão superior responsável pela despesa, em geral um
+          ministério
       - name: nome_orgao_superior
-        description: Nome do Órgão Superior responsável pela despesa.
+        description: Nome do órgão superior responsável pela despesa
       - name: id_orgao_subordinado
-        description: Código do Órgão Subordinado responsável pela despesa.
+        description: Código do órgão subordinado responsável pela despesa, por exemplo
+          uma autarquia ou fundação
       - name: nome_orgao_subordinado
-        description: Nome do Órgão Subordinado responsável pela despesa.
+        description: Nome do órgão subordinado responsável pela despesa
       - name: id_unidade_orcamentaria
-        description: Código da Unidade Orçamentária responsável pela despesa.
+        description: Código da unidade orçamentária, menor nível da estrutura administrativa
+          a que se aloca a dotação
       - name: nome_unidade_orcamentaria
-        description: Nome da Unidade Orçamentária responsável pela despesa.
+        description: Nome da unidade orçamentária
       - name: id_funcao
-        description: Código da Função em que foi classificada a despesa.
+        description: Código da função de governo em que a despesa foi classificada,
+          maior nível de agregação das áreas de atuação do setor público
       - name: nome_funcao
-        description: Nome da Função em que foi classificada a despesa.
+        description: Nome da função de governo em que a despesa foi classificada
       - name: id_subfuncao
-        description: Código da Subfunção em que foi classificada a despesa.
+        description: Código da subfunção, que detalha a função em áreas de atuação
+          mais específicas
       - name: nome_subfuncao
-        description: Nome da Subfunção em que foi classificada a despesa.
+        description: Nome da subfunção
       - name: id_programa_orcamentario
-        description: Código do Programa em que foi classificada a despesa.
+        description: Código do programa orçamentário, instrumento do plano plurianual
+          que articula ações para um objetivo
       - name: nome_programa_orcamentario
-        description: Nome do Programa em que foi classificada a despesa.
+        description: Nome do programa orçamentário
       - name: id_acao
-        description: Código da ação orçamentária em que foi classificada a despesa.
+        description: Código da ação orçamentária, menor unidade de programação que
+          gera bem ou serviço
       - name: nome_acao
-        description: Nome da ação orçamentária em que foi classificada a despesa.
+        description: Nome da ação orçamentária
       - name: id_categoria_economica
-        description: Código da categoria econômica
+        description: Código da categoria econômica da despesa, que separa despesas
+          correntes de despesas de capital
       - name: nome_categoria_economica
-        description: Nome da categoria econômica
+        description: Nome da categoria econômica da despesa
       - name: id_grupo_despesa
-        description: Código do grupo de despesa
+        description: Código do grupo de natureza da despesa, por exemplo pessoal e
+          encargos sociais, juros da dívida, investimentos
       - name: nome_grupo_despesa
-        description: Nome do grupo de despesa
+        description: Nome do grupo de natureza da despesa
       - name: id_elemento_despesa
-        description: Código do elemento da despesa
+        description: Código do elemento de despesa, que identifica o objeto do gasto,
+          por exemplo diárias, material de consumo, obras
       - name: nome_elemento_despesa
-        description: Nome do elemento da despesa
+        description: Nome do elemento de despesa
       - name: orcamento_inicial
-        description: Valor do orçamento inicial
+        description: Dotação inicial aprovada na lei orçamentária anual, em reais
+          correntes
       - name: orcamento_atualizado
-        description: Valor do orçamento atualizado
+        description: Dotação autorizada após créditos adicionais, cancelamentos e
+          remanejamentos, em reais correntes
       - name: orcamento_empenhado
-        description: Valor do orçamento empenhado
+        description: Valor empenhado, isto é, reservado do orçamento para honrar um
+          compromisso assumido, em reais correntes
       - name: orcamento_realizado
-        description: Valor do orçamento realizado
+        description: Valor realizado, correspondente à despesa liquidada no exercício,
+          em reais correntes
       - name: porcentagem_realizado_orcamento
-        description: Pordentagm Realizado do orçamento
+        description: Razão entre o orçamento realizado e o orçamento atualizado, em
+          porcentagem

--- a/pipelines/datasets/br_cgu_orcamento_publico/constants.py
+++ b/pipelines/datasets/br_cgu_orcamento_publico/constants.py
@@ -1,0 +1,126 @@
+"""Constants for the br_cgu_orcamento_publico recurring pipeline (Prefect 3).
+
+Orçamento e execução da despesa do Governo Federal, publicados anualmente pelo
+Portal da Transparência (CGU) como um ZIP por exercício.
+
+Two things about this source drive the design:
+
+* **Past exercises are restated.** The portal regenerates every year's file on
+  the same schedule — on 2026-09-09 the 2024 file carried 142 IBAMA rows and
+  R$ 2,16 bi autorizado against the 139 rows / R$ 2,05 bi that had been ingested
+  earlier. So the pipeline re-downloads the whole history on every run and
+  replaces the table (``dump_mode="overwrite"``), never appends.
+* **The exercise year is not a useful freshness signal**, since it changes once
+  a year while the contents change continuously. The poll uses the ZIP's
+  ``Last-Modified`` header against ``Table.Update.latest`` instead.
+"""
+
+from enum import Enum
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class constants(Enum):
+    """Constants for the br_cgu_orcamento_publico pipeline."""
+
+    DATASET_ID = "br_cgu_orcamento_publico"
+    TABLE_ID = "orcamento"
+
+    BASE_URL = "https://portaldatransparencia.gov.br/download-de-dados/orcamento-despesa"
+
+    # The portal answers a plain scripted GET, but sends 403 to some default
+    # agents; keep a browser UA with a contact address.
+    USER_AGENT = (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0 Safari/537.36 rdahis@basedosdados.org"
+    )
+
+    # Earliest exercise the portal publishes. 2013 and earlier return 403.
+    FIRST_YEAR = 2014
+
+    # Source files are Latin-1, semicolon-separated, every field quoted.
+    SOURCE_ENCODING = "latin-1"
+    SOURCE_DELIMITER = ";"
+
+    # Staging column names, in the order the existing external table expects.
+    # These are the *raw-ish* names the dbt model renames to the published ones
+    # (codigo_orgao_superior -> id_orgao_superior, and so on); staging mirrors
+    # the source, the model does the renaming. ``ano_exercicio`` is absent
+    # because it is the hive partition key, not a column in the file.
+    STAGING_COLUMNS = [
+        "codigo_orgao_superior",
+        "nome_orgao_superior",
+        "codigo_orgao_subordinado",
+        "nome_orgao_subordinado",
+        "codigo_unidade_orcamentaria",
+        "nome_unidade_orcamentaria",
+        "codigo_funcao",
+        "nome_funcao",
+        "codigo_subfuncao",
+        "nome_subfuncao",
+        "codigo_programa_orcamentario",
+        "nome_programa_orcamentario",
+        "codigo_acao",
+        "nome_acao",
+        "codigo_categoria_economica",
+        "nome_categoria_economica",
+        "codigo_grupo_de_despesa",
+        "nome_grupo_de_despesa",
+        "codigo_elemento_de_despesa",
+        "nome_elemento_de_despesa",
+        "orcamento_inicial",
+        "orcamento_atualizado",
+        "orcamento_empenhado",
+        "orcamento_realizado",
+        "porcentagem_realizado_orcamento",
+    ]
+
+    # Token each source header must start with once accent-folded, in file
+    # order. Position 0 is the exercise. Validated on every run so a source
+    # layout change fails loudly instead of silently mis-assigning columns.
+    HEADER_TOKENS = [
+        "exercicio",
+        "codigo_orgao_superior",
+        "nome_orgao_superior",
+        "codigo_orgao_subordinado",
+        "nome_orgao_subordinado",
+        "codigo_unidade_orcamentaria",
+        "nome_unidade_orcamentaria",
+        "codigo_funcao",
+        "nome_funcao",
+        "codigo_subfuncao",
+        "nome_subfuncao",
+        "codigo_programa_orcamentario",
+        "nome_programa_orcamentario",
+        "codigo_acao",
+        "nome_acao",
+        "codigo_categoria_economica",
+        "nome_categoria_economica",
+        "codigo_grupo_de_despesa",
+        "nome_grupo_de_despesa",
+        "codigo_elemento_de_despesa",
+        "nome_elemento_de_despesa",
+        "orcamento_inicial",
+        "orcamento_atualizado",
+        "orcamento_empenhado",
+        "orcamento_realizado",
+        "realizado_do_orcamento",
+    ]
+
+    # Columns holding Brazilian-formatted numbers ("23929428,72", "86,16%").
+    NUMERIC_COLUMNS = [
+        "orcamento_inicial",
+        "orcamento_atualizado",
+        "orcamento_empenhado",
+        "orcamento_realizado",
+        "porcentagem_realizado_orcamento",
+    ]
+
+    ARCHITECTURE_DIR = (
+        _REPO_ROOT
+        / "models"
+        / "br_cgu_orcamento_publico"
+        / "code"
+        / "architecture"
+    )

--- a/pipelines/datasets/br_cgu_orcamento_publico/flows.py
+++ b/pipelines/datasets/br_cgu_orcamento_publico/flows.py
@@ -1,0 +1,192 @@
+"""Flows for br_cgu_orcamento_publico — Prefect 3.
+
+Orçamento e execução da despesa do Governo Federal (Portal da Transparência,
+CGU): dotação inicial e autorizada, valor empenhado e valor realizado, por
+órgão, unidade orçamentária, função, subfunção, programa, ação e natureza da
+despesa, um exercício por arquivo desde 2014.
+
+The portal restates closed exercises — the 2024 file gained rows and value
+months after the year ended — so every run re-downloads the whole history and
+replaces the table (``dump_mode="overwrite"``). The whole source is a handful of
+megabytes, which is what makes a full rebuild the cheap option as well as the
+correct one.
+
+Deploy: ``.github/scripts/deploy_flows.py`` auto-discovers
+``br_cgu_orcamento_publico_flow``; the dev pool ignores the schedule, the prod
+pool activates it.
+"""
+
+import shutil
+import tempfile
+
+from prefect import flow
+
+from pipelines.datasets.br_cgu_orcamento_publico.constants import constants
+from pipelines.datasets.br_cgu_orcamento_publico.tasks import (
+    clean_orcamento,
+    download_orcamento,
+    probe_source,
+)
+from pipelines.utils.metadata.domain import AllFree, DateFormat, YearOnly
+from pipelines.utils.metadata.tasks import (
+    commit_source_update_task,
+    poll_source_for_update_task,
+    register_table_materialization_task,
+)
+from pipelines.utils.tasks import (
+    rename_flow_run_dataset_table,
+    run_dbt,
+    upload_to_gcs,
+)
+
+DATASET_ID = constants.DATASET_ID.value
+TABLE_ID = constants.TABLE_ID.value
+
+# Annual table, so no BD Pro rolling window: the paywall applies to tables
+# refreshed monthly or more often. Coverage is the exercise year.
+_COVERAGE = AllFree(
+    date_column=YearOnly(col="ano_exercicio"), date_format=DateFormat.YEAR
+)
+
+
+@flow(name="br_cgu_orcamento_publico", log_prints=True)
+def br_cgu_orcamento_publico_flow(
+    materialize_to_prod: bool = True,
+    update_metadata: bool = True,
+    force_run: bool = False,
+) -> None:
+    """Rebuild br_cgu_orcamento_publico.orcamento from the Portal da Transparência.
+
+    Args:
+        materialize_to_prod: Continue past the dev materialization to write the
+            prod staging bucket and run dbt against ``target="prod"``. Set False
+            to exercise only the dev half — required for a safe test run, since
+            the default writes production.
+        update_metadata: After a successful prod materialization, register table
+            coverage and commit the source update. No effect when
+            ``materialize_to_prod`` is False.
+        force_run: Materialize even when the portal has not regenerated the
+            files since the last refresh. Needed for the first run, whose
+            ``Table.Update.latest`` is newer than the source's ``Last-Modified``.
+    """
+    # pyrefly: ignore [unused-coroutine]
+    rename_flow_run_dataset_table(
+        prefix="Dump: ", dataset_id=DATASET_ID, table_id=TABLE_ID
+    )
+
+    work_dir = tempfile.mkdtemp(prefix="br_cgu_orcamento_publico_")
+    try:
+        # One HEAD, before spending the download budget. The CGU host is behind
+        # an AWS WAF rate rule that CAPTCHA-blocks bursts, so the run asks the
+        # cheapest possible question first and bails when there is nothing new.
+        max_modified = probe_source()
+
+        # The exercise year only moves once a year while the file contents move
+        # continuously, so freshness is the ZIP's Last-Modified compared against
+        # Table.Update.latest — a publication timestamp against a wall clock,
+        # which is what compare_against="table_update" is for.
+        has_new_data = poll_source_for_update_task(
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            source_max_date=max_modified,
+            env="prod",
+            date_format="%Y-%m-%d",
+            compare_against="table_update",
+        )
+        if not has_new_data and not force_run:
+            return
+
+        downloaded = download_orcamento(work_dir=work_dir)
+        result = clean_orcamento(
+            work_dir=work_dir,
+            input_dir=downloaded["input_dir"],
+            years=downloaded["years"],
+        )
+        print(
+            f"cleaned {len(result['rows'])} exercises, "
+            f"{result['total']:,} rows: {result['rows']}"
+        )
+
+        commit_source_update_task(
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            source_max_date=max_modified,
+            env="prod",
+            date_format="%Y-%m-%d",
+            update_metadata=update_metadata,
+            materialize_after_dump=materialize_to_prod,
+        )
+
+        if not materialize_to_prod:
+            upload_to_gcs(
+                data_path=result["path"],
+                dataset_id=DATASET_ID,
+                table_id=TABLE_ID,
+                bucket_name="basedosdados-dev",
+                dump_mode="overwrite",
+                source_format="csv",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=TABLE_ID,
+                dbt_command="run",
+                target="dev",
+            )
+            run_dbt(
+                dataset_id=DATASET_ID,
+                table_id=TABLE_ID,
+                dbt_command="test",
+                target="dev",
+            )
+            return
+
+        upload_to_gcs(
+            data_path=result["path"],
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            bucket_name="basedosdados",
+            dump_mode="overwrite",
+            source_format="csv",
+        )
+        run_dbt(
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            dbt_command="run",
+            target="prod",
+        )
+        run_dbt(
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            dbt_command="test",
+            target="prod",
+        )
+
+        if update_metadata:
+            register_table_materialization_task(
+                dataset_id=DATASET_ID,
+                table_id=TABLE_ID,
+                coverage=_COVERAGE,
+                env="prod",
+                bq_project="basedosdados",
+            )
+    finally:
+        # Covers both early returns and any exception. A process worker reuses
+        # its filesystem between runs, so the scratch directory has to go.
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# The portal regenerates every exercise file together, currently around 05:00
+# BRT. Weekly is enough for an annual table whose closed years are restated
+# now and then; the poll guard no-ops a run that finds nothing new.
+# pyrefly: ignore [missing-attribute]
+br_cgu_orcamento_publico_flow.deploy_schedules = [
+    {"cron": "23 6 * * 4", "timezone": "America/Sao_Paulo"}
+]
+# ~290k CSV rows streamed a few thousand at a time; the 4Gi default is ample.
+# `memory` alone is silently dropped by the work pool template — the effective
+# key is `memory_limit`.
+# pyrefly: ignore [missing-attribute]
+br_cgu_orcamento_publico_flow.job_variables = {
+    "memory_limit": "2Gi",
+    "memory_request": "1Gi",
+}

--- a/pipelines/datasets/br_cgu_orcamento_publico/tasks.py
+++ b/pipelines/datasets/br_cgu_orcamento_publico/tasks.py
@@ -1,0 +1,50 @@
+"""Prefect 3 tasks for br_cgu_orcamento_publico — thin wrappers over utils.py."""
+
+from pathlib import Path
+
+from prefect import task
+
+from pipelines.datasets.br_cgu_orcamento_publico.utils import (
+    clean_all,
+    download_all,
+    probe_latest,
+)
+
+
+@task(retries=2, retry_delay_seconds=300)
+def probe_source() -> str:
+    """Return when the portal last regenerated the exercise files, ``YYYY-MM-DD``.
+
+    One HEAD request. The exercise year itself is useless as a freshness signal
+    — it moves once a year while the file contents move continuously — so the
+    poll compares this publication timestamp against ``Table.Update.latest``.
+
+    Retries are spaced five minutes apart because the failure worth retrying is
+    an AWS WAF rate block, which a fast retry only deepens.
+    """
+    return probe_latest()
+
+
+@task(retries=2, retry_delay_seconds=600)
+def download_orcamento(work_dir: str) -> dict:
+    """Download every published exercise ZIP into ``<work_dir>/input``.
+
+    Returns:
+        ``{"input_dir": str, "years": [int, ...]}`` — the exercises the portal
+        actually published, discovered by walking forward until one is missing.
+    """
+    input_dir = Path(work_dir) / "input"
+    years = download_all(input_dir)
+    return {"input_dir": str(input_dir), "years": years}
+
+
+@task
+def clean_orcamento(work_dir: str, input_dir: str, years: list[int]) -> dict:
+    """Clean the downloaded exercises into hive-partitioned staging CSV.
+
+    Returns:
+        ``{"path": str, "rows": {year: n}, "total": n}`` — ``path`` is the
+        table directory handed to ``upload_to_gcs``.
+    """
+    result = clean_all(Path(input_dir), Path(work_dir) / "output", years)
+    return {**result, "path": str(result["path"])}

--- a/pipelines/datasets/br_cgu_orcamento_publico/utils.py
+++ b/pipelines/datasets/br_cgu_orcamento_publico/utils.py
@@ -1,0 +1,276 @@
+"""Pure download and cleaning helpers for br_cgu_orcamento_publico.
+
+No Prefect imports here: ``tasks.py`` wraps these, and they can be run directly
+for local parity checks against an already-downloaded ``input/``.
+
+The transform itself is small — the source ships one ZIP per exercise, each
+holding a single Latin-1, semicolon-separated CSV with 26 quoted columns, and
+the only real work is normalising Brazilian number formatting ("23929428,72",
+"86,16%") into something ``safe_cast`` accepts.
+
+**The download is the delicate part.** ``portaldatransparencia.gov.br`` redirects
+to ``dadosabertos-download.cgu.gov.br``, which sits behind CloudFront + AWS WAF
+with a rate-based rule. A burst trips it and every later request comes back
+``405`` with ``x-amzn-waf-action: captcha`` — an HTML CAPTCHA page, not the ZIP —
+for a sustained period, from that IP, regardless of client. Measured 2026-09-11:
+15 HEADs followed immediately by 13 GETs tripped it after three files, and it was
+still refusing every request twelve seconds apart some minutes later. So this
+module issues **one request per exercise**, spaced by ``REQUEST_DELAY``, and
+reads ``Last-Modified`` off the download response rather than probing separately.
+A CAPTCHA response raises :class:`SourceChallengedError` — it is never solved or
+worked around.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import re
+import time
+import unicodedata
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import requests
+
+from pipelines.datasets.br_cgu_orcamento_publico.constants import constants
+
+log = logging.getLogger(__name__)
+
+BASE_URL = constants.BASE_URL.value
+USER_AGENT = constants.USER_AGENT.value
+FIRST_YEAR = constants.FIRST_YEAR.value
+ENCODING = constants.SOURCE_ENCODING.value
+DELIMITER = constants.SOURCE_DELIMITER.value
+STAGING_COLUMNS = constants.STAGING_COLUMNS.value
+HEADER_TOKENS = constants.HEADER_TOKENS.value
+NUMERIC_COLUMNS = set(constants.NUMERIC_COLUMNS.value)
+
+# Seconds between requests to the CGU download host. Generous on purpose: the
+# whole source is ~10 MB across 13 files, so pacing costs a minute and buys us
+# not being CAPTCHA-blocked for the rest of the run.
+REQUEST_DELAY = 5.0
+_TIMEOUT = 300
+
+
+class SourceChallengedError(RuntimeError):
+    """AWS WAF answered with a CAPTCHA challenge instead of the file.
+
+    Raised so the run fails loudly and visibly rather than silently writing a
+    2 KB HTML page as if it were data. The remedy is to wait out the block and
+    re-run, not to defeat the challenge.
+    """
+
+
+def _session() -> requests.Session:
+    s = requests.Session()
+    s.headers.update({"User-Agent": USER_AGENT})
+    return s
+
+
+def _fold(text: str) -> str:
+    """Accent-fold and snake-case a source header for comparison."""
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(c for c in text if not unicodedata.combining(c))
+    return re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", text.lower())).strip(
+        "_"
+    )
+
+
+def year_url(year: int) -> str:
+    return f"{BASE_URL}/{year}"
+
+
+def _check_not_challenged(response: requests.Response, year: int) -> None:
+    if response.headers.get("x-amzn-waf-action") == "captcha":
+        raise SourceChallengedError(
+            f"{year}: the CGU download host answered with an AWS WAF CAPTCHA "
+            f"(HTTP {response.status_code}). The IP is rate-limited; wait for "
+            "the block to lapse and re-run. Do not try to solve the challenge."
+        )
+
+
+def _parse_last_modified(response: requests.Response) -> datetime:
+    stamp = response.headers.get("Last-Modified")
+    if not stamp:
+        # Published but undated; treat as modified now so the run proceeds.
+        return datetime.now(UTC)
+    return datetime.strptime(stamp, "%a, %d %b %Y %H:%M:%S %Z").replace(
+        tzinfo=UTC
+    )
+
+
+def probe_latest(session: requests.Session | None = None) -> str:
+    """Return the newest exercise ZIP's ``Last-Modified`` as ``YYYY-MM-DD``.
+
+    Costs a single HEAD. The portal regenerates every exercise file in the same
+    pass — 2024 and 2026 both carried ``Wed, 09 Sep 2026 08:03:12 GMT`` — so one
+    file's timestamp stands for the whole release, and the flow can decide
+    whether to run before spending the download budget.
+
+    Falls back to the previous exercise when the current one is not published
+    yet, which is the state between January 1st and the LOA's publication.
+    """
+    session = session or _session()
+    this_year = datetime.now(UTC).year
+    for year in (this_year, this_year - 1):
+        r = session.head(year_url(year), allow_redirects=True, timeout=60)
+        _check_not_challenged(r, year)
+        if r.status_code == 200:
+            return _parse_last_modified(r).date().isoformat()
+    raise RuntimeError(
+        f"Neither exercise {this_year} nor {this_year - 1} is published under "
+        f"{BASE_URL} — the source layout changed"
+    )
+
+
+def download_all(
+    input_dir: Path, session: requests.Session | None = None
+) -> list[int]:
+    """Download every published exercise ZIP into ``input_dir``.
+
+    Walks forward from :data:`FIRST_YEAR` and stops at the first exercise the
+    portal does not publish, which is how the year range is discovered rather
+    than hardcoded. A 403 is only accepted as the end of the range once we are
+    at or past the current year — a gap in the middle of the history is a source
+    problem, not a stopping condition, and raises.
+
+    Returns the sorted list of exercises actually downloaded.
+    """
+    session = session or _session()
+    input_dir.mkdir(parents=True, exist_ok=True)
+    this_year = datetime.now(UTC).year
+    years: list[int] = []
+
+    for i, year in enumerate(range(FIRST_YEAR, this_year + 3)):
+        if i:
+            time.sleep(REQUEST_DELAY)
+        r = session.get(year_url(year), timeout=_TIMEOUT)
+        _check_not_challenged(r, year)
+        if r.status_code != 200:
+            if year >= this_year:
+                log.info(
+                    "%d not published (HTTP %d) — end of range",
+                    year,
+                    r.status_code,
+                )
+                break
+            raise RuntimeError(
+                f"{year}: HTTP {r.status_code} for an exercise that should exist "
+                f"(the history runs from {FIRST_YEAR} without gaps)"
+            )
+        _extract(r.content, year, input_dir)
+        years.append(year)
+
+    if not years:
+        raise RuntimeError(f"No exercise downloaded from {BASE_URL}")
+    log.info("downloaded %d exercises: %s", len(years), years)
+    return years
+
+
+def _extract(payload: bytes, year: int, input_dir: Path) -> Path:
+    """Extract the single CSV member of one exercise archive."""
+    with zipfile.ZipFile(io.BytesIO(payload)) as zf:
+        members = [n for n in zf.namelist() if n.lower().endswith(".csv")]
+        if len(members) != 1:
+            raise RuntimeError(
+                f"{year}: expected exactly one CSV in the archive, got {members}"
+            )
+        target = input_dir / f"{year}.csv"
+        with zf.open(members[0]) as src, open(target, "wb") as dst:
+            dst.write(src.read())
+    log.info("%d: %s (%d bytes)", year, target.name, target.stat().st_size)
+    return target
+
+
+def _check_header(year: int, header: list[str]) -> None:
+    """Fail loudly when the source layout drifts from what the model expects."""
+    if len(header) != len(HEADER_TOKENS):
+        raise RuntimeError(
+            f"{year}: expected {len(HEADER_TOKENS)} columns, got {len(header)}: {header}"
+        )
+    for pos, (raw, token) in enumerate(
+        zip(header, HEADER_TOKENS, strict=True)
+    ):
+        if not _fold(raw).startswith(token):
+            raise RuntimeError(
+                f"{year}: column {pos} is {raw!r} (folded {_fold(raw)!r}), "
+                f"expected something starting with {token!r}"
+            )
+
+
+def parse_number(value: str) -> str:
+    """Normalise a Brazilian-formatted number into a ``safe_cast``-able string.
+
+    ``"23929428,72"`` -> ``"23929428.72"``, ``"86,16%"`` -> ``"86.16"``,
+    ``"-23657%"`` -> ``"-23657"``. A blank stays blank, which the CSV writes as
+    an empty field and BigQuery reads as NULL — never the literal ``"nan"``.
+    """
+    value = value.strip().rstrip("%").strip()
+    if not value:
+        return ""
+    # "." can only be a thousands separator here; the decimal mark is ",".
+    return value.replace(".", "").replace(",", ".")
+
+
+def clean_year(csv_path: Path, year: int, output_dir: Path) -> int:
+    """Clean one exercise into ``<output_dir>/ano_exercicio=<year>/data.csv``.
+
+    Returns the number of data rows written. The exercise column is dropped from
+    the file because it is carried by the hive partition key.
+    """
+    part_dir = output_dir / f"ano_exercicio={year}"
+    part_dir.mkdir(parents=True, exist_ok=True)
+    target = part_dir / "data.csv"
+
+    written = 0
+    with (
+        open(csv_path, encoding=ENCODING, newline="") as fh,
+        open(target, "w", encoding="utf-8", newline="") as out,
+    ):
+        reader = csv.reader(fh, delimiter=DELIMITER)
+        writer = csv.writer(out, lineterminator="\n")
+        _check_header(year, next(reader))
+        writer.writerow(STAGING_COLUMNS)
+        for row in reader:
+            if len(row) != len(HEADER_TOKENS):
+                raise RuntimeError(
+                    f"{year}: row {written + 2} has {len(row)} fields, "
+                    f"expected {len(HEADER_TOKENS)}"
+                )
+            exercise, rest = row[0].strip(), row[1:]
+            if exercise != str(year):
+                raise RuntimeError(
+                    f"{year}: row {written + 2} carries exercise {exercise!r}"
+                )
+            writer.writerow(
+                [
+                    parse_number(v) if name in NUMERIC_COLUMNS else v.strip()
+                    for name, v in zip(STAGING_COLUMNS, rest, strict=True)
+                ]
+            )
+            written += 1
+    if written == 0:
+        raise RuntimeError(
+            f"{year}: cleaned to zero rows — an empty partition would poison "
+            "the staging schema, so this is an error, not an empty result"
+        )
+    log.info("%d: %d rows -> %s", year, written, target)
+    return written
+
+
+def clean_all(input_dir: Path, output_dir: Path, years: list[int]) -> dict:
+    """Clean every downloaded exercise into one hive-partitioned directory.
+
+    Returns ``{"path": <table dir>, "rows": {year: n}, "total": n}``.
+    """
+    table_dir = output_dir / constants.TABLE_ID.value
+    rows = {
+        year: clean_year(input_dir / f"{year}.csv", year, table_dir)
+        for year in sorted(years)
+    }
+    total = sum(rows.values())
+    log.info("cleaned %d exercises, %d rows total", len(rows), total)
+    return {"path": table_dir, "rows": rows, "total": total}


### PR DESCRIPTION
## Why

`br_cgu_orcamento_publico.orcamento` has been stuck at exercise **2024** since it was
onboarded, while the Portal da Transparência already publishes **2025 and 2026** — because
the dataset had no refresh pipeline at all.

Separately, and already fixed directly on the prod backend (no code change, so not in this
diff): the table was **invisible in the catalog**. It carried 0 columns, 0 cloud tables, 0
coverages and 0 observation levels, and the dataset sat at `under_review`, so the data was
live in BigQuery but nothing showed on the site. That is now registered and published —
26 columns with types, units, trilingual descriptions and the time-directory FK, three
observation levels, cloud table, coverage, Update, and a raw data source.

## What this PR adds

`pipelines/datasets/br_cgu_orcamento_publico/` — a Prefect 3 flow that rebuilds the whole
history on every run, plus the architecture CSV, a partitioned dbt model, and a rewritten
`schema.yml`.

Three properties of the source drove the design:

**1. Closed exercises are restated.** The 2024 file as served on 2026-09-09 carries 142 IBAMA
rows and R$ 2,16 bi authorised, against the 139 rows / R$ 2,05 bi that were ingested earlier.
Across 2014–2024 the row count moved 289,426 → 290,050. So the run re-downloads every
exercise and `dump_mode="overwrite"`s — an append would freeze the restatements out. At ~10 MB
for the whole source, the full rebuild is also the cheap option.

**2. The exercise year is useless as a freshness signal** — it moves once a year while the file
contents move continuously. The poll uses the ZIP's `Last-Modified` against
`Table.Update.latest` (`compare_against="table_update"`). Every exercise shares one timestamp,
so a single HEAD decides whether the run proceeds.

**3. The CGU download host is behind CloudFront + AWS WAF with a rate rule.** A burst gets
`405` with `x-amzn-waf-action: captcha` — a 2 KB HTML challenge page, not the ZIP — IP-wide,
for roughly 6–9 minutes, `curl` and `requests` alike. My first attempt tripped it after three
files. The downloader therefore issues **one request per exercise, 5 s apart** (no separate
HEAD probe), discovers the year range by walking forward until a non-200 at or past the
current year, and raises `SourceChallengedError` on a challenge rather than writing the HTML
to disk as if it were data. Retry delays are 5–10 minutes, which outlasts the block.

## Model changes

- **Partitioned by `ano_exercicio`** (int64, 2014–2031), matching the hive layout the staging
  external table already uses (`.../orcamento/ano_exercicio=YYYY/data.csv`, EXTERNAL,
  all-STRING).
- `schema.yml` descriptions now match the ones registered in the backend, and the
  `Pordentagm` typo is gone.
- The model description now records that **the classification columns are NOT a unique key**.
  The source aggregates over subtítulo/localizador and fonte de recursos without publishing
  them, so one combination of órgão × UO × função × programa × ação × natureza appears in up
  to 10 rows with different values (~2,500 duplicate rows per year). No
  `unique_combination_of_columns` test is possible here; those hidden dimensions are what
  `despesas-execucao` exposes.

## Verification

Local, on the real source:

- Full path exercised end to end: `probe_latest` → `2026-09-09`; 13 exercises downloaded in
  108 s across 14 requests with **no WAF challenge**; 2027 correctly detected as end of range.
- **340,705 rows** cleaned across 2014–2026. Per-exercise counts match the source files
  exactly (line count minus header), every numeric parses, and **no column has a single blank**
  — so the `not_null_proportion_multiple_columns` floor is safe.
- Flow discoverable by `deploy_flows.load_flows_from_file`.
- `ruff` clean; `pyrefly check` 0 diagnostics; dbt graph resolves (1,540 models, 7,224 tests).

Not yet exercised, and the reason for the `deploy-flow` label: the dev run on the worker.
The prod upload half is never exercisable locally.

## After merge

The flow deploys **paused**, as always. Before arming it, note the first armed run is the
first execution of the prod upload. All tables here are `AllFree` — this is annual data, so
there is no BD Pro rolling window and no Row Access Policies are issued.

`table-approve` is on so the prod table picks up the new partitioning and column descriptions
at merge; it rebuilds from the existing 2014–2024 staging. 2025 and 2026 arrive with the
first pipeline run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated weekly updates for the Public Budget dataset, including downloading, validating, and processing annual data from the transparency portal.
  * Added support for refreshing historical records from 2014 onward and detecting newly published exercises.
  * Improved handling of Brazilian numeric formats and organized data by fiscal year.

* **Documentation**
  * Expanded dataset and field descriptions, including units, classification details, and guidance for interpreting repeated records.

* **Bug Fixes**
  * Added validation to identify missing years, empty data, invalid layouts, and incomplete records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->