### PR TITLE
[Data] world_oecd_pisa

### DIFF
--- a/models/world_oecd_pisa/code/atualizar_dicionario_2025.py
+++ b/models/world_oecd_pisa/code/atualizar_dicionario_2025.py
@@ -1,0 +1,367 @@
+"""
+Atualização do dicionário de `world_oecd_pisa.student` para o ciclo 2025.
+
+Duas tarefas, a partir da arquitetura (`extra/student.csv`) e do dicionário
+já publicado na BD (`extra/dictionary.csv`, sem 2025):
+
+1. Colunas que só existem a partir de 2025 (`covered_by_dictionary=yes` e
+   `original_name_2025` preenchido, sem nome original em nenhum ano anterior)
+   não têm nenhuma linha no dicionário ainda — extrai a chave-valor do .sav
+   2025 e cria essas linhas.
+
+2. Colunas que já existiam antes de 2025 podem ter mudado de codificação no
+   novo ciclo. Compara a chave-valor do .sav 2025 com o que já está
+   registrado (a linha "(1)" é o padrão que vale para todos os anos; uma
+   coluna já pode ter overrides pontuais tipo "2018" para um ano específico
+   que divergiu — ver `models/br_ibge_pnadc` para o mesmo padrão). Nunca
+   sobrescreve o histórico: toda divergência vira uma linha nova com
+   temporal_coverage="2025", igual à convenção já usada para os anos
+   anteriores.
+
+Fonte da chave-valor: só existe nos metadados do .sav (`variable_value_labels`
+do pyreadstat) — a staging em BigQuery guarda os códigos, não os rótulos.
+Requer `pip install pyreadstat` e o arquivo CY09_MS_STU_PUF.sav local ou
+acessível (ex.: Google Drive montado, como no Colab onde os anos anteriores
+foram processados).
+
+Uso:
+    python atualizar_dicionario_2025.py
+
+Gera, em extra/:
+    dictionary_2025.csv   — dicionário antigo + linhas novas (task 1 e 2)
+    relatorio_2025.csv    — 1 linha por coluna comparada, com o veredito
+    diffs_2025.csv        — 1 linha por chave cujo rótulo mudou (revisão humana)
+
+Co-Authored-By: Claude Sonnet 5
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+BASE = Path(__file__).resolve().parents[1]  # models/world_oecd_pisa
+ARQUITETURA = BASE / "extra" / "student.csv"
+DICIONARIO_ANTIGO = BASE / "extra" / "dictionary.csv"
+
+# Ajuste para o caminho real do .sav de 2025 antes de rodar — ou, se só o
+# JSON de rótulos exportado do Colab estiver disponível, deixe ROTULOS_JSON
+# apontando para ele e ignore SAV_2025.
+SAV_2025 = BASE / "input" / "2025" / "CY09_MS_STU_PUF.sav"
+ROTULOS_JSON = BASE / "extra" / "rotulos_2025.json"
+
+SAIDA_DICIONARIO = BASE / "extra" / "dictionary_2025.csv"
+SAIDA_RELATORIO = BASE / "extra" / "relatorio_2025.csv"
+SAIDA_DIFFS = BASE / "extra" / "diffs_2025.csv"
+
+TABLE_ID = "student"
+ANO_NOVO = "2025"
+
+ANOS_CICLO = (2025, 2022, 2018, 2015, 2012, 2009, 2006, 2003, 2000)
+YEAR_COLS = [f"original_name_{ano}" for ano in ANOS_CICLO]
+COL_2025, *OUTROS_ANOS_COLS = YEAR_COLS
+
+COLUNAS_DICIONARIO = [
+    "table_id",
+    "column_name",
+    "key",
+    "temporal_coverage",
+    "value",
+]
+
+
+def carregar_arquitetura(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path, dtype=str, keep_default_na=False)
+
+
+def carregar_dicionario_antigo(path: Path) -> pd.DataFrame:
+    dic = pd.read_csv(path, dtype=str, keep_default_na=False)
+    return dic.loc[:, ~dic.columns.str.startswith("Unnamed")]
+
+
+def carregar_rotulos_sav(sav_path: Path) -> dict:
+    """Lê só os metadados do .sav — rápido mesmo em arquivos grandes, não
+    carrega as linhas de dado. Devolve {nome_original: {chave: rotulo}}."""
+    # pyrefly: ignore [missing-import]
+    import pyreadstat
+
+    _, meta = pyreadstat.read_sav(str(sav_path), metadataonly=True)
+    return meta.variable_value_labels
+
+
+def carregar_rotulos_json(json_path: Path) -> dict:
+    """Alternativa a carregar_rotulos_sav quando o .sav não está acessível
+    localmente: lê um dump de meta.variable_value_labels (só as colunas que
+    interessam) exportado do Colab. Ver README/histórico do PR para o
+    trecho que gera esse JSON a partir do pyreadstat."""
+    with open(json_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def normaliza_chave(k) -> str:
+    """1.0, '1.0' (string, vindo de JSON), '0001', 1 -> '1' — mesma
+    convenção do dicionário atual (sem zero à esquerda; ver amostras de
+    `gender`, `oecd`, `isced_level`, `country_birth_self`)."""
+    try:
+        f = float(k)
+        if f.is_integer():
+            k = int(f)
+    except (TypeError, ValueError):
+        pass
+    s = str(k).strip()
+    return (s.lstrip("0") or "0") if s.lstrip("-").isdigit() else s
+
+
+def normaliza_valor(v) -> str:
+    """Compara só o conteúdo textual do rótulo — ignora espaço duplicado e caixa."""
+    return " ".join(str(v).split()).casefold()
+
+
+def colunas_novas_2025(arq: pd.DataFrame) -> pd.DataFrame:
+    """Task 1: colunas com dicionário que só existem a partir de 2025."""
+    mask = (
+        (arq["covered_by_dictionary"] == "yes")
+        & (arq[COL_2025] != "")
+        & arq[OUTROS_ANOS_COLS].apply(
+            lambda r: all(v == "" for v in r), axis=1
+        )
+    )
+    return arq.loc[mask, ["name", "temporal_coverage", COL_2025]]
+
+
+def colunas_compartilhadas(arq: pd.DataFrame) -> pd.DataFrame:
+    """Task 2: colunas com dicionário que já existiam antes de 2025."""
+    mask = (
+        (arq["covered_by_dictionary"] == "yes")
+        & (arq[COL_2025] != "")
+        & arq[OUTROS_ANOS_COLS].apply(
+            lambda r: any(v != "" for v in r), axis=1
+        )
+    )
+    return arq.loc[mask, ["name", "temporal_coverage", COL_2025]]
+
+
+def linhas_para_colunas_novas(
+    novas: pd.DataFrame, rotulos: dict
+) -> pd.DataFrame:
+    """Task 1 — gera as linhas de dicionário para colunas exclusivas de 2025.
+    temporal_coverage vem direto da arquitetura (ex.: "2025(1)")."""
+    linhas, sem_rotulo = [], []
+    for nome, cobertura, original in novas.itertuples(index=False):
+        rot = rotulos.get(original)
+        if not rot:
+            sem_rotulo.append((nome, original))
+            continue
+        for chave, valor in rot.items():
+            linhas.append(
+                {
+                    "table_id": TABLE_ID,
+                    "column_name": nome,
+                    "key": normaliza_chave(chave),
+                    "temporal_coverage": cobertura,
+                    "value": str(valor).strip(),
+                }
+            )
+    if sem_rotulo:
+        print(
+            f"AVISO: {len(sem_rotulo)} colunas novas de 2025 sem value label no .sav:"
+        )
+        for nome, original in sem_rotulo:
+            print(f"    {nome} ({original})")
+    return pd.DataFrame(linhas, columns=COLUNAS_DICIONARIO)
+
+
+def comparar_colunas_compartilhadas(
+    compartilhadas: pd.DataFrame, rotulos: dict, dic_antigo: pd.DataFrame
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Task 2 — compara a chave-valor de 2025 com o histórico, coluna a coluna.
+
+    Devolve (relatorio, diffs, linhas_2025):
+    - relatorio: 1 linha por coluna comparada, com o veredito.
+    - diffs: 1 linha por chave cujo rótulo mudou, para revisão humana.
+    - linhas_2025: linhas a inserir no dicionário (sempre temporal_coverage
+      ="2025" — o histórico nunca é sobrescrito).
+    """
+    relatorio_rows, diffs_rows, linhas_2025 = [], [], []
+
+    for nome, _cobertura_arq, original in compartilhadas.itertuples(
+        index=False
+    ):
+        bloco_antigo = dic_antigo[dic_antigo["column_name"] == nome]
+        rot = rotulos.get(original)
+
+        if bloco_antigo.empty:
+            # Coluna passou a ter dicionário agora, mas nunca teve linha
+            # registrada (ex.: form_id/BOOKID, effort_*). Só temos o .sav de
+            # 2025 aqui — os códigos são adicionados com cobertura 2025 e
+            # ficam sinalizados para confirmar contra os .sav de anos
+            # anteriores antes de estender a cobertura.
+            status = (
+                "AUSENTE_NO_DICIONARIO_ANTIGO"
+                if rot
+                else "AUSENTE_NO_DICIONARIO_E_SEM_VALUE_LABEL"
+            )
+            relatorio_rows.append(
+                {
+                    "column_name": nome,
+                    "original_name_2025": original,
+                    "status": status,
+                    "mudaram": None,
+                    "so_2025": len(rot) if rot else None,
+                    "so_anteriores": None,
+                }
+            )
+            if rot:
+                for chave, valor in rot.items():
+                    linhas_2025.append(
+                        {
+                            "table_id": TABLE_ID,
+                            "column_name": nome,
+                            "key": normaliza_chave(chave),
+                            "temporal_coverage": ANO_NOVO,
+                            "value": str(valor).strip(),
+                        }
+                    )
+            continue
+
+        if not rot:
+            relatorio_rows.append(
+                {
+                    "column_name": nome,
+                    "original_name_2025": original,
+                    "status": "SEM_VALUE_LABEL_NO_SAV",
+                    "mudaram": None,
+                    "so_2025": None,
+                    "so_anteriores": None,
+                }
+            )
+            continue
+
+        # Referência histórica: a linha "(1)" é o rótulo padrão (vale para
+        # todos os anos salvo overrides pontuais tipo "2018"). Quando não há
+        # linha "(1)" — coluna só tem overrides ano-a-ano — usa o bloco
+        # inteiro; nesse caso, chaves repetidas em anos diferentes ficam
+        # com o último valor lido (raro; ver aviso abaixo).
+        referencia = bloco_antigo[bloco_antigo["temporal_coverage"] == "(1)"]
+        so_overrides = referencia.empty
+        if so_overrides:
+            referencia = bloco_antigo
+
+        atuais_2025 = {
+            normaliza_chave(k): str(v).strip() for k, v in rot.items()
+        }
+        historico = dict(
+            zip(
+                referencia["key"].map(normaliza_chave),
+                referencia["value"],
+                strict=True,
+            )
+        )
+
+        mudaram = {
+            k
+            for k in atuais_2025.keys() & historico.keys()
+            if normaliza_valor(atuais_2025[k]) != normaliza_valor(historico[k])
+        }
+        so_2025 = atuais_2025.keys() - historico.keys()
+        so_anteriores = historico.keys() - atuais_2025.keys()
+
+        status = "IGUAL" if not (mudaram or so_2025) else "DIVERGENTE"
+        if so_overrides:
+            status += "_SO_OVERRIDES_SEM_LINHA_(1)"
+        relatorio_rows.append(
+            {
+                "column_name": nome,
+                "original_name_2025": original,
+                "status": status,
+                "mudaram": len(mudaram),
+                "so_2025": len(so_2025),
+                "so_anteriores": len(so_anteriores),
+            }
+        )
+
+        for k in sorted(mudaram):
+            diffs_rows.append(
+                {
+                    "column_name": nome,
+                    "key": k,
+                    "valor_historico": historico[k],
+                    "valor_2025": atuais_2025[k],
+                }
+            )
+        for k in sorted(mudaram | so_2025):
+            linhas_2025.append(
+                {
+                    "table_id": TABLE_ID,
+                    "column_name": nome,
+                    "key": k,
+                    "temporal_coverage": ANO_NOVO,
+                    "value": atuais_2025[k],
+                }
+            )
+
+    relatorio = pd.DataFrame(relatorio_rows)
+    diffs = pd.DataFrame(
+        diffs_rows,
+        columns=["column_name", "key", "valor_historico", "valor_2025"],
+    )
+    linhas_2025_df = pd.DataFrame(linhas_2025, columns=COLUNAS_DICIONARIO)
+    return relatorio, diffs, linhas_2025_df
+
+
+def main() -> None:
+    print("Lendo arquitetura e dicionário antigo...")
+    arq = carregar_arquitetura(ARQUITETURA)
+    dic_antigo = carregar_dicionario_antigo(DICIONARIO_ANTIGO)
+
+    if ROTULOS_JSON.exists():
+        print(f"Lendo rótulos de {ROTULOS_JSON}...")
+        rotulos = carregar_rotulos_json(ROTULOS_JSON)
+    else:
+        print(f"Lendo metadados do .sav ({SAV_2025})...")
+        rotulos = carregar_rotulos_sav(SAV_2025)
+
+    novas = colunas_novas_2025(arq)
+    compartilhadas = colunas_compartilhadas(arq)
+    print(
+        f"{len(novas)} colunas novas em 2025, "
+        f"{len(compartilhadas)} colunas compartilhadas com dicionário"
+    )
+
+    linhas_novas = linhas_para_colunas_novas(novas, rotulos)
+    relatorio, diffs, linhas_2025 = comparar_colunas_compartilhadas(
+        compartilhadas, rotulos, dic_antigo
+    )
+
+    # dedupe pelas 5 colunas (linha idêntica, ex.: rodar o script 2x) — NAO
+    # pelas 4 primeiras. O dicionario antigo tem ~100 linhas onde a mesma
+    # (column_name, key, temporal_coverage) tem 2 valores legitimamente
+    # diferentes (ex.: country_birth_mother, chave 939200 == "Another
+    # country (JPN)" para uns paises e "Other country in Asia..." para
+    # outros — o PISA reaproveita codigo numerico por pais nessas colunas
+    # "national categories"). Dedupe em 4 colunas apagaria uma das duas
+    # linhas por acidente.
+    final = (
+        pd.concat([dic_antigo, linhas_novas, linhas_2025], ignore_index=True)
+        .drop_duplicates(subset=COLUNAS_DICIONARIO)
+        .sort_values(["column_name", "temporal_coverage", "key"])
+        .reset_index(drop=True)
+    )
+
+    final.to_csv(SAIDA_DICIONARIO, index=False)
+    relatorio.sort_values("status").to_csv(SAIDA_RELATORIO, index=False)
+    diffs.to_csv(SAIDA_DIFFS, index=False)
+
+    print(
+        f"\n{len(dic_antigo)} -> {len(final)} linhas no dicionário ({SAIDA_DICIONARIO})"
+    )
+    print(f"\nRelatório por coluna ({SAIDA_RELATORIO}):")
+    print(relatorio["status"].value_counts().to_string())
+    if not diffs.empty:
+        print(
+            f"\n{len(diffs)} chaves com rótulo divergente — ver {SAIDA_DIFFS}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/world_oecd_pisa/code/pisa_2025.ipynb
+++ b/models/world_oecd_pisa/code/pisa_2025.ipynb
@@ -12,7 +12,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# %!pip install pyreadstat basedosdados\n\nimport glob\nimport os\nimport shutil\nimport time\nfrom pathlib import Path\n\nimport basedosdados as bd\nimport pandas as pd\nimport pyreadstat\n\n# from google.colab import drive\n\n# drive.mount(\"/content/drive\")"
+   "source": "# %!pip install pyreadstat basedosdados\n\nimport glob\nimport os\nimport shutil\nimport time\nfrom pathlib import Path\n\nimport basedosdados as bd\nimport pandas as pd\n\n# pyrefly: ignore [missing-import]\nimport pyreadstat\n\n# from google.colab import drive\n\n# drive.mount(\"/content/drive\")"
   },
   {
    "cell_type": "markdown",

--- a/models/world_oecd_pisa/code/pisa_2025.ipynb
+++ b/models/world_oecd_pisa/code/pisa_2025.ipynb
@@ -1,0 +1,992 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Set up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mounted at /content/drive\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install pyreadstat basedosdados\n",
+    "\n",
+    "import glob\n",
+    "import os\n",
+    "import shutil\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import basedosdados as bd\n",
+    "import pandas as pd\n",
+    "import pyreadstat\n",
+    "from google.cloud import bigquery\n",
+    "from google.colab import drive\n",
+    "\n",
+    "drive.mount(\"/content/drive\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Funções"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def to_partitions(\n",
+    "    data: pd.DataFrame, partition_columns: list[str], savepath: str\n",
+    "):\n",
+    "    \"\"\"Salva o dataframe particionado em pastas hive (ex.: ano=2025/sigla_uf=SP/).\"\"\"\n",
+    "\n",
+    "    if isinstance(data, (pd.core.frame.DataFrame)):\n",
+    "        savepath = Path(savepath)\n",
+    "\n",
+    "        # combinações únicas entre as colunas de partição\n",
+    "        unique_combinations = (\n",
+    "            data[partition_columns]\n",
+    "            .drop_duplicates(subset=partition_columns)\n",
+    "            .to_dict(orient=\"records\")\n",
+    "        )\n",
+    "\n",
+    "        for filter_combination in unique_combinations:\n",
+    "            patitions_values = [\n",
+    "                f\"{partition}={value}\"\n",
+    "                for partition, value in filter_combination.items()\n",
+    "            ]\n",
+    "\n",
+    "            # filtra os dados dessa combinação\n",
+    "            df_filter = data.loc[\n",
+    "                data[filter_combination.keys()]\n",
+    "                .isin(filter_combination.values())\n",
+    "                .all(axis=1),\n",
+    "                :,\n",
+    "            ]\n",
+    "            df_filter = df_filter.drop(columns=partition_columns)\n",
+    "\n",
+    "            # cria a árvore de pastas\n",
+    "            filter_save_path = Path(savepath / \"/\".join(patitions_values))\n",
+    "            filter_save_path.mkdir(parents=True, exist_ok=True)\n",
+    "            file_filter_save_path = Path(filter_save_path) / \"student.csv\"\n",
+    "\n",
+    "            # acrescenta os dados ao csv\n",
+    "            df_filter.to_csv(\n",
+    "                file_filter_save_path,\n",
+    "                index=False,\n",
+    "                mode=\"a\",\n",
+    "                header=not file_filter_save_path.exists(),\n",
+    "            )\n",
+    "    else:\n",
+    "        raise BaseException(\"Data need to be a pandas DataFrame\")\n",
+    "\n",
+    "\n",
+    "def contar_linhas(caminho):\n",
+    "    \"\"\"Numero de linhas de dado num csv (desconta o cabecalho).\"\"\"\n",
+    "    with open(caminho, encoding=\"utf-8\") as f:\n",
+    "        return sum(1 for _ in f) - 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2025"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE = \"/content/drive/Shareddrives/Base dos Dados - Geral/Dados/Conjuntos/mundo_oecd_pisa/\"\n",
+    "ARQUITETURA = (\n",
+    "    BASE + \"extra/architecture/student.csv\"\n",
+    ")  # suba a versao final (294 linhas) para o Colab\n",
+    "SAV = BASE + \"input/2025/CY09_MS_STU_PUF.sav\"\n",
+    "OUTPUT = BASE + \"output2/year=2025\"\n",
+    "PARTICAO = \"country_id_iso_3\"\n",
+    "CICLO = \"2025\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "arquitetura: 295 colunas, 206 mapeadas em 2025\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ------------------------------------------------------- 1. arquitetura\n",
+    "\n",
+    "arq = pd.read_csv(ARQUITETURA, dtype=str, keep_default_na=False)\n",
+    "col_ciclo = f\"original_name_{CICLO}\"\n",
+    "for c in (\"name\", \"bigquery_type\", col_ciclo):\n",
+    "    assert c in arq.columns, f\"arquitetura sem coluna {c}: {list(arq.columns)}\"\n",
+    "\n",
+    "selected_variables = [n.strip() for n in arq[\"name\"] if n.strip()]\n",
+    "dicionario_colunas = {\n",
+    "    r[col_ciclo].strip(): r[\"name\"].strip()\n",
+    "    for _, r in arq.iterrows()\n",
+    "    if r[col_ciclo].strip() and r[\"name\"].strip()\n",
+    "}\n",
+    "tipos = dict(zip(arq[\"name\"], arq[\"bigquery_type\"], strict=True))\n",
+    "\n",
+    "assert len(selected_variables) == len(set(selected_variables)), (\n",
+    "    \"name duplicado\"\n",
+    ")\n",
+    "assert len(dicionario_colunas) == len(\n",
+    "    [v for v in arq[col_ciclo] if v.strip()]\n",
+    "), f\"{col_ciclo} duplicado\"\n",
+    "\n",
+    "print(\n",
+    "    f\"arquitetura: {len(selected_variables)} colunas, \"\n",
+    "    f\"{len(dicionario_colunas)} mapeadas em {CICLO}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "31/31 encontradas no .sav\n",
+      "salvo em /content/drive/Shareddrives/Base dos Dados - Geral/Dados/Conjuntos/mundo_oecd_pisa/extra/rotulos_2025.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "_, meta = pyreadstat.read_sav(SAV, metadataonly=True)\n",
+    "vv = meta.variable_value_labels\n",
+    "\n",
+    "precisamos = [\n",
+    "    # tarefa 1 — colunas novas de 2025\n",
+    "    \"Option_LDW\",\n",
+    "    \"Option_PQ\",\n",
+    "    \"Option_ICTQ\",\n",
+    "    \"Option_FLA\",\n",
+    "    \"Option_UH\",\n",
+    "    \"OCOP1\",\n",
+    "    \"OCOP2\",\n",
+    "    \"COBN_P1\",\n",
+    "    \"COBN_P2\",\n",
+    "    \"P1ISCED\",\n",
+    "    \"P2ISCED\",\n",
+    "    # tarefa 2 — colunas compartilhadas com anos anteriores\n",
+    "    \"NatCen\",\n",
+    "    \"STRATUM\",\n",
+    "    \"SUBNATIO\",\n",
+    "    \"OECD\",\n",
+    "    \"ADMINMODE\",\n",
+    "    \"LANGTEST_QQQ\",\n",
+    "    \"LANGTEST_COG\",\n",
+    "    \"BOOKID\",\n",
+    "    \"ST001D01T\",\n",
+    "    \"ST004D01T\",\n",
+    "    \"EFFORT1\",\n",
+    "    \"EFFORT2\",\n",
+    "    \"OCOD3\",\n",
+    "    \"PROGN\",\n",
+    "    \"COBN_S\",\n",
+    "    \"LANGN\",\n",
+    "    \"ISCEDP\",\n",
+    "    \"HISCED\",\n",
+    "    \"IMMIG\",\n",
+    "    \"REPEAT\",\n",
+    "]\n",
+    "\n",
+    "filtrado = {k: vv[k] for k in precisamos if k in vv}\n",
+    "faltando = [k for k in precisamos if k not in vv]\n",
+    "print(f\"{len(filtrado)}/{len(precisamos)} encontradas no .sav\")\n",
+    "if faltando:\n",
+    "    print(\"AVISO — sem value label no .sav:\", faltando)\n",
+    "\n",
+    "caminho = (\n",
+    "    BASE + \"extra/rotulos_2025.json\"\n",
+    ")  # BASE já definido nas celulas anteriores\n",
+    "with open(caminho, \"w\", encoding=\"utf-8\") as f:\n",
+    "    json.dump(filtrado, f, ensure_ascii=False, indent=2)\n",
+    "print(\"salvo em\", caminho)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".sav: 755,721 linhas x 885 colunas | usecols: 206\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ------------------------------------------------- 2. checagem do .sav\n",
+    "\n",
+    "_, meta = pyreadstat.read_sav(SAV, metadataonly=True)\n",
+    "disponiveis = set(meta.column_names)\n",
+    "n_sav = meta.number_rows\n",
+    "\n",
+    "usecols = [c for c in dicionario_colunas if c in disponiveis]\n",
+    "ausentes = [c for c in dicionario_colunas if c not in disponiveis]\n",
+    "\n",
+    "print(\n",
+    "    f\".sav: {n_sav:,} linhas x {len(disponiveis)} colunas | usecols: {len(usecols)}\"\n",
+    ")\n",
+    "if ausentes:\n",
+    "    raise SystemExit(\n",
+    "        f\"PARE. {len(ausentes)} nomes de {col_ciclo} nao existem no .sav: {ausentes}\\n\"\n",
+    "        \"Corrija a arquitetura antes de continuar.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lendo o .sav (alguns minutos)...\n",
+      "lido: 755,721 x 206\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ------------------------------------------------------------ 3. leitura\n",
+    "\n",
+    "print(\"lendo o .sav (alguns minutos)...\")\n",
+    "df = pd.read_spss(SAV, usecols=usecols, convert_categoricals=False)\n",
+    "assert len(df) == n_sav, f\"leitura truncada: {len(df):,} de {n_sav:,}\"\n",
+    "print(f\"lido: {df.shape[0]:,} x {df.shape[1]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.rename(columns=dicionario_colunas)\n",
+    "assert not df.columns.duplicated().any(), \"colisao de nomes apos rename\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "falhas = []\n",
+    "for coluna, tipo in tipos.items():\n",
+    "    if coluna not in df.columns:\n",
+    "        continue\n",
+    "    try:\n",
+    "        if tipo == \"int64\":\n",
+    "            df[coluna] = df[coluna].astype(\"Int64\")\n",
+    "        elif tipo in (\"float\", \"float64\"):\n",
+    "            df[coluna] = df[coluna].astype(\"float64\")\n",
+    "        elif tipo == \"date\":\n",
+    "            df[coluna] = pd.to_datetime(\n",
+    "                df[coluna].astype(\"string\").str.strip().str[:7],\n",
+    "                format=\"%d%b%y\",\n",
+    "                errors=\"coerce\",\n",
+    "            )\n",
+    "        elif tipo == \"string\":\n",
+    "            if df[coluna].dtypes == \"float64\":\n",
+    "                df[coluna] = df[coluna].astype(\"Int64\").astype(\"string\")\n",
+    "            else:\n",
+    "                df[coluna] = df[coluna].astype(\"string\")\n",
+    "    except (ValueError, TypeError) as e:\n",
+    "        falhas.append((coluna, tipo, f\"{type(e).__name__}: {e}\"))\n",
+    "\n",
+    "if falhas:\n",
+    "    print(f\"{len(falhas)} colunas nao converteram:\")\n",
+    "    for c, t, e in falhas:\n",
+    "        print(f\"   {c} -> {t}: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "89 colunas sem dado em 2025, preenchidas com vazio\n",
+      "saida: 755,721 linhas x 294 colunas (293 no CSV, sem country_id_iso_3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ------------------------------------- 6. colunas descontinuadas e ordem\n",
+    "\n",
+    "faltantes = [c for c in selected_variables if c not in df.columns]\n",
+    "if faltantes:\n",
+    "    # de uma vez so: 87 insercoes separadas fragmentam o frame e disparam\n",
+    "    # PerformanceWarning a cada chamada\n",
+    "    df = pd.concat(\n",
+    "        [df, pd.DataFrame(\"\", index=df.index, columns=faltantes)],\n",
+    "        axis=1,\n",
+    "        copy=False,\n",
+    "    )\n",
+    "print(f\"{len(faltantes)} colunas sem dado em {CICLO}, preenchidas com vazio\")\n",
+    "\n",
+    "# `year` e particao do caminho (output/year=2025), nao coluna do arquivo\n",
+    "colunas_saida = [c for c in selected_variables if c != \"year\"]\n",
+    "df = df[colunas_saida].copy()\n",
+    "print(\n",
+    "    f\"saida: {df.shape[0]:,} linhas x {df.shape[1]} colunas \"\n",
+    "    f\"({df.shape[1] - 1} no CSV, sem {PARTICAO})\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if os.path.isdir(OUTPUT):\n",
+    "    antigos = [\n",
+    "        os.path.join(r, f)\n",
+    "        for r, _, fs in os.walk(OUTPUT)\n",
+    "        for f in fs\n",
+    "        if f == \"student.csv\"\n",
+    "    ]\n",
+    "    if antigos:\n",
+    "        print(f\"removendo {len(antigos)} student.csv de execucao anterior\")\n",
+    "    shutil.rmtree(OUTPUT)\n",
+    "Path(OUTPUT).mkdir(parents=True, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "particionando por country_id_iso_3...\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"particionando por {PARTICAO}...\")\n",
+    "to_partitions(data=df, partition_columns=[PARTICAO], savepath=OUTPUT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --------------------------------------------------------- 9. conferencia\n",
+    "\n",
+    "arquivos = [\n",
+    "    os.path.join(r, f)\n",
+    "    for r, _, fs in os.walk(OUTPUT)\n",
+    "    for f in fs\n",
+    "    if f == \"student.csv\"\n",
+    "]\n",
+    "total = sum(contar_linhas(p) for p in arquivos)\n",
+    "\n",
+    "print(\n",
+    "    f\"\\n{len(arquivos)} particoes | linhas nos CSVs: {total:,} | no .sav: {n_sav:,}\"\n",
+    ")\n",
+    "\n",
+    "amostra = pd.read_csv(arquivos[0], dtype=str, keep_default_na=False, nrows=3)\n",
+    "pais = Path(arquivos[0]).parent.name\n",
+    "print(f\"amostra {pais}: {amostra.shape[1]} colunas\")\n",
+    "print(f\"  {PARTICAO} fora do CSV: {PARTICAO not in amostra.columns}\")\n",
+    "print(f\"  year fora do CSV:            {'year' not in amostra.columns}\")\n",
+    "\n",
+    "ok = (\n",
+    "    total == n_sav\n",
+    "    and amostra.shape[1] == len(colunas_saida) - 1\n",
+    "    and PARTICAO not in amostra.columns\n",
+    "    and \"year\" not in amostra.columns\n",
+    ")\n",
+    "print(\"\\nOK\" if ok else \"\\nErro\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arquivos = sorted(glob.glob(f\"{OUTPUT}/country_id_iso_3=*/student.csv\"))\n",
+    "print(len(arquivos), \"partições\")\n",
+    "\n",
+    "p = next(x for x in arquivos if \"BRA\" in x)\n",
+    "d = pd.read_csv(p, dtype=str, keep_default_na=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q = \"\"\"\n",
+    "SELECT *\n",
+    "FROM `basedosdados.world_oecd_pisa.student`\n",
+    "LIMIT 0\n",
+    "\"\"\"\n",
+    "bq = bd.read_sql(q, billing_project_id=\"basedosdados-dev\")\n",
+    "print(bq)\n",
+    "\n",
+    "novas = [c for c in d.columns if c not in bq]\n",
+    "sumiram = [\n",
+    "    c\n",
+    "    for c in bq\n",
+    "    if c not in d.columns and c not in (\"year\", \"country_id_iso_3\")\n",
+    "]\n",
+    "print(f\"{len(novas)} colunas novas:\")\n",
+    "for c in novas:\n",
+    "    print(\"  \", c)\n",
+    "print(f\"\\n{len(sumiram)} colunas do BQ ausentes no CSV:\", sumiram or \"nenhuma\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Baixar anos anteriores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cli = bigquery.Client(project=\"basedosdados-dev\")\n",
+    "cfg = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)\n",
+    "\n",
+    "sql = \"\"\"SELECT * EXCEPT(year, country_id_iso_3) FROM `basedosdados.world_oecd_pisa.student`\n",
+    "          WHERE year = 2025 AND country_id_iso_3 = 'BRA'\"\"\"\n",
+    "job = cli.query(sql, job_config=cfg)\n",
+    "gb = job.total_bytes_processed / 1e9\n",
+    "print(\n",
+    "    f\"{gb:.2f} GB por consulta -> ~{gb * 300:.0f} GB nas 300 -> ~US$ {gb * 300 / 1000 * 6.25:.2f}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for ano in (2015, 2018, 2022, 2025):\n",
+    "    sql = f\"\"\"SELECT * EXCEPT(year, country_id_iso_3) FROM `basedosdados.world_oecd_pisa.student`\n",
+    "              WHERE year = {ano} AND country_id_iso_3 = 'BRA'\"\"\"\n",
+    "    gb = cli.query(sql, job_config=cfg).total_bytes_processed / 1e9\n",
+    "    print(f\"{ano}: {gb:.3f} GB\")\n",
+    "\n",
+    "# quanto pesa a tabela inteira, como referencia\n",
+    "total = (\n",
+    "    cli.query(\n",
+    "        \"SELECT * FROM `basedosdados.world_oecd_pisa.student`\", job_config=cfg\n",
+    "    ).total_bytes_processed\n",
+    "    / 1e9\n",
+    ")\n",
+    "print(f\"tabela inteira: {total:.2f} GB\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ----------------------------------------------------------------- config\n",
+    "\n",
+    "PROJETO = \"basedosdados-dev\"  # billing project no GCP\n",
+    "TABELA = \"basedosdados.world_oecd_pisa.student\"\n",
+    "\n",
+    "# Grava local primeiro: o FUSE do Drive e lento para ~300 arquivos pequenos e\n",
+    "# ocasionalmente falha em silencio. A copia para o Drive acontece no fim.\n",
+    "TRABALHO = Path(\"/content/download_student\")\n",
+    "DRIVE = Path(BASE) / \"output/novas_colunas\"\n",
+    "\n",
+    "ANOS = None  # None = todos; ou [2015, 2018] para restringir\n",
+    "TENTATIVAS = 3  # por particao, em caso de falha de rede"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ------------------------------------------------------ 1. lista de particoes\n",
+    "# Traz tambem a contagem de linhas, que serve para validar cada download.\n",
+    "\n",
+    "sql_pares = f\"\"\"\n",
+    "    SELECT year, country_id_iso_3, COUNT(*) AS linhas\n",
+    "    FROM `{TABELA}`\n",
+    "    {\"WHERE year IN (\" + \",\".join(map(str, ANOS)) + \")\" if ANOS else \"\"}\n",
+    "    GROUP BY 1, 2\n",
+    "    ORDER BY 1, 2\n",
+    "\"\"\"\n",
+    "pares = bd.read_sql(sql_pares, billing_project_id=PROJETO)\n",
+    "print(f\"{len(pares)} particoes, {pares['linhas'].sum():,} linhas no total\")\n",
+    "print(pares.groupby(\"year\")[\"linhas\"].agg([\"count\", \"sum\"]).to_string())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ---------------------------------------------------------------- 2. download\n",
+    "\n",
+    "pendentes, divergentes = [], []\n",
+    "t0 = time.time()\n",
+    "\n",
+    "for k, (_, r) in enumerate(pares.iterrows(), 1):\n",
+    "    pasta = (\n",
+    "        TRABALHO / f\"year={r.year}\" / f\"country_id_iso_3={r.country_id_iso_3}\"\n",
+    "    )\n",
+    "    arquivo = pasta / \"student.csv\"\n",
+    "    rotulo = f\"{r.year} {r.country_id_iso_3}\"\n",
+    "\n",
+    "    if arquivo.exists():\n",
+    "        continue\n",
+    "\n",
+    "    sql = f\"\"\"\n",
+    "        SELECT * EXCEPT(year, country_id_iso_3)\n",
+    "        FROM `{TABELA}`\n",
+    "        WHERE year = {r.year} AND country_id_iso_3 = '{r.country_id_iso_3}'\n",
+    "    \"\"\"\n",
+    "\n",
+    "    d = None\n",
+    "    for tentativa in range(1, TENTATIVAS + 1):\n",
+    "        try:\n",
+    "            d = bd.read_sql(sql, billing_project_id=PROJETO)\n",
+    "            break\n",
+    "        except Exception as e:\n",
+    "            print(\n",
+    "                f\"  [{k}/{len(pares)}] {rotulo}: tentativa {tentativa} falhou \"\n",
+    "                f\"({type(e).__name__})\"\n",
+    "            )\n",
+    "            if tentativa < TENTATIVAS:\n",
+    "                time.sleep(5 * tentativa)\n",
+    "\n",
+    "    if d is None:\n",
+    "        pendentes.append(rotulo)\n",
+    "        continue\n",
+    "\n",
+    "    # Nao aborta o laco: registra a divergencia e segue, para nao perder as\n",
+    "    # particoes restantes por causa de uma. Revisar a lista no fim.\n",
+    "    if len(d) != r.linhas:\n",
+    "        divergentes.append((rotulo, len(d), int(r.linhas)))\n",
+    "        print(\n",
+    "            f\"  [{k}/{len(pares)}] {rotulo}: DIVERGENCIA {len(d)} != {r.linhas}\"\n",
+    "        )\n",
+    "\n",
+    "    pasta.mkdir(parents=True, exist_ok=True)\n",
+    "    d.to_csv(arquivo, index=False)\n",
+    "    print(f\"[{k}/{len(pares)}] {rotulo} {len(d):>7,} linhas\")\n",
+    "    del d\n",
+    "\n",
+    "print(f\"\\ntempo: {(time.time() - t0) / 60:.1f} min\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "\n",
+    "TRABALHO = Path(\"/content/download_student\")\n",
+    "DRIVE = Path(BASE) / \"output/novas_colunas\"\n",
+    "\n",
+    "baixados = sorted(TRABALHO.glob(\"year=*/country_id_iso_3=*/student.csv\"))\n",
+    "print(f\"{len(baixados)} arquivos em {TRABALHO}\")\n",
+    "print(\"esperado: 233\")\n",
+    "\n",
+    "if len(baixados) == 233:\n",
+    "    DRIVE.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    shutil.copytree(TRABALHO, DRIVE, dirs_exist_ok=True)\n",
+    "    n = len(list(DRIVE.glob(\"year=*/country_id_iso_3=*/student.csv\")))\n",
+    "    print(f\"{n} arquivos no Drive\")\n",
+    "else:\n",
+    "    print(\"faltou arquivo -- nao copie ainda\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adicionando as 45 colunas novas na ordem de 2025"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ----------------------------------------------------------------- config\n",
+    "\n",
+    "DRIVE = Path(BASE) / \"output/novas_colunas\"\n",
+    "TRABALHO = Path(\"/content/uniformizado\")\n",
+    "REFERENCIA = \"year=2025\"  # de onde sai a ordem canonica das colunas\n",
+    "\n",
+    "# ------------------------------------------------------- 1. ordem canonica\n",
+    "\n",
+    "algum_2025 = next(\n",
+    "    iter(sorted((DRIVE / REFERENCIA).glob(\"*/student.csv\"))), None\n",
+    ")\n",
+    "if algum_2025 is None:\n",
+    "    raise SystemExit(f\"Nenhum arquivo em {DRIVE / REFERENCIA}\")\n",
+    "\n",
+    "ORDEM = pd.read_csv(algum_2025, nrows=0).columns.tolist()\n",
+    "print(f\"ordem de referencia: {len(ORDEM)} colunas ({algum_2025.parts[-3]})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --------------------------------------------------- 2. inventario de entrada\n",
+    "\n",
+    "from collections import Counter\n",
+    "\n",
+    "arquivos = sorted(DRIVE.glob(\"year=*/country_id_iso_3=*/student.csv\"))\n",
+    "print(f\"{len(arquivos)} arquivos encontrados\")\n",
+    "\n",
+    "antes = {}\n",
+    "for p in arquivos:\n",
+    "    cols = pd.read_csv(p, nrows=0).columns.tolist()\n",
+    "    sobra = [c for c in cols if c not in ORDEM]\n",
+    "    if sobra:\n",
+    "        raise SystemExit(\n",
+    "            f\"PARE. {p.parts[-3]}/{p.parts[-2]} tem colunas fora da referencia: {sobra}\\n\"\n",
+    "            \"Investigue antes de continuar: reordenar descartaria esses dados.\"\n",
+    "        )\n",
+    "    antes[p] = len(cols)\n",
+    "\n",
+    "print(\"colunas por arquivo:\", dict(Counter(antes.values())))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if TRABALHO.exists():\n",
+    "    shutil.rmtree(TRABALHO)\n",
+    "\n",
+    "feitos, ja_ok = 0, 0\n",
+    "for p in arquivos:\n",
+    "    ano, pais = p.parts[-3], p.parts[-2]\n",
+    "\n",
+    "    d = pd.read_csv(p, dtype=str, keep_default_na=False)\n",
+    "    n_linhas = len(d)\n",
+    "\n",
+    "    faltantes = [c for c in ORDEM if c not in d.columns]\n",
+    "    if faltantes:\n",
+    "        d = pd.concat(\n",
+    "            [d, pd.DataFrame(\"\", index=d.index, columns=faltantes)],\n",
+    "            axis=1,\n",
+    "            copy=False,\n",
+    "        )\n",
+    "    else:\n",
+    "        ja_ok += 1\n",
+    "\n",
+    "    d = d[ORDEM].copy()\n",
+    "\n",
+    "    assert len(d) == n_linhas, f\"{ano}/{pais}: perdeu linha\"\n",
+    "    assert list(d.columns) == ORDEM, f\"{ano}/{pais}: ordem errada\"\n",
+    "\n",
+    "    destino = TRABALHO / ano / pais\n",
+    "    destino.mkdir(parents=True, exist_ok=True)\n",
+    "    d.to_csv(destino / \"student.csv\", index=False)\n",
+    "\n",
+    "    feitos += 1\n",
+    "    if feitos % 25 == 0 or faltantes:\n",
+    "        print(\n",
+    "            f\"[{feitos}/{len(arquivos)}] {ano} {pais}  \"\n",
+    "            f\"{n_linhas:>7,} linhas  +{len(faltantes)} colunas\"\n",
+    "        )\n",
+    "    del d\n",
+    "\n",
+    "print(f\"\\n{feitos} arquivos gravados em {TRABALHO}\")\n",
+    "print(f\"{ja_ok} ja estavam completos (nenhuma coluna acrescentada)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "DRIVE = Path(BASE) / \"output/novas_colunas\"\n",
+    "TRABALHO = Path(\"/content/uniformizado\")\n",
+    "\n",
+    "ORDEM = pd.read_csv(\n",
+    "    next(iter(sorted((TRABALHO / \"year=2025\").glob(\"*/student.csv\")))), nrows=0\n",
+    ").columns.tolist()\n",
+    "print(f\"{len(ORDEM)} colunas na referencia\")\n",
+    "\n",
+    "problemas = []\n",
+    "for p in sorted(DRIVE.glob(\"year=*/country_id_iso_3=*/student.csv\")):\n",
+    "    novo = TRABALHO / p.parts[-3] / p.parts[-2] / \"student.csv\"\n",
+    "    if not novo.exists():\n",
+    "        problemas.append((p.parts[-3], p.parts[-2], \"nao gerado\"))\n",
+    "        continue\n",
+    "    if pd.read_csv(novo, nrows=0).columns.tolist() != ORDEM:\n",
+    "        problemas.append((p.parts[-3], p.parts[-2], \"ordem divergente\"))\n",
+    "        continue\n",
+    "    a = contar_linhas(p)\n",
+    "    b = contar_linhas(novo)\n",
+    "    if a != b:\n",
+    "        problemas.append((p.parts[-3], p.parts[-2], f\"{b} != {a}\"))\n",
+    "\n",
+    "print(f\"{len(problemas)} problemas\", problemas[:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "\n",
+    "TRABALHO = Path(\"/content/uniformizado\")\n",
+    "DRIVE = Path(BASE) / \"output/novas_colunas\"\n",
+    "\n",
+    "shutil.copytree(TRABALHO, DRIVE, dirs_exist_ok=True)\n",
+    "print(\n",
+    "    len(list(DRIVE.glob(\"year=*/country_id_iso_3=*/student.csv\"))),\n",
+    "    \"arquivos no Drive\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "d = pd.read_csv(\n",
+    "    DRIVE / \"year=2015/country_id_iso_3=BRA/student.csv\",\n",
+    "    dtype=str,\n",
+    "    keep_default_na=False,\n",
+    ")\n",
+    "novas = [\n",
+    "    \"plausible_value_1_ldw\",\n",
+    "    \"option_learning_digital_world\",\n",
+    "    \"isced_parent_1\",\n",
+    "    \"wle_ai_use_school\",\n",
+    "]\n",
+    "print(d.shape)\n",
+    "print({c: (d[c] == \"\").all() for c in novas})  # todos devem dar True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "\n",
+    "ORIGEM = Path(\"/content/download_student\")\n",
+    "DESTINO = Path(BASE) / \"backup\"\n",
+    "\n",
+    "print(\"origem existe:\", ORIGEM.exists())\n",
+    "if ORIGEM.exists():\n",
+    "    n = len(list(ORIGEM.glob(\"year=*/country_id_iso_3=*/student.csv\")))\n",
+    "    print(f\"{n} arquivos (esperado 233)\")\n",
+    "\n",
+    "# compacta local\n",
+    "zip_local = shutil.make_archive(\"/content/download_student_bq\", \"zip\", ORIGEM)\n",
+    "mb = os.path.getsize(zip_local) / 1e6\n",
+    "print(f\"{zip_local}  {mb:.0f} MB\")\n",
+    "\n",
+    "DESTINO.mkdir(parents=True, exist_ok=True)\n",
+    "shutil.copy2(zip_local, DESTINO / \"download_student_bq.zip\")\n",
+    "\n",
+    "final = DESTINO / \"download_student_bq.zip\"\n",
+    "print(f\"no Drive: {final}  {os.path.getsize(final) / 1e6:.0f} MB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comparar com output2 (validação)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "anos em comum: ['2025']\n",
+      "\n",
+      "2025: 30140 x 293 (nova) vs 30140 x 293 (antiga)\n",
+      "  colunas so na nova: ['wle_ict_availability_school']\n",
+      "  colunas so na antiga: ['wle_availability_usage_school']\n",
+      "  dados identicos\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---- comparar BRA: output novo x output2 (script antigo) ----\n",
+    "# ajuste os dois caminhos abaixo se as pastas tiverem outro nome no seu Drive\n",
+    "\n",
+    "PASTA_NOVA = Path(BASE) / \"output\" / \"novas_colunas\"\n",
+    "PASTA_ANTIGA = Path(BASE) / \"output2\"\n",
+    "\n",
+    "anos_nova = {p.name.split(\"=\")[1] for p in PASTA_NOVA.glob(\"year=*\")}\n",
+    "anos_antiga = {p.name.split(\"=\")[1] for p in PASTA_ANTIGA.glob(\"year=*\")}\n",
+    "anos = sorted(anos_nova & anos_antiga, key=int)\n",
+    "print(f\"anos em comum: {anos}\")\n",
+    "\n",
+    "# colunas que sabidamente divergem por design (fix aplicado so no dbt, nao no\n",
+    "# CSV bruto) -- reportadas a parte, sem contar como divergencia real\n",
+    "CONHECIDAS = {\n",
+    "    \"country_id_m49\"\n",
+    "}  # zero a esquerda: fix e so no safe_cast do dbt\n",
+    "\n",
+    "for ano in anos:\n",
+    "    a = PASTA_NOVA / f\"year={ano}\" / \"country_id_iso_3=BRA\" / \"student.csv\"\n",
+    "    b = PASTA_ANTIGA / f\"year={ano}\" / \"country_id_iso_3=BRA\" / \"student.csv\"\n",
+    "    if not a.exists() or not b.exists():\n",
+    "        print(\n",
+    "            f\"{ano}: arquivo faltando ({'nova' if not a.exists() else 'antiga'})\"\n",
+    "        )\n",
+    "        continue\n",
+    "\n",
+    "    da = pd.read_csv(a, dtype=str, keep_default_na=False)\n",
+    "    db = pd.read_csv(b, dtype=str, keep_default_na=False)\n",
+    "\n",
+    "    so_nova = [c for c in da.columns if c not in db.columns]\n",
+    "    so_antiga = [c for c in db.columns if c not in da.columns]\n",
+    "    comuns = [c for c in da.columns if c in db.columns]\n",
+    "\n",
+    "    print(\n",
+    "        f\"\\n{ano}: {da.shape[0]} x {da.shape[1]} (nova) vs {db.shape[0]} x {db.shape[1]} (antiga)\"\n",
+    "    )\n",
+    "    if so_nova:\n",
+    "        print(\"  colunas so na nova:\", so_nova)\n",
+    "    if so_antiga:\n",
+    "        print(\"  colunas so na antiga:\", so_antiga)\n",
+    "\n",
+    "    if da.shape[0] != db.shape[0]:\n",
+    "        print(\"  numero de linhas diferente -- pulando comparacao de valores\")\n",
+    "        continue\n",
+    "\n",
+    "    chave = \"student_id\" if \"student_id\" in comuns else comuns\n",
+    "    da_cmp = da[comuns].sort_values(chave).reset_index(drop=True)\n",
+    "    db_cmp = db[comuns].sort_values(chave).reset_index(drop=True)\n",
+    "\n",
+    "    dif = da_cmp.ne(db_cmp)\n",
+    "    colunas_dif = list(dif.any(axis=0)[dif.any(axis=0)].index)\n",
+    "    esperadas = [c for c in colunas_dif if c in CONHECIDAS]\n",
+    "    inesperadas = [c for c in colunas_dif if c not in CONHECIDAS]\n",
+    "\n",
+    "    if not colunas_dif:\n",
+    "        print(\"  dados identicos\")\n",
+    "    else:\n",
+    "        if esperadas:\n",
+    "            print(\"  divergem (esperado, fix so no dbt):\", esperadas)\n",
+    "        if inesperadas:\n",
+    "            linhas_dif = dif[inesperadas].any(axis=1).sum()\n",
+    "            print(\n",
+    "                f\"  divergem (NAO esperado): {inesperadas} -- {linhas_dif} linhas afetadas\"\n",
+    "            )"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/models/world_oecd_pisa/code/pisa_2025.ipynb
+++ b/models/world_oecd_pisa/code/pisa_2025.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -21,7 +21,7 @@
     }
    ],
    "source": [
-    "!pip install pyreadstat basedosdados\n",
+    "%!pip install pyreadstat basedosdados\n",
     "\n",
     "import glob\n",
     "import os\n",
@@ -32,10 +32,10 @@
     "import basedosdados as bd\n",
     "import pandas as pd\n",
     "import pyreadstat\n",
-    "from google.cloud import bigquery\n",
-    "from google.colab import drive\n",
     "\n",
-    "drive.mount(\"/content/drive\")"
+    "# from google.colab import drive\n",
+    "\n",
+    "# drive.mount(\"/content/drive\")"
    ]
   },
   {
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,10 +56,9 @@
     "):\n",
     "    \"\"\"Salva o dataframe particionado em pastas hive (ex.: ano=2025/sigla_uf=SP/).\"\"\"\n",
     "\n",
-    "    if isinstance(data, (pd.core.frame.DataFrame)):\n",
-    "        savepath = Path(savepath)\n",
+    "    if isinstance(data, pd.DataFrame):\n",
+    "        Path(savepath)\n",
     "\n",
-    "        # combinações únicas entre as colunas de partição\n",
     "        unique_combinations = (\n",
     "            data[partition_columns]\n",
     "            .drop_duplicates(subset=partition_columns)\n",
@@ -112,23 +111,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "BASE = \"/content/drive/Shareddrives/Base dos Dados - Geral/Dados/Conjuntos/mundo_oecd_pisa/\"\n",
-    "ARQUITETURA = (\n",
-    "    BASE + \"extra/architecture/student.csv\"\n",
-    ")  # suba a versao final (294 linhas) para o Colab\n",
+    "BASE = \"/mundo_oecd_pisa/\"\n",
+    "ARQUITETURA = BASE + \"extra/architecture/student.csv\"\n",
     "SAV = BASE + \"input/2025/CY09_MS_STU_PUF.sav\"\n",
-    "OUTPUT = BASE + \"output2/year=2025\"\n",
+    "OUTPUT = BASE + \"output/year=2025\"\n",
     "PARTICAO = \"country_id_iso_3\"\n",
     "CICLO = \"2025\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -140,7 +137,7 @@
     }
    ],
    "source": [
-    "# ------------------------------------------------------- 1. arquitetura\n",
+    "# arquitetura\n",
     "\n",
     "arq = pd.read_csv(ARQUITETURA, dtype=str, keep_default_na=False)\n",
     "col_ciclo = f\"original_name_{CICLO}\"\n",
@@ -170,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -189,7 +186,7 @@
     "vv = meta.variable_value_labels\n",
     "\n",
     "precisamos = [\n",
-    "    # tarefa 1 — colunas novas de 2025\n",
+    "    # colunas novas de 2025\n",
     "    \"Option_LDW\",\n",
     "    \"Option_PQ\",\n",
     "    \"Option_ICTQ\",\n",
@@ -201,7 +198,7 @@
     "    \"COBN_P2\",\n",
     "    \"P1ISCED\",\n",
     "    \"P2ISCED\",\n",
-    "    # tarefa 2 — colunas compartilhadas com anos anteriores\n",
+    "    # colunas compartilhadas com anos anteriores\n",
     "    \"NatCen\",\n",
     "    \"STRATUM\",\n",
     "    \"SUBNATIO\",\n",
@@ -230,9 +227,7 @@
     "if faltando:\n",
     "    print(\"AVISO — sem value label no .sav:\", faltando)\n",
     "\n",
-    "caminho = (\n",
-    "    BASE + \"extra/rotulos_2025.json\"\n",
-    ")  # BASE já definido nas celulas anteriores\n",
+    "caminho = BASE + \"extra/rotulos_2025.json\"\n",
     "with open(caminho, \"w\", encoding=\"utf-8\") as f:\n",
     "    json.dump(filtrado, f, ensure_ascii=False, indent=2)\n",
     "print(\"salvo em\", caminho)"
@@ -240,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -252,7 +247,7 @@
     }
    ],
    "source": [
-    "# ------------------------------------------------- 2. checagem do .sav\n",
+    "# checagem do .sav\n",
     "\n",
     "_, meta = pyreadstat.read_sav(SAV, metadataonly=True)\n",
     "disponiveis = set(meta.column_names)\n",
@@ -273,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -286,7 +281,7 @@
     }
    ],
    "source": [
-    "# ------------------------------------------------------------ 3. leitura\n",
+    "# leitura do .sav\n",
     "\n",
     "print(\"lendo o .sav (alguns minutos)...\")\n",
     "df = pd.read_spss(SAV, usecols=usecols, convert_categoricals=False)\n",
@@ -296,10 +291,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# rename das colunas para nomes padronizados\n",
     "df = df.rename(columns=dicionario_colunas)\n",
     "assert not df.columns.duplicated().any(), \"colisao de nomes apos rename\""
    ]
@@ -341,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -354,7 +350,7 @@
     }
    ],
    "source": [
-    "# ------------------------------------- 6. colunas descontinuadas e ordem\n",
+    "# colunas descontinuadas e ordem\n",
     "\n",
     "faltantes = [c for c in selected_variables if c not in df.columns]\n",
     "if faltantes:\n",
@@ -419,7 +415,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# --------------------------------------------------------- 9. conferencia\n",
+    "# conferencia\n",
     "\n",
     "arquivos = [\n",
     "    os.path.join(r, f)\n",
@@ -467,12 +463,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q = \"\"\"\n",
+    "# conferir colunas\n",
+    "query = \"\"\"\n",
     "SELECT *\n",
     "FROM `basedosdados.world_oecd_pisa.student`\n",
     "LIMIT 0\n",
     "\"\"\"\n",
-    "bq = bd.read_sql(q, billing_project_id=\"basedosdados-dev\")\n",
+    "bq = bd.read_sql(query, billing_project_id=\"\")\n",
     "print(bq)\n",
     "\n",
     "novas = [c for c in d.columns if c not in bq]\n",
@@ -500,49 +497,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cli = bigquery.Client(project=\"basedosdados-dev\")\n",
-    "cfg = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)\n",
+    "# config\n",
     "\n",
-    "sql = \"\"\"SELECT * EXCEPT(year, country_id_iso_3) FROM `basedosdados.world_oecd_pisa.student`\n",
-    "          WHERE year = 2025 AND country_id_iso_3 = 'BRA'\"\"\"\n",
-    "job = cli.query(sql, job_config=cfg)\n",
-    "gb = job.total_bytes_processed / 1e9\n",
-    "print(\n",
-    "    f\"{gb:.2f} GB por consulta -> ~{gb * 300:.0f} GB nas 300 -> ~US$ {gb * 300 / 1000 * 6.25:.2f}\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for ano in (2015, 2018, 2022, 2025):\n",
-    "    sql = f\"\"\"SELECT * EXCEPT(year, country_id_iso_3) FROM `basedosdados.world_oecd_pisa.student`\n",
-    "              WHERE year = {ano} AND country_id_iso_3 = 'BRA'\"\"\"\n",
-    "    gb = cli.query(sql, job_config=cfg).total_bytes_processed / 1e9\n",
-    "    print(f\"{ano}: {gb:.3f} GB\")\n",
-    "\n",
-    "# quanto pesa a tabela inteira, como referencia\n",
-    "total = (\n",
-    "    cli.query(\n",
-    "        \"SELECT * FROM `basedosdados.world_oecd_pisa.student`\", job_config=cfg\n",
-    "    ).total_bytes_processed\n",
-    "    / 1e9\n",
-    ")\n",
-    "print(f\"tabela inteira: {total:.2f} GB\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ----------------------------------------------------------------- config\n",
-    "\n",
-    "PROJETO = \"basedosdados-dev\"  # billing project no GCP\n",
+    "PROJETO = \"\"  # billing project no GCP\n",
     "TABELA = \"basedosdados.world_oecd_pisa.student\"\n",
     "\n",
     "# Grava local primeiro: o FUSE do Drive e lento para ~300 arquivos pequenos e\n",
@@ -550,7 +507,7 @@
     "TRABALHO = Path(\"/content/download_student\")\n",
     "DRIVE = Path(BASE) / \"output/novas_colunas\"\n",
     "\n",
-    "ANOS = None  # None = todos; ou [2015, 2018] para restringir\n",
+    "ANOS = None  # None = todos\n",
     "TENTATIVAS = 3  # por particao, em caso de falha de rede"
    ]
   },
@@ -560,7 +517,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ------------------------------------------------------ 1. lista de particoes\n",
+    "#  lista de particoes\n",
     "# Traz tambem a contagem de linhas, que serve para validar cada download.\n",
     "\n",
     "sql_pares = f\"\"\"\n",
@@ -581,7 +538,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ---------------------------------------------------------------- 2. download\n",
+    "# download\n",
     "\n",
     "pendentes, divergentes = [], []\n",
     "t0 = time.time()\n",
@@ -664,7 +621,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Adicionando as 45 colunas novas na ordem de 2025"
+    "### Adicionando as 45 colunas novas na ordem de 2025 aos anos anteriores"
    ]
   },
   {
@@ -673,13 +630,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ----------------------------------------------------------------- config\n",
+    "# config\n",
     "\n",
     "DRIVE = Path(BASE) / \"output/novas_colunas\"\n",
     "TRABALHO = Path(\"/content/uniformizado\")\n",
     "REFERENCIA = \"year=2025\"  # de onde sai a ordem canonica das colunas\n",
     "\n",
-    "# ------------------------------------------------------- 1. ordem canonica\n",
+    "# ordem canonica\n",
     "\n",
     "algum_2025 = next(\n",
     "    iter(sorted((DRIVE / REFERENCIA).glob(\"*/student.csv\"))), None\n",
@@ -697,7 +654,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# --------------------------------------------------- 2. inventario de entrada\n",
+    "# entrada\n",
     "\n",
     "from collections import Counter\n",
     "\n",
@@ -711,7 +668,6 @@
     "    if sobra:\n",
     "        raise SystemExit(\n",
     "            f\"PARE. {p.parts[-3]}/{p.parts[-2]} tem colunas fora da referencia: {sobra}\\n\"\n",
-    "            \"Investigue antes de continuar: reordenar descartaria esses dados.\"\n",
     "        )\n",
     "    antes[p] = len(cols)\n",
     "\n",
@@ -870,98 +826,6 @@
     "\n",
     "final = DESTINO / \"download_student_bq.zip\"\n",
     "print(f\"no Drive: {final}  {os.path.getsize(final) / 1e6:.0f} MB\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Comparar com output2 (validação)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "anos em comum: ['2025']\n",
-      "\n",
-      "2025: 30140 x 293 (nova) vs 30140 x 293 (antiga)\n",
-      "  colunas so na nova: ['wle_ict_availability_school']\n",
-      "  colunas so na antiga: ['wle_availability_usage_school']\n",
-      "  dados identicos\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ---- comparar BRA: output novo x output2 (script antigo) ----\n",
-    "# ajuste os dois caminhos abaixo se as pastas tiverem outro nome no seu Drive\n",
-    "\n",
-    "PASTA_NOVA = Path(BASE) / \"output\" / \"novas_colunas\"\n",
-    "PASTA_ANTIGA = Path(BASE) / \"output2\"\n",
-    "\n",
-    "anos_nova = {p.name.split(\"=\")[1] for p in PASTA_NOVA.glob(\"year=*\")}\n",
-    "anos_antiga = {p.name.split(\"=\")[1] for p in PASTA_ANTIGA.glob(\"year=*\")}\n",
-    "anos = sorted(anos_nova & anos_antiga, key=int)\n",
-    "print(f\"anos em comum: {anos}\")\n",
-    "\n",
-    "# colunas que sabidamente divergem por design (fix aplicado so no dbt, nao no\n",
-    "# CSV bruto) -- reportadas a parte, sem contar como divergencia real\n",
-    "CONHECIDAS = {\n",
-    "    \"country_id_m49\"\n",
-    "}  # zero a esquerda: fix e so no safe_cast do dbt\n",
-    "\n",
-    "for ano in anos:\n",
-    "    a = PASTA_NOVA / f\"year={ano}\" / \"country_id_iso_3=BRA\" / \"student.csv\"\n",
-    "    b = PASTA_ANTIGA / f\"year={ano}\" / \"country_id_iso_3=BRA\" / \"student.csv\"\n",
-    "    if not a.exists() or not b.exists():\n",
-    "        print(\n",
-    "            f\"{ano}: arquivo faltando ({'nova' if not a.exists() else 'antiga'})\"\n",
-    "        )\n",
-    "        continue\n",
-    "\n",
-    "    da = pd.read_csv(a, dtype=str, keep_default_na=False)\n",
-    "    db = pd.read_csv(b, dtype=str, keep_default_na=False)\n",
-    "\n",
-    "    so_nova = [c for c in da.columns if c not in db.columns]\n",
-    "    so_antiga = [c for c in db.columns if c not in da.columns]\n",
-    "    comuns = [c for c in da.columns if c in db.columns]\n",
-    "\n",
-    "    print(\n",
-    "        f\"\\n{ano}: {da.shape[0]} x {da.shape[1]} (nova) vs {db.shape[0]} x {db.shape[1]} (antiga)\"\n",
-    "    )\n",
-    "    if so_nova:\n",
-    "        print(\"  colunas so na nova:\", so_nova)\n",
-    "    if so_antiga:\n",
-    "        print(\"  colunas so na antiga:\", so_antiga)\n",
-    "\n",
-    "    if da.shape[0] != db.shape[0]:\n",
-    "        print(\"  numero de linhas diferente -- pulando comparacao de valores\")\n",
-    "        continue\n",
-    "\n",
-    "    chave = \"student_id\" if \"student_id\" in comuns else comuns\n",
-    "    da_cmp = da[comuns].sort_values(chave).reset_index(drop=True)\n",
-    "    db_cmp = db[comuns].sort_values(chave).reset_index(drop=True)\n",
-    "\n",
-    "    dif = da_cmp.ne(db_cmp)\n",
-    "    colunas_dif = list(dif.any(axis=0)[dif.any(axis=0)].index)\n",
-    "    esperadas = [c for c in colunas_dif if c in CONHECIDAS]\n",
-    "    inesperadas = [c for c in colunas_dif if c not in CONHECIDAS]\n",
-    "\n",
-    "    if not colunas_dif:\n",
-    "        print(\"  dados identicos\")\n",
-    "    else:\n",
-    "        if esperadas:\n",
-    "            print(\"  divergem (esperado, fix so no dbt):\", esperadas)\n",
-    "        if inesperadas:\n",
-    "            linhas_dif = dif[inesperadas].any(axis=1).sum()\n",
-    "            print(\n",
-    "                f\"  divergem (NAO esperado): {inesperadas} -- {linhas_dif} linhas afetadas\"\n",
-    "            )"
    ]
   }
  ],

--- a/models/world_oecd_pisa/code/pisa_2025.ipynb
+++ b/models/world_oecd_pisa/code/pisa_2025.ipynb
@@ -11,32 +11,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mounted at /content/drive\n"
-     ]
-    }
-   ],
-   "source": [
-    "%!pip install pyreadstat basedosdados\n",
-    "\n",
-    "import glob\n",
-    "import os\n",
-    "import shutil\n",
-    "import time\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import basedosdados as bd\n",
-    "import pandas as pd\n",
-    "import pyreadstat\n",
-    "\n",
-    "# from google.colab import drive\n",
-    "\n",
-    "# drive.mount(\"/content/drive\")"
-   ]
+   "outputs": [],
+   "source": "# %!pip install pyreadstat basedosdados\n\nimport glob\nimport os\nimport shutil\nimport time\nfrom pathlib import Path\n\nimport basedosdados as bd\nimport pandas as pd\nimport pyreadstat\n\n# from google.colab import drive\n\n# drive.mount(\"/content/drive\")"
   },
   {
    "cell_type": "markdown",
@@ -81,7 +57,7 @@
     "            df_filter = df_filter.drop(columns=partition_columns)\n",
     "\n",
     "            # cria a árvore de pastas\n",
-    "            filter_save_path = Path(savepath / \"/\".join(patitions_values))\n",
+    "            filter_save_path = Path(savepath) / \"/\".join(patitions_values)\n",
     "            filter_save_path.mkdir(parents=True, exist_ok=True)\n",
     "            file_filter_save_path = Path(filter_save_path) / \"student.csv\"\n",
     "\n",

--- a/models/world_oecd_pisa/schema.yml
+++ b/models/world_oecd_pisa/schema.yml
@@ -50,6 +50,16 @@ models:
         description: Language of Assessment
       - name: form_id
         description: Form Identifier
+      - name: option_learning_digital_world
+        description: Learning in the Digital World Option
+      - name: option_parent_questionnaire
+        description: Parent Questionnaire Option
+      - name: option_ict_questionnaire
+        description: ICT Questionnaire Option
+      - name: option_foreign_language_assessment
+        description: Foreign Language Assessment Option
+      - name: option_une_heure
+        description: Une Heure Option
       - name: international_grade
         description: Student International Grade (Derived)
       - name: month_birth
@@ -74,6 +84,10 @@ models:
         description: ISCO-08 Occupation code - Mother
       - name: occupation_father
         description: ISCO-08 Occupation code - Father
+      - name: occupation_parent_1
+        description: ISCO-08 Occupation code (2-digit) - Parent/guardian 1
+      - name: occupation_parent_2
+        description: ISCO-08 Occupation code (2-digit) - Parent/guardian 2
       - name: occupation_self
         description: ISCO-08 Occupation code - Self
       - name: grade_compared
@@ -88,6 +102,10 @@ models:
         description: Country of Birth National Categories- Mother
       - name: country_birth_father
         description: Country of Birth National Categories- Father
+      - name: country_birth_parent_1
+        description: Country of Birth National Categories - Parent/guardian 1
+      - name: country_birth_parent_2
+        description: Country of Birth National Categories - Parent/guardian 2
       - name: language_home
         description: Language at home (3-digit code)
       - name: isced_level
@@ -100,6 +118,10 @@ models:
         description: Mothers Education (ISCED)
       - name: father_isced
         description: Fathers Education (ISCED)
+      - name: isced_parent_1
+        description: Parent/guardian 1 level of education (ISCED)
+      - name: isced_parent_2
+        description: Parent/guardian 2 level of education (ISCED)
       - name: highest_parent_isced
         description: Highest Education of parents (ISCED)
       - name: highest_parent_years_schooling
@@ -117,6 +139,10 @@ models:
         description: ISEI of mother
       - name: father_isei
         description: ISEI of father
+      - name: isei_parent_1
+        description: ISEI of parent/guardian 1 (occupational status)
+      - name: isei_parent_2
+        description: ISEI of parent/guardian 2 (occupational status)
       - name: index_highest_parent_occupation
         description: Index highest parental occupational status
       - name: index_immigration_status
@@ -151,8 +177,12 @@ models:
         description: 'Meta-cognition: assess credibility'
       - name: ict_home
         description: ICT available at home
+      - name: wle_ict_availability_home
+        description: ICT availability outside school (WLE)
       - name: ict_school
         description: ICT available at school
+      - name: wle_availability_usage_school
+        description: ICT availability at school (WLE)
       - name: wle_home_possessions
         description: Home possessions index (WLE)
       - name: wle_cultural_possessions
@@ -186,6 +216,26 @@ models:
         description: Perceived autonomy related to ICT use index (WLE)
       - name: wle_ict_social_interaction
         description: ICT as a topic in social interaction index (WLE)
+      - name: wle_ai_use_school
+        description: Students' AI use at school (WLE)
+      - name: wle_views_regulated_ict_use_school
+        description: Views of regulated ICT use in school (WLE)
+      - name: wle_distress_online_content_cyberbullying
+        description: Distress from online content and cyberbullying
+      - name: wle_environmental_awareness
+        description: Students' environmental awareness (WLE)
+      - name: wle_environment_related_activities
+        description: Students' participation in environment-related activities (WLE)
+      - name: wle_opportunities_environmental_learning
+        description: Opportunities for environmental learning in class (WLE)
+      - name: working_for_pay
+        description: Working for pay before or after school
+      - name: skipping_school
+        description: Skipping of classes or days of school
+      - name: arriving_late_school
+        description: Arriving late for school
+      - name: wle_feeling_safe
+        description: Student reports on feeling safe (WLE)
       - name: wle_parental_support_learning
         description: Current parental support for learning at home index (WLE)
       - name: wle_parents_emotional_support
@@ -619,6 +669,46 @@ models:
         description: Plausible Value 9 in Science
       - name: plausible_value_10_science
         description: Plausible Value 10 in Science
+      - name: plausible_value_1_environmental_science
+        description: Plausible Value 1 in Environmental Science
+      - name: plausible_value_2_environmental_science
+        description: Plausible Value 2 in Environmental Science
+      - name: plausible_value_3_environmental_science
+        description: Plausible Value 3 in Environmental Science
+      - name: plausible_value_4_environmental_science
+        description: Plausible Value 4 in Environmental Science
+      - name: plausible_value_5_environmental_science
+        description: Plausible Value 5 in Environmental Science
+      - name: plausible_value_6_environmental_science
+        description: Plausible Value 6 in Environmental Science
+      - name: plausible_value_7_environmental_science
+        description: Plausible Value 7 in Environmental Science
+      - name: plausible_value_8_environmental_science
+        description: Plausible Value 8 in Environmental Science
+      - name: plausible_value_9_environmental_science
+        description: Plausible Value 9 in Environmental Science
+      - name: plausible_value_10_environmental_science
+        description: Plausible Value 10 in Environmental Science
+      - name: plausible_value_1_ldw
+        description: Plausible Value 1 in LDW Computational Problem Solving
+      - name: plausible_value_2_ldw
+        description: Plausible Value 2 in LDW Computational Problem Solving
+      - name: plausible_value_3_ldw
+        description: Plausible Value 3 in LDW Computational Problem Solving
+      - name: plausible_value_4_ldw
+        description: Plausible Value 4 in LDW Computational Problem Solving
+      - name: plausible_value_5_ldw
+        description: Plausible Value 5 in LDW Computational Problem Solving
+      - name: plausible_value_6_ldw
+        description: Plausible Value 6 in LDW Computational Problem Solving
+      - name: plausible_value_7_ldw
+        description: Plausible Value 7 in LDW Computational Problem Solving
+      - name: plausible_value_8_ldw
+        description: Plausible Value 8 in LDW Computational Problem Solving
+      - name: plausible_value_9_ldw
+        description: Plausible Value 9 in LDW Computational Problem Solving
+      - name: plausible_value_10_ldw
+        description: Plausible Value 10 in LDW Computational Problem Solving
       - name: senate_weight
         description: Senate Weight (sum of 5000 per country)
       - name: date_database_creation

--- a/models/world_oecd_pisa/schema.yml
+++ b/models/world_oecd_pisa/schema.yml
@@ -185,7 +185,7 @@ models:
         description: ICT availability outside school (WLE)
       - name: ict_school
         description: ICT available at school
-      - name: wle_availability_usage_school
+      - name: wle_ict_availability_school
         description: ICT availability at school (WLE)
       - name: wle_home_possessions
         description: Home possessions index (WLE)

--- a/models/world_oecd_pisa/schema.yml
+++ b/models/world_oecd_pisa/schema.yml
@@ -13,19 +13,23 @@ models:
         tests:
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__ano')
-              field: ano
+              field: ano.ano
       - name: country_id_iso_3
         description: Country ID ISO3
         tests:
           - relationships:
               to: ref('br_bd_diretorios_mundo__pais')
               field: sigla_iso3
+              config:
+                severity: warn
       - name: country_id_m49
         description: Country Identifier
         tests:
           - relationships:
               to: ref('br_bd_diretorios_mundo__pais')
               field: id_m49
+              config:
+                severity: warn
       - name: school_id
         description: School ID
       - name: student_id
@@ -66,14 +70,14 @@ models:
         description: Student (Standardized) Birth - Month
         tests:
           - relationships:
-              to: ref('br_bd_diretorios_data_tempo__ano')
-              field: ano.ano
+              to: ref('br_bd_diretorios_data_tempo__mes')
+              field: mes.mes
       - name: year_birth
         description: Student (Standardized) Birth - Year
         tests:
           - relationships:
-              to: ref('br_bd_diretorios_data_tempo__mes')
-              field: mes.mes
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
       - name: gender
         description: Student (Standardized) Gender
       - name: effort_put_into_test

--- a/models/world_oecd_pisa/world_oecd_pisa__student.sql
+++ b/models/world_oecd_pisa/world_oecd_pisa__student.sql
@@ -112,7 +112,7 @@ select
     safe_cast(ict_home as int64) ict_home,
     safe_cast(wle_ict_availability_home as float64) wle_ict_availability_home,
     safe_cast(ict_school as int64) ict_school,
-    safe_cast(wle_ict_availability_school as float64) wle_availability_usage_school,
+    safe_cast(wle_ict_availability_school as float64) wle_ict_availability_school,
     safe_cast(wle_home_possessions as float64) wle_home_possessions,
     safe_cast(wle_cultural_possessions as float64) wle_cultural_possessions,
     safe_cast(wle_home_educational_resources as float64) wle_home_educational_resources,

--- a/models/world_oecd_pisa/world_oecd_pisa__student.sql
+++ b/models/world_oecd_pisa/world_oecd_pisa__student.sql
@@ -19,7 +19,7 @@
 select
     safe_cast(year as int64) year,
     safe_cast(country_id_iso_3 as string) country_id_iso_3,
-    safe_cast(country_id_m49 as string) country_id_m49,
+    safe_cast(safe_cast(country_id_m49 as int64) as string) country_id_m49,
     safe_cast(school_id as string) school_id,
     safe_cast(student_id as string) student_id,
     safe_cast(assessment_type as string) assessment_type,

--- a/models/world_oecd_pisa/world_oecd_pisa__student.sql
+++ b/models/world_oecd_pisa/world_oecd_pisa__student.sql
@@ -8,7 +8,7 @@
             "data_type": "int64",
             "range": {
                 "start": 2015,
-                "end": 2022,
+                "end": 2025,
                 "interval": 1,
             },
         },
@@ -31,6 +31,13 @@ select
     safe_cast(language_questionnaire as string) language_questionnaire,
     safe_cast(language_assessment as string) language_assessment,
     safe_cast(form_id as string) form_id,
+    safe_cast(option_learning_digital_world as string) option_learning_digital_world,
+    safe_cast(option_parent_questionnaire as string) option_parent_questionnaire,
+    safe_cast(option_ict_questionnaire as string) option_ict_questionnaire,
+    safe_cast(
+        option_foreign_language_assessment as string
+    ) option_foreign_language_assessment,
+    safe_cast(option_une_heure as string) option_une_heure,
     safe_cast(international_grade as string) international_grade,
     safe_cast(month_birth as int64) month_birth,
     safe_cast(year_birth as int64) year_birth,
@@ -39,6 +46,8 @@ select
     safe_cast(effort_would_have_invested as int64) effort_would_have_invested,
     safe_cast(occupation_mother as string) occupation_mother,
     safe_cast(occupation_father as string) occupation_father,
+    safe_cast(occupation_parent_1 as string) occupation_parent_1,
+    safe_cast(occupation_parent_2 as string) occupation_parent_2,
     safe_cast(occupation_self as string) occupation_self,
     safe_cast(grade_compared as int64) grade_compared,
     safe_cast(age as float64) age,
@@ -46,12 +55,16 @@ select
     safe_cast(country_birth_self as string) country_birth_self,
     safe_cast(country_birth_mother as string) country_birth_mother,
     safe_cast(country_birth_father as string) country_birth_father,
+    safe_cast(country_birth_parent_1 as string) country_birth_parent_1,
+    safe_cast(country_birth_parent_2 as string) country_birth_parent_2,
     safe_cast(language_home as string) language_home,
     safe_cast(isced_level as string) isced_level,
     safe_cast(isced_designation as string) isced_designation,
     safe_cast(isced_orientation as string) isced_orientation,
     safe_cast(mother_isced as string) mother_isced,
     safe_cast(father_isced as string) father_isced,
+    safe_cast(isced_parent_1 as string) isced_parent_1,
+    safe_cast(isced_parent_2 as string) isced_parent_2,
     safe_cast(highest_parent_isced as string) highest_parent_isced,
     safe_cast(highest_parent_years_schooling as int64) highest_parent_years_schooling,
     safe_cast(
@@ -68,6 +81,8 @@ select
     ) highest_parent_international_years_schooling,
     safe_cast(mother_isei as float64) mother_isei,
     safe_cast(father_isei as float64) father_isei,
+    safe_cast(isei_parent_1 as float64) isei_parent_1,
+    safe_cast(isei_parent_2 as float64) isei_parent_2,
     safe_cast(
         index_highest_parent_occupation as float64
     ) index_highest_parent_occupation,
@@ -95,7 +110,9 @@ select
         meta_cognition_assess_credibility as float64
     ) meta_cognition_assess_credibility,
     safe_cast(ict_home as int64) ict_home,
+    safe_cast(wle_ict_availability_home as float64) wle_ict_availability_home,
     safe_cast(ict_school as int64) ict_school,
+    safe_cast(wle_ict_availability_school as float64) wle_availability_usage_school,
     safe_cast(wle_home_possessions as float64) wle_home_possessions,
     safe_cast(wle_cultural_possessions as float64) wle_cultural_possessions,
     safe_cast(wle_home_educational_resources as float64) wle_home_educational_resources,
@@ -120,6 +137,24 @@ select
     safe_cast(wle_ict_competence as float64) wle_ict_competence,
     safe_cast(wle_ict_autonomy as float64) wle_ict_autonomy,
     safe_cast(wle_ict_social_interaction as float64) wle_ict_social_interaction,
+    safe_cast(wle_ai_use_school as float64) wle_ai_use_school,
+    safe_cast(
+        wle_views_regulated_ict_use_school as float64
+    ) wle_views_regulated_ict_use_school,
+    safe_cast(
+        wle_distress_online_content_cyberbullying as float64
+    ) wle_distress_online_content_cyberbullying,
+    safe_cast(wle_environmental_awareness as float64) wle_environmental_awareness,
+    safe_cast(
+        wle_environment_related_activities as float64
+    ) wle_environment_related_activities,
+    safe_cast(
+        wle_opportunities_environmental_learning as float64
+    ) wle_opportunities_environmental_learning,
+    safe_cast(working_for_pay as float64) working_for_pay,
+    safe_cast(skipping_school as float64) skipping_school,
+    safe_cast(arriving_late_school as float64) arriving_late_school,
+    safe_cast(wle_feeling_safe as float64) wle_feeling_safe,
     safe_cast(wle_parental_support_learning as float64) wle_parental_support_learning,
     safe_cast(wle_parents_emotional_support as float64) wle_parents_emotional_support,
     safe_cast(
@@ -359,6 +394,46 @@ select
     safe_cast(plausible_value_8_science as float64) plausible_value_8_science,
     safe_cast(plausible_value_9_science as float64) plausible_value_9_science,
     safe_cast(plausible_value_10_science as float64) plausible_value_10_science,
+    safe_cast(
+        plausible_value_1_environmental_science as float64
+    ) plausible_value_1_environmental_science,
+    safe_cast(
+        plausible_value_2_environmental_science as float64
+    ) plausible_value_2_environmental_science,
+    safe_cast(
+        plausible_value_3_environmental_science as float64
+    ) plausible_value_3_environmental_science,
+    safe_cast(
+        plausible_value_4_environmental_science as float64
+    ) plausible_value_4_environmental_science,
+    safe_cast(
+        plausible_value_5_environmental_science as float64
+    ) plausible_value_5_environmental_science,
+    safe_cast(
+        plausible_value_6_environmental_science as float64
+    ) plausible_value_6_environmental_science,
+    safe_cast(
+        plausible_value_7_environmental_science as float64
+    ) plausible_value_7_environmental_science,
+    safe_cast(
+        plausible_value_8_environmental_science as float64
+    ) plausible_value_8_environmental_science,
+    safe_cast(
+        plausible_value_9_environmental_science as float64
+    ) plausible_value_9_environmental_science,
+    safe_cast(
+        plausible_value_10_environmental_science as float64
+    ) plausible_value_10_environmental_science,
+    safe_cast(plausible_value_1_ldw as float64) plausible_value_1_ldw,
+    safe_cast(plausible_value_2_ldw as float64) plausible_value_2_ldw,
+    safe_cast(plausible_value_3_ldw as float64) plausible_value_3_ldw,
+    safe_cast(plausible_value_4_ldw as float64) plausible_value_4_ldw,
+    safe_cast(plausible_value_5_ldw as float64) plausible_value_5_ldw,
+    safe_cast(plausible_value_6_ldw as float64) plausible_value_6_ldw,
+    safe_cast(plausible_value_7_ldw as float64) plausible_value_7_ldw,
+    safe_cast(plausible_value_8_ldw as float64) plausible_value_8_ldw,
+    safe_cast(plausible_value_9_ldw as float64) plausible_value_9_ldw,
+    safe_cast(plausible_value_10_ldw as float64) plausible_value_10_ldw,
     safe_cast(senate_weight as float64) senate_weight,
     safe_cast(
         case

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ dependencies = [
   "types-python-dateutil>=2.9.0.20260518",
   "types-geopandas>=1.1.4.20260628",
   "types-hvac>=2.4.0.20260518",
+  "pyreadstat>=1.3.6",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,6 @@ dependencies = [
   "types-python-dateutil>=2.9.0.20260518",
   "types-geopandas>=1.1.4.20260628",
   "types-hvac>=2.4.0.20260518",
-  "pyreadstat>=1.3.6",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2926,15 +2926,6 @@ wheels = [
 ]
 
 [[package]]
-name = "narwhals"
-version = "2.26.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/68/5351e34623d253423240ea7de3f8fc74fa8ab14b1ab3c0ec4ac8997413c9/narwhals-2.26.0.tar.gz", hash = "sha256:6b9cadca82f375c7e4cf584fdc86ca25da54827307a9c58f94547ee6104b82dd", size = 686970, upload-time = "2026-09-08T13:32:08.964Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/b5/1b84b2c784db76d69442334bc8b8748c840f13ca53be086f4f250ad4a0bc/narwhals-2.26.0-py3-none-any.whl", hash = "sha256:29326d74f107c347fd1009bd58e38d9f7c7c5b51e6de97bc93dbc325d9038b54", size = 474034, upload-time = "2026-09-08T13:32:07.159Z" },
-]
-
-[[package]]
 name = "nbformat"
 version = "5.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3509,7 +3500,6 @@ dependencies = [
     { name = "pydata-google-auth" },
     { name = "pymssql" },
     { name = "pyparsing" },
-    { name = "pyreadstat" },
     { name = "python-box" },
     { name = "python-calamine" },
     { name = "python-dateutil" },
@@ -3662,7 +3652,6 @@ requires-dist = [
     { name = "pydata-google-auth", specifier = ">=1.8.0,<2.0.0" },
     { name = "pymssql", specifier = ">=2.3.0" },
     { name = "pyparsing", specifier = "==3.0.6" },
-    { name = "pyreadstat", specifier = ">=1.3.6" },
     { name = "python-box", specifier = "==5.4.1" },
     { name = "python-calamine", specifier = ">=0.6.1" },
     { name = "python-dateutil", specifier = "==2.8.2" },
@@ -4447,33 +4436,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/d9/5ccefb8bca925f44256b188a91c31238cae29ab6ee7f53661ecc04616146/pyproj-3.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bf84d766646f1ebd706d883755df4370aaf02b48187cedaa7e4239f16bc8213d", size = 10771259, upload-time = "2025-02-16T04:28:20.822Z" },
     { url = "https://files.pythonhosted.org/packages/2a/7d/31dedff9c35fa703162f922eeb0baa6c44a3288469a5fd88d209e2892f9e/pyproj-3.7.1-cp312-cp312-win32.whl", hash = "sha256:5f0da2711364d7cb9f115b52289d4a9b61e8bca0da57f44a3a9d6fc9bdeb7274", size = 5859914, upload-time = "2025-02-16T04:28:23.303Z" },
     { url = "https://files.pythonhosted.org/packages/3e/47/c6ab03d6564a7c937590cff81a2742b5990f096cce7c1a622d325be340ee/pyproj-3.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:aee664a9d806612af30a19dba49e55a7a78ebfec3e9d198f6a6176e1d140ec98", size = 6273196, upload-time = "2025-02-16T04:28:25.227Z" },
-]
-
-[[package]]
-name = "pyreadstat"
-version = "1.3.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "narwhals" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/46/5da098432b075d5ddadaf3d2f1f9f7abe1477a5be06697528ceb30337301/pyreadstat-1.3.6.tar.gz", hash = "sha256:c7b3bde1d86d5b4bd93b8a783d306a1cc6b9cc64adc4b892754f24caa8270aa5", size = 519810, upload-time = "2026-08-12T13:03:23.231Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/b3/87ca1fbbd6c9daab50733005dce52e8dfad2f3f505246b0bc8881fe39dc6/pyreadstat-1.3.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:450cc85f4e782734c0de8bd6aee1ee8e36ad6f5d514900ab9db5e23fdcf8d3bb", size = 779902, upload-time = "2026-08-12T13:02:35.9Z" },
-    { url = "https://files.pythonhosted.org/packages/de/9a/dc6ecfd52708ddb48d941458f5a41a01e46931a71a75bbaaf414dee6304b/pyreadstat-1.3.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5ae4fe78389e783f9f846f6e0bb82191b7d59188909609524d39a81a7501dbba", size = 739402, upload-time = "2026-08-12T13:02:37.783Z" },
-    { url = "https://files.pythonhosted.org/packages/68/f6/f10eef906d5d6d96f6bfacec1c6da11d032e76c572fd0e547898887ceb67/pyreadstat-1.3.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3dc2e98c129e27c50728a9ed65eb46d4b37c8868df1dc374eb5e4f820c6dc1bc", size = 2534012, upload-time = "2026-08-12T13:02:39.436Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1e/33895071058359ee5a6eaa0a20ee35a793b5ec166af66788189b3df37bef/pyreadstat-1.3.6-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f20a507456878a521530a503c22ed0653767fa88339f911e496256721bc4fb0c", size = 2605002, upload-time = "2026-08-12T13:02:41.445Z" },
-    { url = "https://files.pythonhosted.org/packages/48/f5/5746ed50f2c560b1a8fc94998c0e6cf79687c567de6c0be4736c3d36df5d/pyreadstat-1.3.6-cp310-cp310-win_amd64.whl", hash = "sha256:ef0476ce667a86c70aad2801ff13117ef0e64fa3c45b48d160441dbd43c69b1f", size = 2042692, upload-time = "2026-08-12T13:02:43.418Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/96/2b8316d5a748fe28ed3018ab3ae56f73af8f9bbcb8bf86cc3b3f4c075342/pyreadstat-1.3.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:48972d5f947e63ad69beea4a124e52b93bd61f294dff4d9b0f0c8e3b7f4664c9", size = 778738, upload-time = "2026-08-12T13:02:46.177Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c2/e0ec4a029bb0c252d9b7776a162409bf4d6ee82a9f0ce6d2ddc0f3aea254/pyreadstat-1.3.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f90698b5aaa7e837029d70f5170ad3b6df4b6c678dcca55907c3b00ac4b3e1b8", size = 738981, upload-time = "2026-08-12T13:02:47.558Z" },
-    { url = "https://files.pythonhosted.org/packages/51/5c/9d40c65035d0c55e385b1e4a8281007a743cbed102665729ba63401aa105/pyreadstat-1.3.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a8ce92ac23e5f46839e0d636b526e250f90ab771ecf53a408a7179197a14077f", size = 2637243, upload-time = "2026-08-12T13:02:49.363Z" },
-    { url = "https://files.pythonhosted.org/packages/16/42/b4ccb8e9ab2c618497aa9d1cd389d19d57a7b30c48da1ff2c0b4a1ba00bd/pyreadstat-1.3.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:db275cc6a96b259a6369cd8b2d8ad159cf6c81b296c1a8205bb23e51686b0f24", size = 2709210, upload-time = "2026-08-12T13:02:52.403Z" },
-    { url = "https://files.pythonhosted.org/packages/32/3a/0e4ae09736fb26aa00895e4b81a321ec7d8d6cc4aa08c2dc8ec9c59f49bb/pyreadstat-1.3.6-cp311-cp311-win_amd64.whl", hash = "sha256:5030aa5105c0edc2eac46ce2a2c7621bf52c6456fb3c056b86d8eed635e416c5", size = 2043029, upload-time = "2026-08-12T13:02:55.37Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/5f/ee640e28413703e87989ed2f06c43d56c8021239bc51c88ebce9846a7510/pyreadstat-1.3.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd3c1b6b948ec8c7ac4cd140f4542a5fd076ef814a1e252d26b218624e975457", size = 772771, upload-time = "2026-08-12T13:02:56.741Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/70/f7d84cea3b4134cab1e2199ac5e0fd961203073c76672b28f8d4c1ed0712/pyreadstat-1.3.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6949c7535dc57115f3d5620b3f381ca76589f0fb079c20c26b7cbcdd5fca54db", size = 736578, upload-time = "2026-08-12T13:02:58.062Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/73/8e8a1ebca7cef372fc3615db6d943a40c6a3a5c444a64d38ac00814b929e/pyreadstat-1.3.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9806877e74e17b65142526799e48e83c6d534423f80c2bca9d76836f9733aab", size = 2600229, upload-time = "2026-08-12T13:02:59.937Z" },
-    { url = "https://files.pythonhosted.org/packages/da/74/8986d34b4a0d99bf2dfdb822d1f1c564be6ad6ea55bac26e73dd44b7864b/pyreadstat-1.3.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93182fc101e2adf27c36fb935e8144e5bc92a3da8d7577a1dabfcacf29b672e8", size = 2677736, upload-time = "2026-08-12T13:03:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/25/32/5fb250eb7f0f3eb4eef0f1f2f10571c9705f3ddbe48cb973e5b2f99118c9/pyreadstat-1.3.6-cp312-cp312-win_amd64.whl", hash = "sha256:3d48c59ab77b6e39df1cf846ef343eba274af4a536f54491c78f4f4e8d2bc984", size = 2034889, upload-time = "2026-08-12T13:03:03.589Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -2926,6 +2926,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/68/5351e34623d253423240ea7de3f8fc74fa8ab14b1ab3c0ec4ac8997413c9/narwhals-2.26.0.tar.gz", hash = "sha256:6b9cadca82f375c7e4cf584fdc86ca25da54827307a9c58f94547ee6104b82dd", size = 686970, upload-time = "2026-09-08T13:32:08.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/b5/1b84b2c784db76d69442334bc8b8748c840f13ca53be086f4f250ad4a0bc/narwhals-2.26.0-py3-none-any.whl", hash = "sha256:29326d74f107c347fd1009bd58e38d9f7c7c5b51e6de97bc93dbc325d9038b54", size = 474034, upload-time = "2026-09-08T13:32:07.159Z" },
+]
+
+[[package]]
 name = "nbformat"
 version = "5.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3500,6 +3509,7 @@ dependencies = [
     { name = "pydata-google-auth" },
     { name = "pymssql" },
     { name = "pyparsing" },
+    { name = "pyreadstat" },
     { name = "python-box" },
     { name = "python-calamine" },
     { name = "python-dateutil" },
@@ -3652,6 +3662,7 @@ requires-dist = [
     { name = "pydata-google-auth", specifier = ">=1.8.0,<2.0.0" },
     { name = "pymssql", specifier = ">=2.3.0" },
     { name = "pyparsing", specifier = "==3.0.6" },
+    { name = "pyreadstat", specifier = ">=1.3.6" },
     { name = "python-box", specifier = "==5.4.1" },
     { name = "python-calamine", specifier = ">=0.6.1" },
     { name = "python-dateutil", specifier = "==2.8.2" },
@@ -4436,6 +4447,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/d9/5ccefb8bca925f44256b188a91c31238cae29ab6ee7f53661ecc04616146/pyproj-3.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bf84d766646f1ebd706d883755df4370aaf02b48187cedaa7e4239f16bc8213d", size = 10771259, upload-time = "2025-02-16T04:28:20.822Z" },
     { url = "https://files.pythonhosted.org/packages/2a/7d/31dedff9c35fa703162f922eeb0baa6c44a3288469a5fd88d209e2892f9e/pyproj-3.7.1-cp312-cp312-win32.whl", hash = "sha256:5f0da2711364d7cb9f115b52289d4a9b61e8bca0da57f44a3a9d6fc9bdeb7274", size = 5859914, upload-time = "2025-02-16T04:28:23.303Z" },
     { url = "https://files.pythonhosted.org/packages/3e/47/c6ab03d6564a7c937590cff81a2742b5990f096cce7c1a622d325be340ee/pyproj-3.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:aee664a9d806612af30a19dba49e55a7a78ebfec3e9d198f6a6176e1d140ec98", size = 6273196, upload-time = "2025-02-16T04:28:25.227Z" },
+]
+
+[[package]]
+name = "pyreadstat"
+version = "1.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/46/5da098432b075d5ddadaf3d2f1f9f7abe1477a5be06697528ceb30337301/pyreadstat-1.3.6.tar.gz", hash = "sha256:c7b3bde1d86d5b4bd93b8a783d306a1cc6b9cc64adc4b892754f24caa8270aa5", size = 519810, upload-time = "2026-08-12T13:03:23.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/b3/87ca1fbbd6c9daab50733005dce52e8dfad2f3f505246b0bc8881fe39dc6/pyreadstat-1.3.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:450cc85f4e782734c0de8bd6aee1ee8e36ad6f5d514900ab9db5e23fdcf8d3bb", size = 779902, upload-time = "2026-08-12T13:02:35.9Z" },
+    { url = "https://files.pythonhosted.org/packages/de/9a/dc6ecfd52708ddb48d941458f5a41a01e46931a71a75bbaaf414dee6304b/pyreadstat-1.3.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5ae4fe78389e783f9f846f6e0bb82191b7d59188909609524d39a81a7501dbba", size = 739402, upload-time = "2026-08-12T13:02:37.783Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f6/f10eef906d5d6d96f6bfacec1c6da11d032e76c572fd0e547898887ceb67/pyreadstat-1.3.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3dc2e98c129e27c50728a9ed65eb46d4b37c8868df1dc374eb5e4f820c6dc1bc", size = 2534012, upload-time = "2026-08-12T13:02:39.436Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/1e/33895071058359ee5a6eaa0a20ee35a793b5ec166af66788189b3df37bef/pyreadstat-1.3.6-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f20a507456878a521530a503c22ed0653767fa88339f911e496256721bc4fb0c", size = 2605002, upload-time = "2026-08-12T13:02:41.445Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f5/5746ed50f2c560b1a8fc94998c0e6cf79687c567de6c0be4736c3d36df5d/pyreadstat-1.3.6-cp310-cp310-win_amd64.whl", hash = "sha256:ef0476ce667a86c70aad2801ff13117ef0e64fa3c45b48d160441dbd43c69b1f", size = 2042692, upload-time = "2026-08-12T13:02:43.418Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/96/2b8316d5a748fe28ed3018ab3ae56f73af8f9bbcb8bf86cc3b3f4c075342/pyreadstat-1.3.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:48972d5f947e63ad69beea4a124e52b93bd61f294dff4d9b0f0c8e3b7f4664c9", size = 778738, upload-time = "2026-08-12T13:02:46.177Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c2/e0ec4a029bb0c252d9b7776a162409bf4d6ee82a9f0ce6d2ddc0f3aea254/pyreadstat-1.3.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f90698b5aaa7e837029d70f5170ad3b6df4b6c678dcca55907c3b00ac4b3e1b8", size = 738981, upload-time = "2026-08-12T13:02:47.558Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5c/9d40c65035d0c55e385b1e4a8281007a743cbed102665729ba63401aa105/pyreadstat-1.3.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a8ce92ac23e5f46839e0d636b526e250f90ab771ecf53a408a7179197a14077f", size = 2637243, upload-time = "2026-08-12T13:02:49.363Z" },
+    { url = "https://files.pythonhosted.org/packages/16/42/b4ccb8e9ab2c618497aa9d1cd389d19d57a7b30c48da1ff2c0b4a1ba00bd/pyreadstat-1.3.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:db275cc6a96b259a6369cd8b2d8ad159cf6c81b296c1a8205bb23e51686b0f24", size = 2709210, upload-time = "2026-08-12T13:02:52.403Z" },
+    { url = "https://files.pythonhosted.org/packages/32/3a/0e4ae09736fb26aa00895e4b81a321ec7d8d6cc4aa08c2dc8ec9c59f49bb/pyreadstat-1.3.6-cp311-cp311-win_amd64.whl", hash = "sha256:5030aa5105c0edc2eac46ce2a2c7621bf52c6456fb3c056b86d8eed635e416c5", size = 2043029, upload-time = "2026-08-12T13:02:55.37Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/ee640e28413703e87989ed2f06c43d56c8021239bc51c88ebce9846a7510/pyreadstat-1.3.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd3c1b6b948ec8c7ac4cd140f4542a5fd076ef814a1e252d26b218624e975457", size = 772771, upload-time = "2026-08-12T13:02:56.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/70/f7d84cea3b4134cab1e2199ac5e0fd961203073c76672b28f8d4c1ed0712/pyreadstat-1.3.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6949c7535dc57115f3d5620b3f381ca76589f0fb079c20c26b7cbcdd5fca54db", size = 736578, upload-time = "2026-08-12T13:02:58.062Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/73/8e8a1ebca7cef372fc3615db6d943a40c6a3a5c444a64d38ac00814b929e/pyreadstat-1.3.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9806877e74e17b65142526799e48e83c6d534423f80c2bca9d76836f9733aab", size = 2600229, upload-time = "2026-08-12T13:02:59.937Z" },
+    { url = "https://files.pythonhosted.org/packages/da/74/8986d34b4a0d99bf2dfdb822d1f1c564be6ad6ea55bac26e73dd44b7864b/pyreadstat-1.3.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93182fc101e2adf27c36fb935e8144e5bc92a3da8d7577a1dabfcacf29b672e8", size = 2677736, upload-time = "2026-08-12T13:03:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/25/32/5fb250eb7f0f3eb4eef0f1f2f10571c9705f3ddbe48cb973e5b2f99118c9/pyreadstat-1.3.6-cp312-cp312-win_amd64.whl", hash = "sha256:3d48c59ab77b6e39df1cf846ef343eba274af4a536f54491c78f4f4e8d2bc984", size = 2034889, upload-time = "2026-08-12T13:03:03.589Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Descrição do PR:

- Atualiza `world_oecd_pisa__student` para cobrir o ciclo 2025 (partition range 2015→2025), adicionando as novas variáveis introduzidas nesse ciclo: opções de aplicação (option_learning_digital_world, option_parent_questionnaire, option_ict_questionnaire, option_foreign_language_assessment, option_une_heure).
- Os campos de pai/mãe reformulados como parent_1/parent_2 (ocupação, país de nascimento, ISCED, ISEI) e os novos índices WLE (IA na escola, uso regulado de TIC, cyberbullying, consciência ambiental, segurança, trabalho remunerado, faltas/atrasos) e os plausible values de environmental_science e ldw (learning in the digital world).
- Corrige os testes` relationships` de month_birth/year_birth no `schema.yml`, que estavam trocados (apontando month_birth para o diretório de ano e vice-versa), e adiciona `severity: warn `nos testes de `country_id_iso_3/country_id_m49` para países que ainda não existem no diretório `br_bd_diretorios_mundo`.
- Adiciona `models/world_oecd_pisa/code/atualizar_dicionario_2025.py`, script para atualizar o dicionário do student com os novos códigos/labels do ciclo 2025.
- Adiciona `models/world_oecd_pisa/code/pisa_2025.ipynb`, o notebook de processamento/limpeza dos microdados brutos do PISA 2025.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing and publishing OECD PISA 2025 student data.
  * Expanded student data with new questionnaire, parent/guardian, ICT, wellbeing, environmental, and school-behavior measures.
  * Added environmental science and computational problem-solving plausible values.
  * Added 2025 value-label dictionaries and human-review comparison reports.
  * Extended student data coverage through 2025 with partitioned country outputs.

* **Validation**
  * Added checks for column availability, data types, row counts, and output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->